### PR TITLE
[Fase 1] Definir política de conflictos concurrentes del MVP

### DIFF
--- a/docs/conflict-policy.md
+++ b/docs/conflict-policy.md
@@ -1,0 +1,119 @@
+# Política de Conflictos Concurrentes MVP
+
+## Metadatos
+
+- `doc_id`: DOC-CONFLICT-POLICY
+- `purpose`: Definir la política de resolución de conflictos concurrentes del MVP.
+- `status`: active
+- `source_of_truth`: official
+- `last_updated`: 2026-02-23
+- `next_review`: 2026-03-09
+
+## Objetivo
+
+Cerrar una política de conflictos concurrentes para Firestore en el MVP que
+priorice simplicidad, previsibilidad y consistencia de datos, sin adelantar el
+contrato técnico por agregado de la Issue #12 ni la política de timestamps y
+desempates de la Issue #18.
+
+## Alcance MVP y no alcance
+
+Incluye:
+
+- reglas de resolución de conflictos por familia de operación;
+- reglas de precedencia y rechazo;
+- flujo esperado de cliente tras conflicto (`refrescar` y `reintentar`);
+- límites y dependencias con Issues #12 y #18.
+
+No incluye:
+
+- definición técnica exacta de transacciones/precondiciones por agregado
+  (Issue #12);
+- política de timestamps y desempate de orden estable (Issue #18);
+- lock/lease explícito entre dispositivos;
+- soporte offline con cola de escrituras.
+
+## Principios de la política de conflictos
+
+1. En el MVP se adopta una política **estricta de rechazo en conflicto** con
+   `refresco` y `reintento`.
+1. Se mantiene la recomendación operativa de `single writer` definida en
+   `docs/sync-strategy.md`.
+1. No se usa `last-write-wins` para operaciones de estado, edición de notas ni
+   `ResourceChange`.
+1. La política define comportamiento esperado; el mecanismo técnico exacto de
+   detección queda para la Issue #12.
+
+## Matriz de operaciones y resolución (MVP)
+
+| Operación | Agregado principal | Riesgo de conflicto | Política MVP | Acción cliente | Notas / dependencias |
+| --- | --- | --- | --- | --- | --- |
+| `Session.start` | `campaign` + `entry` + `session` | Alto | `rechazar` | `refrescar` + `reintentar` | Depende de unicidad de sesión activa global; detalle técnico en #12 |
+| `Session.stop` | `campaign` + `entry` + `session` | Alto | `rechazar` | `refrescar` + `reintentar` | Rechazar si la sesión activa cambió o ya fue cerrada |
+| `auto-stop` por nuevo `start` | `campaign` + `session` | Alto | `rechazar` | `refrescar` + `reintentar` | No usar LWW sobre estado de sesión |
+| `Week.close` | `week` + `campaign` | Alto | `rechazar` | `refrescar` + `reintentar` | Rechazar si `week.status` o `week_cursor` cambió |
+| Borrado de `Entry` activa (con cascada) | `entry` + `session` + `resource_change` | Alto | `rechazar` | `refrescar` + `reintentar` | Incluye auto-stop y borrado en cascada; contratos técnicos en #12 |
+| Edición de `Week.notes` | `week` | Medio | `rechazar` | `refrescar` + reingresar cambios | No usar `last-write-wins` en MVP |
+| Crear `ResourceChange` | `resource_change` (+ totales derivados) | Medio/Alto | `rechazar` | `refrescar` + `reintentar` | Política estricta para evitar inconsistencias silenciosas |
+| Editar `ResourceChange` | `resource_change` | Alto | `rechazar` | `refrescar` + `reintentar` | Rechazar si el cambio fue modificado o borrado concurrentemente |
+| Borrar `ResourceChange` | `resource_change` | Alto | `rechazar` | `refrescar` + `reintentar` | Rechazar si ya fue alterado o eliminado |
+
+## Reglas de precedencia y rechazo
+
+1. Si una entidad fue modificada por otro dispositivo desde la lectura base del
+   cliente, la operación se **rechaza por conflicto**.
+1. Si una entidad fue borrada (o marcada como borrada) concurrentemente,
+   prevalece el estado remoto actual y la operación local se **rechaza**.
+1. Si una operación depende de `Week.status=open` y la semana ya fue cerrada,
+   la operación se **rechaza**.
+1. Si una operación depende de la sesión activa global y esa condición cambió,
+   la operación se **rechaza**.
+1. Si el rechazo ocurre durante una operación compuesta (por ejemplo `auto-stop`
+   + `start`, cierre de semana, borrado con cascada), se considera fallo de la
+   operación completa y se requiere `refresco`.
+1. La precedencia de orden temporal fino y desempates entre eventos casi
+   simultáneos queda fuera de esta issue y se define en la Issue #18.
+
+## Flujo esperado tras conflicto (cliente)
+
+1. Mostrar error de conflicto concurrente (mensaje breve en castellano).
+1. Ejecutar `refresco` del estado relevante desde Firestore.
+1. Recalcular foco/estado visible en la UI según la fuente de verdad.
+1. Permitir `reintentar` manualmente si la acción sigue siendo válida.
+1. No reintentar automáticamente en el MVP (para evitar efectos duplicados y
+   comportamiento opaco).
+
+## Edge cases documentados
+
+- Dos dispositivos intentan iniciar sesión activa casi a la vez.
+  - Resultado MVP: uno de los intentos puede quedar inválido tras refresco;
+    conflicto se resuelve por rechazo y reintento.
+- Un dispositivo cierra una `Week` mientras otro edita `Week.notes`.
+  - Resultado MVP: la edición depende del estado actual; si el estado cambió de
+    forma incompatible, se rechaza y se refresca.
+- Un dispositivo borra una `Entry` activa mientras otro registra recursos sobre
+  esa `Entry`.
+  - Resultado MVP: una de las operaciones quedará inválida; se rechaza la que
+    opere sobre estado obsoleto.
+- Ediciones concurrentes sobre el mismo `ResourceChange`.
+  - Resultado MVP: rechazo en conflicto; no `last-write-wins`.
+
+## Dependencias y relación con otras Issues
+
+- **Issue #7**: `docs/sync-strategy.md` define el marco de sincronización
+  (`single writer`, `online-only writes`, `on-demand refresh`).
+- **Issue #8**: esta política de conflictos concurrentes.
+- **Issue #12**: define el contrato técnico por agregado y el mecanismo de
+  detección/validación de conflictos.
+- **Issue #18**: define timestamps y desempates de orden estable entre
+  dispositivos, compatibles con esta política.
+
+## Referencias
+
+- `docs/domain-glossary.md`
+- `docs/sync-strategy.md`
+- `docs/decision-log.md`
+- `tdd.md` (legado temporal, alineado con referencia oficial)
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/8`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/18`

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -190,3 +190,26 @@
 - `references`: `AGENTS.md`, `docs/repo-workflow.md`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/7`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/22`
+
+### DEC-0015
+
+- `date`: 2026-02-23
+- `status`: accepted
+- `problem`: falta una política de conflictos concurrentes para operaciones
+  simultáneas sobre `entries`, `sessions`, `weeks` y `resource_changes` en el
+  MVP con Firestore.
+- `decision`: adoptar una política MVP estricta de rechazo en conflicto con
+  `refresco` y `reintento`, sin `last-write-wins`, aplicada por familias de
+  operación (estado crítico, `Week.notes` y `ResourceChange`), y diferir el
+  mecanismo técnico exacto de detección/validación a la Issue #12.
+- `rationale`: prioriza previsibilidad y consistencia del estado frente a
+  sobrescrituras silenciosas, y mantiene bajo control la complejidad antes de
+  cerrar el contrato técnico por agregado (#12) y la política de
+  timestamps/desempates (#18).
+- `impact`: cierra la Issue #8 a nivel de política, condiciona la definición de
+  operaciones por agregado en #12 y la compatibilidad con orden estable en #18.
+- `references`: `docs/conflict-policy.md`, `docs/sync-strategy.md`,
+  `docs/domain-glossary.md`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/8`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/18`

--- a/docs/sync-strategy.md
+++ b/docs/sync-strategy.md
@@ -26,7 +26,8 @@ Incluye:
 
 No incluye:
 
-- política detallada de conflictos concurrentes (Issue #8);
+- política detallada de conflictos concurrentes (ver `docs/conflict-policy.md`,
+  Issue #8);
 - política de timestamps y desempate estable entre dispositivos (Issue #18);
 - contrato de operaciones Firestore por agregado (Issue #12);
 - soporte offline con cola de escrituras.
@@ -40,7 +41,8 @@ No incluye:
   - Se recomienda un dispositivo escribiendo activamente a la vez.
   - Otros dispositivos pueden consultar.
   - Si otro dispositivo escribe de forma concurrente, el resultado queda en
-    zona de `best-effort` hasta cerrar la política de conflictos en la Issue #8.
+    zona de `best-effort` hasta definir la política de conflictos en la
+    Issue #8 (`docs/conflict-policy.md`).
 - **Política de conectividad para escrituras**: `online-only writes`.
   - Sin conexión, las escrituras del MVP se bloquean.
   - No existe cola offline de escrituras en esta fase.
@@ -65,8 +67,8 @@ No incluye:
    (sin encolar para sincronización posterior).
 1. El uso normal esperado es `single writer`; el segundo dispositivo escritor no
    está prohibido por contrato, pero queda fuera del flujo recomendado.
-1. La resolución de conflictos de escrituras concurrentes queda diferida a la
-   Issue #8.
+1. La resolución de conflictos de escrituras concurrentes se rige por
+   `docs/conflict-policy.md` (Issue #8).
 
 ## Criterios de consistencia del MVP
 
@@ -91,7 +93,8 @@ Límites aceptados MVP:
 - `No realtime guarantee`.
 - no soporte formal de `multiwriter` coordinado.
 - no escrituras offline ni cola de sincronización.
-- conflictos concurrentes detallados se definen en la Issue #8.
+- conflictos concurrentes detallados se definen en `docs/conflict-policy.md`
+  (Issue #8).
 - política de timestamps y desempates se define en la Issue #18.
 
 ## Escenarios normales esperados
@@ -114,7 +117,8 @@ Límites aceptados MVP:
 
 - Dos dispositivos escriben casi al mismo tiempo sobre el mismo agregado.
   - Esta estrategia solo define el límite de soporte del MVP.
-  - La política de resolución queda en la Issue #8.
+  - La política de resolución se define en `docs/conflict-policy.md`
+    (Issue #8).
 - Diferencias de orden visual entre dispositivos por eventos casi simultáneos.
   - La política de timestamps y desempate queda en la Issue #18.
 - La definición de operaciones por agregado y atomicidad se concreta en la
@@ -123,7 +127,8 @@ Límites aceptados MVP:
 ## Dependencias y relación con otras Issues
 
 - **Issue #7**: documento de decisión principal (esta estrategia).
-- **Issue #8**: política de conflictos concurrentes (depende de este marco).
+- **Issue #8**: política de conflictos concurrentes, documentada en
+  `docs/conflict-policy.md` y dependiente de este marco.
 - **Issue #18**: política de timestamps y orden estable (depende de #7 y debe
   ser compatible con #8).
 - **Issue #12**: contrato de operaciones Firestore por agregado, que deberá
@@ -132,6 +137,7 @@ Límites aceptados MVP:
 ## Referencias
 
 - `docs/domain-glossary.md`
+- `docs/conflict-policy.md`
 - `docs/decision-log.md`
 - `tdd.md` (legado temporal, alineado con referencia oficial)
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/7`

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -31,6 +31,8 @@ Este documento permite que una persona o agente nuevo entienda rápidamente:
   - Contrato de modelo de dominio e invariantes.
 - `docs/sync-strategy.md`
   - Estrategia de sincronización multidispositivo del MVP.
+- `docs/conflict-policy.md`
+  - Política de conflictos concurrentes del MVP.
 - `docs/context-checklists.md`
   - Checklists por trigger de trabajo.
 - `docs/repo-workflow.md`
@@ -75,6 +77,7 @@ Este documento permite que una persona o agente nuevo entienda rápidamente:
 - Decisión tomada -> `docs/decision-log.md`
 - Modelo de dominio -> `docs/domain-glossary.md`
 - Sincronización MVP -> `docs/sync-strategy.md`
+- Conflictos concurrentes MVP -> `docs/conflict-policy.md`
 - Estado de fase -> `docs/context-governance.md`
 - Pasos operativos -> `docs/context-checklists.md`
 - Material reutilizable -> `learning/handbook.md`

--- a/tdd.md
+++ b/tdd.md
@@ -153,5 +153,6 @@ No incluye en MVP:
 
 - Estrategia de sincronización multi dispositivo (resuelta en
   `docs/sync-strategy.md`, Issue #7).
-- Política de conflictos concurrentes.
+- Política de conflictos concurrentes (resuelta en `docs/conflict-policy.md`,
+  Issue #8).
 - Proceso de provisión inicial de años (por ejemplo, crear 4 años).


### PR DESCRIPTION
## Resumen

Define la política de conflictos concurrentes del MVP para Firestore, alineada con el marco de sincronización de la Issue #7 y dejando explícitos los límites pendientes de las Issues #12 y #18.

## Issue relacionada

Closes #8

## Referencias

- `DEC-0015` en `docs/decision-log.md`
- `docs/conflict-policy.md` (nuevo documento oficial)
- `docs/sync-strategy.md` (alineación con la política de conflictos)

## Alcance

- Nueva política oficial en `docs/conflict-policy.md`
- Matriz de operaciones y resolución (estado crítico, `Week.notes`, `ResourceChange`)
- Reglas de precedencia, rechazo, refresco y reintento
- Referencias cruzadas en `docs/system-map.md`, `docs/sync-strategy.md`, `docs/decision-log.md` y `tdd.md`

## Límites explícitos

- No define el mecanismo técnico exacto por agregado (queda para #12)
- No define timestamps ni desempates de orden estable (queda para #18)
- No introduce locking explícito ni soporte offline

## Checklist

- [x] El alcance está claro
- [x] Los commits siguen Conventional Commits
- [x] Cambio documental (sin código de app)
- [x] Trazabilidad de decisiones actualizada (`DEC-0015`)
- [x] Referencias cruzadas actualizadas