### PR TITLE
[Fase 1] Definir selector temporal superior y provisión/extensión de años

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,7 @@ Cada interacción termina con un menú numerado fijo de 3 a 5 siguientes pasos.
 - Checklists operativas: `docs/context-checklists.md`
 - Estrategia de sincronización MVP: `docs/sync-strategy.md`
 - Política de conflictos concurrentes MVP: `docs/conflict-policy.md`
+- Controles temporales de campaña: `docs/campaign-temporal-controls.md`
 - Guía reusable: `learning/handbook.md`
 - Anexo Frosthaven: `learning/frosthaven-annex.md`
 - Bibliografía anotada: `learning/sources.md`

--- a/docs/campaign-temporal-controls.md
+++ b/docs/campaign-temporal-controls.md
@@ -1,0 +1,128 @@
+# Controles Temporales de Campaña (MVP)
+
+## Metadatos
+
+- `doc_id`: DOC-CAMPAIGN-TEMPORAL-CONTROLS
+- `purpose`: Definir el contrato funcional de navegación temporal y provisión/extensión de años en la pantalla principal del MVP.
+- `status`: active
+- `source_of_truth`: official
+- `last_updated`: 2026-02-23
+- `next_review`: 2026-03-09
+
+## Objetivo
+
+Cerrar el contrato funcional del selector temporal superior (año/semana) en la
+pantalla principal única del MVP, incluyendo la provisión inicial y extensión
+manual de años sin depender de una pantalla separada de ajustes de campaña solo
+para esta función.
+
+## Alcance MVP y no alcance
+
+Incluye:
+
+- ubicación funcional del control temporal en la barra superior;
+- selector de año y selector de semanas del año seleccionado;
+- provisión inicial automática de años en `campaign/01`;
+- extensión manual de años (`+1`) con confirmación;
+- semántica de navegación de semana vs cambio de `week_cursor`;
+- patrón de UI del selector de entry al pulsar semana (a nivel de intención).
+
+No incluye:
+
+- detalle de creación de `year/season/week` (Issue #13);
+- detalle del contenido y acciones del popover de entries (Issue #14 o
+  equivalente);
+- políticas de conflicto/timestamps más allá de las referencias a `#8` y `#18`;
+- acciones destructivas de reset o reprovisión completa de la estructura
+  temporal.
+
+## Estructura funcional de la pantalla principal (MVP)
+
+- **Barra superior**:
+  - navegación temporal (`year` + semanas);
+  - acceso a provisión/extensión de años;
+  - reemplaza la función de navegación temporal de la barra izquierda del
+    boceto anterior.
+- **Zona central**:
+  - formulario de la `Entry` actual (sin cambios de alcance en esta issue).
+- **Barra inferior**:
+  - totales de campaña (sin cambios de alcance en esta issue).
+
+## Selector de año
+
+1. Muestra el año actualmente seleccionado en la barra superior.
+1. Permite navegación entre años ya provisionados.
+1. Si existen años anteriores, se muestra acción de navegación a la izquierda
+   (`←`).
+1. Si existen años posteriores ya provisionados, se muestra acción de
+   navegación a la derecha (`→`).
+1. Si el año seleccionado es el último año provisionado, la acción derecha se
+   reemplaza por `+` para extensión manual.
+
+## Selector de semana
+
+1. El selector de semanas muestra semanas del **año seleccionado**.
+1. Su función principal en esta issue es navegación/foco temporal.
+1. Pulsar una semana **no cambia automáticamente** `campaign.week_cursor`.
+1. Al pulsar una semana se abre el flujo de selección de entry (popover/modal
+   anclado), definido en esta issue a nivel de patrón e intención.
+
+## Provisión inicial de años (automática)
+
+1. La provisión inicial ocurre automáticamente al crear `campaign/01`.
+1. El valor por defecto del MVP es **4 años**.
+1. Esta issue cierra el contrato funcional de provisión inicial, pero no el
+   detalle técnico de cómo se crean `year/season/week` (Issue #13).
+
+## Extensión manual de años (`+1` con confirmación)
+
+1. La extensión de años es manual y explícita en el MVP.
+1. Cuando el selector está en el último año provisionado, se muestra `+` en la
+   posición de la acción derecha.
+1. Pulsar `+` solicita confirmación.
+1. Tras confirmar, se añade **1 año** nuevo.
+1. No hay extensión automática por umbral en el MVP.
+
+## Ajuste manual de `week_cursor` (acción explícita separada)
+
+1. `week_cursor` sigue avanzando por el flujo normal de cierre de `Week`.
+1. Además, el MVP permite un ajuste manual explícito de `week_cursor` dentro del
+   flujo de controles temporales.
+1. La acción manual de `week_cursor` es separada del click en semana de
+   navegación (por ejemplo, una acción de “Marcar como actual”).
+1. Seleccionar semana para navegar/focalizar y cambiar `week_cursor` son
+   acciones distintas.
+
+## Click en semana y selector de entry (patrón + intención)
+
+1. Patrón de UI adoptado: **popover/modal anclado** al control de semana.
+1. Intención funcional:
+   - permitir seleccionar la `Entry` a editar dentro de la semana;
+   - mostrar estado vacío y/o acción hacia creación cuando no existan entries.
+1. El detalle del contenido del popover (layout, copy, orden y acciones de
+   creación rápida) queda fuera de esta issue y se difiere a Issue #14 o una
+   issue específica equivalente.
+
+## Límites y dependencias
+
+- **Issue #9** (esta decisión): navegación temporal superior + provisión/
+  extensión de años + semántica de `week_cursor`.
+- **Issue #13**: detalle técnico de inicialización y extensión de
+  `year/season/week`.
+- **Issue #14** (o equivalente): detalle del popover de entries y flujo de
+  selección/creación de entry desde semana.
+- **Issue #12**: contrato de operaciones Firestore por agregado (implementación
+  técnica de operaciones como provisión/extensión/cambio de cursor).
+- **Issue #18**: timestamps y desempates de orden estable entre dispositivos.
+
+## Referencias
+
+- `docs/domain-glossary.md`
+- `docs/conflict-policy.md`
+- `docs/decision-log.md`
+- `tdd.md` (legado temporal, alineado con referencia oficial)
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/9`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/13`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/14`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/18`

--- a/docs/conflict-policy.md
+++ b/docs/conflict-policy.md
@@ -52,6 +52,7 @@ No incluye:
 | `Session.stop` | `campaign` + `entry` + `session` | Alto | `rechazar` | `refrescar` + `reintentar` | Rechazar si la sesión activa cambió o ya fue cerrada |
 | `auto-stop` por nuevo `start` | `campaign` + `session` | Alto | `rechazar` | `refrescar` + `reintentar` | No usar LWW sobre estado de sesión |
 | `Week.close` | `week` + `campaign` | Alto | `rechazar` | `refrescar` + `reintentar` | Rechazar si `week.status` o `week_cursor` cambió |
+| `Campaign.set_week_cursor` (acción manual) | `campaign` | Alto | `rechazar` | `refrescar` + `reintentar` | Cambio de estado de campaña; sin `last-write-wins` |
 | Borrado de `Entry` activa (con cascada) | `entry` + `session` + `resource_change` | Alto | `rechazar` | `refrescar` + `reintentar` | Incluye auto-stop y borrado en cascada; contratos técnicos en #12 |
 | Edición de `Week.notes` | `week` | Medio | `rechazar` | `refrescar` + reingresar cambios | No usar `last-write-wins` en MVP |
 | Crear `ResourceChange` | `resource_change` (+ totales derivados) | Medio/Alto | `rechazar` | `refrescar` + `reintentar` | Política estricta para evitar inconsistencias silenciosas |
@@ -68,6 +69,8 @@ No incluye:
    la operación se **rechaza**.
 1. Si una operación depende de la sesión activa global y esa condición cambió,
    la operación se **rechaza**.
+1. Si una operación de ajuste manual de `week_cursor` encuentra que el cursor
+   cambió concurrentemente, la operación se **rechaza** y requiere `refresco`.
 1. Si el rechazo ocurre durante una operación compuesta (por ejemplo `auto-stop`
    + `start`, cierre de semana, borrado con cascada), se considera fallo de la
    operación completa y se requiere `refresco`.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -235,3 +235,27 @@
   `.github/ISSUE_TEMPLATE/decision.md`, `.github/ISSUE_TEMPLATE/task.md`,
   `.github/ISSUE_TEMPLATE/bug.md`, `.editorconfig`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/25`
+
+### DEC-0017
+
+- `date`: 2026-02-23
+- `status`: accepted
+- `problem`: el diseño de ajustes de campaña para provisión de años quedó
+  desalineado con el nuevo enfoque de pantalla única con selector temporal
+  superior.
+- `decision`: reencuadrar la Issue #9 para definir controles temporales de
+  campaña en la barra superior (selector de año/semana), provisión inicial
+  automática de 4 años, extensión manual `+1` con confirmación, patrón de
+  selector de entry en popover anclado y ajuste manual explícito de
+  `week_cursor` separado de la navegación de semanas.
+- `rationale`: simplifica la UI principal, evita una pantalla de ajustes
+  separada solo para años y mantiene coherencia con el modelo de pantalla única
+  del MVP.
+- `impact`: cambia el corte funcional de la Issue #9 respecto a #13 y #14;
+  exige alinear `week_cursor` en `docs/domain-glossary.md` y su política de
+  conflicto en `docs/conflict-policy.md`.
+- `references`: `docs/campaign-temporal-controls.md`, `docs/domain-glossary.md`,
+  `docs/conflict-policy.md`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/9`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/13`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/14`

--- a/docs/domain-glossary.md
+++ b/docs/domain-glossary.md
@@ -6,8 +6,8 @@
 - `purpose`: Definir el modelo de dominio e invariantes operativas del MVP.
 - `status`: active
 - `source_of_truth`: official
-- `last_updated`: 2026-02-20
-- `next_review`: 2026-03-06
+- `last_updated`: 2026-02-23
+- `next_review`: 2026-03-09
 
 ## Objetivo
 
@@ -21,6 +21,8 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
 
 - `campaign_id`: string fijo, valor `01`.
 - `week_cursor`: entero, semana actual activa.
+  - Puede cambiar por cierre de `Week` o por acción manual explícita del flujo
+    de controles temporales del MVP.
 - `resource_totals`: mapa `resource_key -> int` derivado del log de cambios.
 
 ### Year
@@ -89,6 +91,9 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
 
 - Persistencia temporal en UTC.
 - `week_number` global inmutable.
+- Seleccionar `Week` para navegación/foco no implica cambiar `week_cursor`.
+- `week_cursor` puede ajustarse manualmente mediante acción explícita separada
+  del selector de semana (MVP).
 - `year_number` y `season_type` son coherentes con `week_number` y la jerarquía.
 - En esta issue no se define provisión inicial de años (por ejemplo, crear 4
   años en bloque).
@@ -104,6 +109,8 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
 1. Si se borra una `Entry` activa, se hace `auto-stop` y luego borrado en
    cascada (`sessions` y `resource_changes`).
 1. Si se cierra `Week` con sesión activa, se hace `auto-stop` y luego cierre.
+1. `week_cursor` puede cambiar por cierre de `Week` y por acción manual
+   explícita de controles temporales; navegar semanas no cambia el cursor.
 1. `ResourceChange.delta` es entero firmado y se valida que el estado final de
    totales no sea negativo.
 1. `scenario_ref` es obligatorio y entero positivo para `scenario`.
@@ -119,3 +126,5 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
 1. Borrar `Entry` debe eliminar en cascada sus hijos.
 1. Operaciones que dejen totales finales negativos deben rechazarse.
 1. Cerrar `Week` con sesión activa debe cerrar sesión y avanzar cursor.
+1. Seleccionar una semana en el control temporal superior no debe cambiar
+   `week_cursor` sin acción explícita adicional.

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -33,6 +33,8 @@ Este documento permite que una persona o agente nuevo entienda rápidamente:
   - Estrategia de sincronización multidispositivo del MVP.
 - `docs/conflict-policy.md`
   - Política de conflictos concurrentes del MVP.
+- `docs/campaign-temporal-controls.md`
+  - Controles temporales de campaña y provisión/extensión de años del MVP.
 - `docs/context-checklists.md`
   - Checklists por trigger de trabajo.
 - `docs/repo-workflow.md`
@@ -78,6 +80,7 @@ Este documento permite que una persona o agente nuevo entienda rápidamente:
 - Modelo de dominio -> `docs/domain-glossary.md`
 - Sincronización MVP -> `docs/sync-strategy.md`
 - Conflictos concurrentes MVP -> `docs/conflict-policy.md`
+- Controles temporales de campaña -> `docs/campaign-temporal-controls.md`
 - Estado de fase -> `docs/context-governance.md`
 - Pasos operativos -> `docs/context-checklists.md`
 - Material reutilizable -> `learning/handbook.md`

--- a/tdd.md
+++ b/tdd.md
@@ -155,4 +155,7 @@ No incluye en MVP:
   `docs/sync-strategy.md`, Issue #7).
 - Política de conflictos concurrentes (resuelta en `docs/conflict-policy.md`,
   Issue #8).
-- Proceso de provisión inicial de años (por ejemplo, crear 4 años).
+- Controles temporales de campaña y provisión/extensión de años (resuelta en
+  `docs/campaign-temporal-controls.md`, Issue #9).
+- Estrategia de inicialización de años, temporadas y semanas (detalle técnico,
+  Issue #13).


### PR DESCRIPTION
﻿## Resumen

Closes #9.

Reencuadra la decisión de la Issue #9 hacia los controles temporales de campaña en la barra superior de la pantalla principal y documenta el contrato funcional del MVP.

## Qué se define (DEC-0017)

- Selector temporal superior (`año` / `semana`) en la barra superior.
- Provisión inicial automática de 4 años al crear `campaign/01`.
- Extensión manual `+1 año` con confirmación.
- Separación entre navegación de semanas y cambio de `week_cursor`.
- Patrón de selector de entry al pulsar semana: popover/modal anclado (detalle diferido).

## Documentos actualizados

- `docs/campaign-temporal-controls.md` (nuevo)
- `docs/system-map.md`
- `docs/decision-log.md` (`DEC-0017`)
- `docs/domain-glossary.md`
- `docs/conflict-policy.md`
- `tdd.md`
- `AGENTS.md`

## Checklist

- [x] Decisión documental trazada en `docs/decision-log.md`
- [x] Referencias cruzadas actualizadas (`system-map`, `AGENTS`, legado)
- [x] Alineación con `#8` para conflicto de `week_cursor`
- [x] Alcance y límites de `#9` explícitos (corte con `#13` y `#14`)
- [x] Texto en castellano revisado (tildes/ñ/ortografía)
