### PR TITLE
[DECISION] Formalizar que 'siguiente paso' identifica y ejecuta

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,11 @@ sencillo.
    - `siguiente paso` revisa primero PRs pendientes (incluyendo `draft`);
    - si no hay PRs pendientes, `siguiente paso` pasa a resolver la siguiente
      Issue pendiente.
+1. Ejecución por defecto de `siguiente paso`:
+   - `siguiente paso` implica identificar el trabajo prioritario y ejecutarlo
+     en la misma pasada por defecto;
+   - excepciones: `Plan Mode`, bloqueo real o petición explícita de solo plan/
+     análisis.
 1. Redacción en castellano:
    - usar ortografía completa (tildes, `ñ` y signos correctos) en issues, PR,
      documentación y futuros textos de UI;

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -259,3 +259,21 @@
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/9`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/13`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/14`
+
+### DEC-0018
+
+- `date`: 2026-02-23
+- `status`: accepted
+- `problem`: había ambigüedad entre responder cuál era el “siguiente paso” y
+  ejecutar ese siguiente paso en la misma sesión.
+- `decision`: cuando Kiko pide `siguiente paso`, Codex identifica el trabajo
+  prioritario y lo ejecuta por defecto en la misma pasada, manteniendo la
+  prioridad vigente (PRs abiertas, incluyendo `draft`, antes que issues). Si no
+  hay PRs abiertas, se resuelve la siguiente issue pendiente.
+- `rationale`: reduce fricción conversacional, evita intercambios innecesarios y
+  alinea la operación con el objetivo de avanzar de punta a punta en cada turno.
+- `impact`: se actualizan `docs/repo-workflow.md` y `AGENTS.md` para reflejar
+  el comportamiento por defecto y sus excepciones (`Plan Mode`, bloqueo real,
+  petición explícita de solo plan/análisis).
+- `references`: `AGENTS.md`, `docs/repo-workflow.md`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/28`

--- a/docs/repo-workflow.md
+++ b/docs/repo-workflow.md
@@ -64,6 +64,12 @@ Aplicar un flujo profesional, simple y mantenible para un solo desarrollador.
   cierre (merge o cierre explícito si se descarta).
 - Si no hay PRs abiertas, el siguiente paso es resolver la `siguiente pendiente`
   (`siguiente issue pendiente`).
+- Cuando Kiko pide `siguiente paso`, Codex identifica el paso prioritario y lo
+  ejecuta en la misma sesión/pasada por defecto.
+- Excepciones explícitas:
+  - `Plan Mode` (se planifica y no se ejecuta).
+  - Bloqueo real que impida continuar.
+  - Petición explícita de solo plan o solo análisis.
 
 ## Reglas de commits
 


### PR DESCRIPTION
﻿## Resumen

Closes #28.

Formaliza que `siguiente paso` no solo identifica el trabajo prioritario, sino que lo ejecuta en la misma pasada por defecto.

## Qué cambia

- `docs/repo-workflow.md`: añade la subregla operativa de ejecución por defecto y sus excepciones.
- `AGENTS.md`: resume la regla en el protocolo de colaboración con Codex.
- `docs/decision-log.md`: registra `DEC-0018`.

## Excepciones explícitas documentadas

- `Plan Mode`
- Bloqueo real
- Petición explícita de solo plan o solo análisis

## Checklist

- [x] Regla de priorización existente (`PR` -> `issue`) se mantiene
- [x] Regla de ejecución por defecto de `siguiente paso` documentada
- [x] Excepciones explícitas documentadas
- [x] Trazabilidad registrada en `DEC-0018`
- [x] Texto en castellano revisado (tildes/ñ/ortografía)
