### PR TITLE
docs(workflow): cerrar unidades completas en siguiente paso (#35)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,9 +72,16 @@ sencillo.
    `main` (merge/PR), salvo instrucción explícita de Kiko.
 1. Comandos conversacionales de priorización:
    - `siguiente pendiente` y `siguiente issue pendiente` son equivalentes;
-   - `siguiente paso` revisa primero PRs pendientes (incluyendo `draft`);
-   - si no hay PRs pendientes, `siguiente paso` usa orden técnico recomendado
-     (si existe) tomando la fuente oficial más específica (detalle > macro);
+   - `siguiente paso` revisa primero si existe una **unidad pendiente de
+     cierre** (trabajo local sin commit, commits sin `push`, rama sin PR cuando
+     aplica, PR abierta, Issue abierta tras merge o limpieza de rama pendiente);
+   - si existe unidad pendiente de cierre, `siguiente paso` resuelve esa unidad
+     antes de iniciar trabajo nuevo;
+   - solo si no existe unidad pendiente de cierre, `siguiente paso` revisa PRs
+     pendientes (incluyendo `draft`);
+   - si no hay PRs pendientes ni unidad pendiente de cierre, `siguiente paso`
+     usa orden técnico recomendado (si existe) tomando la fuente oficial más
+     específica (detalle > macro);
    - si no existe orden técnico aplicable, `siguiente paso` pasa a resolver la
      siguiente Issue pendiente;
    - si el siguiente item técnico no es cerrable, salta al siguiente cerrable;
@@ -82,6 +89,16 @@ sencillo.
 1. Ejecución por defecto de `siguiente paso`:
    - `siguiente paso` implica identificar el trabajo prioritario y ejecutarlo
      en la misma pasada por defecto;
+   - en trabajo no trivial con rama, el objetivo por defecto es **cierre
+     end-to-end** de la unidad: cambios -> commit -> `push` -> PR -> merge/cierre
+     -> cierre de Issue -> limpieza de rama (cuando aplique);
+   - en `type:decision`, si falta aprobación explícita de Kiko, la unidad se
+     deja bloqueada por aprobación y sigue siendo prioritaria en el siguiente
+     `siguiente paso`; si Kiko aprueba explícitamente en el mismo turno, Codex
+     completa el cierre en esa misma pasada;
+   - tras cada `siguiente paso`, Codex reporta: unidad priorizada, estado de
+     cierre alcanzado (`local`, `push`, `PR`, `merge`, `issue`, `cleanup`),
+     bloqueo (si existe) y si puede pasar o no a la siguiente unidad;
    - excepciones: `Plan Mode`, bloqueo real o petición explícita de solo plan/
      análisis.
 1. Redacción en castellano:

--- a/docs/context-checklists.md
+++ b/docs/context-checklists.md
@@ -6,8 +6,8 @@
 - `purpose`: Checklists operativas para calidad y trazabilidad.
 - `status`: active
 - `source_of_truth`: official
-- `last_updated`: 2026-02-23
-- `next_review`: 2026-03-09
+- `last_updated`: 2026-02-24
+- `next_review`: 2026-03-10
 
 ## Formato canónico por checklist
 
@@ -84,6 +84,37 @@
 
   1. Alcance nuevo documentado.
   1. No hay trabajo oculto fuera de fase.
+
+- `owner`: IA ejecuta, Kiko valida.
+
+## CHK-NEXT-STEP
+
+- `trigger`: comando conversacional `siguiente paso`.
+- `steps`:
+
+  1. Verificar si existe **unidad pendiente de cierre** antes de buscar trabajo
+     nuevo.
+  1. Revisar en orden:
+     - trabajo local sin commit;
+     - commits locales sin `push`;
+     - rama publicada sin PR (si aplica);
+     - PR abierta (`draft` o no);
+     - Issue abierta tras merge;
+     - limpieza de rama pendiente.
+  1. Si existe unidad pendiente de cierre, resolver esa unidad hasta el máximo
+     cerrable (end-to-end por defecto).
+  1. Si no existe unidad pendiente de cierre, aplicar la regla normal de
+     priorización (`PRs` -> orden técnico -> `siguiente pendiente`).
+  1. Reportar unidad priorizada, estado de cierre, bloqueo (si existe) y si se
+     puede pasar a la siguiente unidad.
+
+- `validation`:
+
+  1. No se inicia una unidad nueva mientras exista una unidad pendiente de
+     cierre no bloqueada.
+  1. El reporte final explicita el estado de cierre alcanzado.
+  1. Si la unidad es `type:decision`, queda claro si falta aprobación explícita
+     de Kiko o si se cerró en el mismo turno.
 
 - `owner`: IA ejecuta, Kiko valida.
 

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -324,3 +324,32 @@
   `docs/campaign-temporal-initialization.md`, `docs/domain-glossary.md`,
   `docs/mvp-implementation-blocks.md`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/13`
+
+### DEC-0021
+
+- `date`: 2026-02-24
+- `status`: accepted
+- `problem`: la regla de `siguiente paso` priorizaba PRs abiertas y orden
+  técnico, pero no contemplaba explícitamente unidades ya iniciadas con trabajo
+  local/remoto pendiente de cierre (por ejemplo commits sin `push` o rama sin
+  PR), lo que podía dejar tareas a medias y permitir avanzar al siguiente
+  trabajo.
+- `decision`: redefinir `siguiente paso` para que primero detecte y resuelva una
+  **unidad pendiente de cierre** antes de iniciar trabajo nuevo; adoptar por
+  defecto un cierre end-to-end (commit, `push`, PR, merge/cierre, cierre de
+  Issue y limpieza de rama cuando aplique); y documentar el manejo de
+  bloqueos por aprobación en `type:decision` y el comportamiento específico en
+  `Plan Mode`.
+- `rationale`: alinea la ejecución con la expectativa de cierre real por unidad,
+  reduce riesgo de trabajo huérfano en ramas locales/remotas y corrige el hueco
+  observado en el caso de la Issue `#13` antes de su PR `#34`.
+- `impact`: se actualizan `AGENTS.md`, `docs/repo-workflow.md` y
+  `docs/context-checklists.md`; `siguiente paso` pasa a priorizar pendientes de
+  cierre (incluyendo trabajo local sin publicar) antes de PRs abiertas y orden
+  técnico; el reporte de sesión debe indicar estado de cierre alcanzado y
+  bloqueo si existe.
+- `references`: `AGENTS.md`, `docs/repo-workflow.md`,
+  `docs/context-checklists.md`, `docs/decision-log.md`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/35`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/13`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/pull/34`

--- a/docs/repo-workflow.md
+++ b/docs/repo-workflow.md
@@ -6,8 +6,8 @@
 - `purpose`: Definir el flujo Git y GitHub adoptado.
 - `status`: active
 - `source_of_truth`: official
-- `last_updated`: 2026-02-23
-- `next_review`: 2026-03-09
+- `last_updated`: 2026-02-24
+- `next_review`: 2026-03-10
 
 ## Objetivo
 
@@ -58,7 +58,11 @@ Aplicar un flujo profesional, simple y mantenible para un solo desarrollador.
 
 #### Regla de `siguiente paso`
 
-- Codex revisa primero las PRs abiertas del repo (incluyendo `draft`).
+- Codex revisa primero si existe una **unidad pendiente de cierre**.
+- Si existe una unidad pendiente de cierre, el siguiente paso es resolver esa
+  unidad antes de iniciar trabajo nuevo.
+- Solo si no existe una unidad pendiente de cierre, Codex revisa las PRs
+  abiertas del repo (incluyendo `draft`).
 - Si hay varias PRs abiertas, prioriza la PR con número más bajo.
 - Si existe al menos una PR abierta, el siguiente paso es llevar esa PR a
   cierre (merge o cierre explícito si se descarta).
@@ -73,6 +77,16 @@ Aplicar un flujo profesional, simple y mantenible para un solo desarrollador.
 - Si no existe orden técnico aplicable, el siguiente paso es resolver la
   `siguiente pendiente` (`siguiente issue pendiente`).
 - Definición operativa para esta regla:
+  - `unidad pendiente de cierre`: unidad ya iniciada (issue/rama/PR asociada)
+    que todavía no completó su pipeline de cierre. Se detecta en este orden de
+    prioridad:
+    1. trabajo local sin commit relacionado con la unidad activa;
+    1. commit(s) locales en rama sin `push`;
+    1. rama publicada con trabajo de la unidad pero sin PR (cuando corresponde
+       PR por reglas del repo);
+    1. PR abierta (incluyendo `draft`);
+    1. PR mergeada pero Issue asociada aún abierta;
+    1. rama local/remota mergeada pendiente de limpieza.
   - `cerrable`: Issue abierta con dependencias de cierre satisfechas según la
     documentación oficial vigente.
   - `draftable`: Issue abierta que puede iniciarse en borrador, pero cuyo cierre
@@ -81,10 +95,45 @@ Aplicar un flujo profesional, simple y mantenible para un solo desarrollador.
     faltantes.
 - Cuando Kiko pide `siguiente paso`, Codex identifica el paso prioritario y lo
   ejecuta en la misma sesión/pasada por defecto.
+- En trabajo no trivial con rama, el objetivo por defecto es completar el
+  **cierre end-to-end** de la unidad, hasta donde sea posible en la misma
+  pasada:
+  1. implementar/cerrar cambios pendientes de la unidad;
+  1. commit;
+  1. `push` de rama;
+  1. abrir PR;
+  1. llevar PR a cierre (merge o cierre explícito si se descarta);
+  1. cerrar la Issue asociada tras integración en `main`;
+  1. limpiar rama local/remota (si aplica).
+- Regla específica para `type:decision`:
+  - Codex llega hasta el máximo cerrable.
+  - Si falta aprobación explícita de Kiko, deja la unidad bloqueada por
+    aprobación y no salta a otra unidad por defecto.
+  - Si Kiko aprueba explícitamente en el mismo turno, Codex completa
+    merge/cierre/limpieza en esa misma pasada.
+- Regla en `Plan Mode`:
+  - `siguiente paso` identifica la unidad pendiente de cierre (si existe) y
+    planifica su cierre end-to-end, sin ejecutar mutaciones.
+  - Debe dejar explícito cuál sería el siguiente acto mutante al salir de
+    `Plan Mode`.
+- Reporte obligatorio tras `siguiente paso`:
+  - unidad priorizada;
+  - estado de cierre alcanzado (`local`, `push`, `PR`, `merge`, `issue`,
+    `cleanup`);
+  - bloqueo (si existe) y su motivo;
+  - confirmación explícita de si puede o no pasar a la siguiente unidad.
 - Excepciones explícitas:
   - `Plan Mode` (se planifica y no se ejecuta).
   - Bloqueo real que impida continuar.
   - Petición explícita de solo plan o solo análisis.
+
+##### Nota de aplicación (caso #13)
+
+- El caso de la Issue `#13` (especificación temporal) dejó documentado el hueco
+  de comportamiento: había commit local en rama sin `push`/sin PR y, aun así,
+  se llegó a evaluar trabajo nuevo.
+- Con esta regla, ese estado se clasifica como `unidad pendiente de cierre` y el
+  siguiente `siguiente paso` correcto es publicar/cerrar esa unidad primero.
 
 ## Reglas de commits
 


### PR DESCRIPTION
## Resumen
- a?ade la definici?n de unidad pendiente de cierre para `siguiente paso`
- cambia la prioridad para resolver primero pendientes de cierre antes de PRs/orden t?cnico
- formaliza cierre end-to-end, manejo de `type:decision`, `Plan Mode` y reporte obligatorio
- a?ade `CHK-NEXT-STEP` y registra `DEC-0021`

## Caso cubierto
- el hueco observado en la Issue `#13` (commit local sin `push`/sin PR) queda clasificado como pendiente de cierre

## Checklist
- [x] Documentaci?n oficial actualizada
- [x] Trazabilidad en `decision-log`
- [x] Sin cambios de runtime

Closes #35
