### PR TITLE
[DECISION] Priorizar orden técnico en siguiente paso cuando exista

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,8 +73,12 @@ sencillo.
 1. Comandos conversacionales de priorización:
    - `siguiente pendiente` y `siguiente issue pendiente` son equivalentes;
    - `siguiente paso` revisa primero PRs pendientes (incluyendo `draft`);
-   - si no hay PRs pendientes, `siguiente paso` pasa a resolver la siguiente
-     Issue pendiente.
+   - si no hay PRs pendientes, `siguiente paso` usa orden técnico recomendado
+     (si existe) tomando la fuente oficial más específica (detalle > macro);
+   - si no existe orden técnico aplicable, `siguiente paso` pasa a resolver la
+     siguiente Issue pendiente;
+   - si el siguiente item técnico no es cerrable, salta al siguiente cerrable;
+   - si no hay cerrables en el orden técnico, toma el primer `draftable`.
 1. Ejecución por defecto de `siguiente paso`:
    - `siguiente paso` implica identificar el trabajo prioritario y ejecutarlo
      en la misma pasada por defecto;

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -277,3 +277,27 @@
   petición explícita de solo plan/análisis).
 - `references`: `AGENTS.md`, `docs/repo-workflow.md`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/28`
+
+### DEC-0019
+
+- `date`: 2026-02-23
+- `status`: accepted
+- `problem`: priorizar por número de Issue al pedir `siguiente paso` ignora el
+  orden técnico del checklist cuando ya existe una secuencia recomendada
+  documentada para la Fase 1.
+- `decision`: mantener prioridad de PRs abiertas (incluyendo `draft`) y, si no
+  hay PRs, priorizar el orden técnico recomendado en documentación oficial
+  aplicable usando la fuente más específica (detalle > macro). Si una Issue del
+  orden técnico no es cerrable, se salta a la siguiente cerrable; si no hay
+  cerrables, se toma la primera `draftable`. Solo si no existe orden técnico
+  aplicable se usa la Issue abierta de número más bajo.
+- `rationale`: alinea la ejecución conversacional con la secuencia técnica
+  documentada, reduce saltos de contexto y evita priorizaciones por número que
+  aumentan el retrabajo.
+- `impact`: actualiza la selección de `siguiente paso` en Fase 1 (por ejemplo,
+  puede priorizar `#13` antes de `#12`); mantiene sin cambios `siguiente
+  pendiente`/`siguiente issue pendiente` y la regla de ejecución por defecto de
+  `siguiente paso`.
+- `references`: `AGENTS.md`, `docs/repo-workflow.md`,
+  `docs/mvp-implementation-checklist.md`, `docs/mvp-implementation-blocks.md`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/32`

--- a/docs/repo-workflow.md
+++ b/docs/repo-workflow.md
@@ -62,8 +62,23 @@ Aplicar un flujo profesional, simple y mantenible para un solo desarrollador.
 - Si hay varias PRs abiertas, prioriza la PR con número más bajo.
 - Si existe al menos una PR abierta, el siguiente paso es llevar esa PR a
   cierre (merge o cierre explícito si se descarta).
-- Si no hay PRs abiertas, el siguiente paso es resolver la `siguiente pendiente`
-  (`siguiente issue pendiente`).
+- Si no hay PRs abiertas, Codex busca un **orden técnico recomendado** en la
+  documentación oficial aplicable.
+- Si existe orden técnico recomendado:
+  - usa la fuente oficial más específica disponible (detalle > macro);
+  - recorre el orden y elige la primera Issue abierta **cerrable**;
+  - si una Issue abierta no es cerrable, la salta y evalúa la siguiente;
+  - si no hay Issues cerrables en ese orden, elige la primera Issue
+    `draftable`.
+- Si no existe orden técnico aplicable, el siguiente paso es resolver la
+  `siguiente pendiente` (`siguiente issue pendiente`).
+- Definición operativa para esta regla:
+  - `cerrable`: Issue abierta con dependencias de cierre satisfechas según la
+    documentación oficial vigente.
+  - `draftable`: Issue abierta que puede iniciarse en borrador, pero cuyo cierre
+    depende de otras Issues.
+  - `blocked`: Issue abierta que no debe cerrarse hasta resolver dependencias
+    faltantes.
 - Cuando Kiko pide `siguiente paso`, Codex identifica el paso prioritario y lo
   ejecuta en la misma sesión/pasada por defecto.
 - Excepciones explícitas:


### PR DESCRIPTION
﻿## Resumen

Closes #32.

Formaliza el cambio global de regla para `siguiente paso`: cuando no hay PRs abiertas, se prioriza el orden técnico recomendado (si existe) y solo se usa el número más bajo como fallback.

## Cambios

- `docs/repo-workflow.md`
  - prioriza orden técnico recomendado (detalle > macro)
  - define manejo de `cerrable`, `draftable` y `blocked`
  - mantiene PRs abiertas primero y fallback a `siguiente pendiente` solo si no hay orden técnico
- `AGENTS.md`
  - resume la nueva regla de priorización en el protocolo de colaboración
- `docs/decision-log.md`
  - registra `DEC-0019`

## Compatibilidad y alcance

- Se mantiene `siguiente pendiente` / `siguiente issue pendiente` = issue abierta con número más bajo.
- Se mantiene la regla de ejecución por defecto de `siguiente paso` (identificar + ejecutar).
- No hay cambios de runtime ni código de app.

## Checklist

- [x] Regla global de `siguiente paso` actualizada
- [x] Precedencia de fuente (detalle > macro) documentada
- [x] Manejo de `cerrable` / `draftable` / `blocked` documentado
- [x] Trazabilidad registrada en `DEC-0019`
- [x] Texto en castellano revisado (tildes/ñ/ortografía)
