### PR TITLE
docs(domain): politica de editabilidad manual MVP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,7 @@ Cada interacción termina con un menú numerado fijo de 3 a 5 siguientes pasos.
 - Política de conflictos concurrentes MVP: `docs/conflict-policy.md`
 - Controles temporales de campaña: `docs/campaign-temporal-controls.md`
 - Inicialización temporal de campaña (técnica): `docs/campaign-temporal-initialization.md`
+- Política de editabilidad manual MVP: `docs/editability-policy.md`
 - Checklist técnico de implementación MVP: `docs/mvp-implementation-checklist.md`
 - Bloques de implementación MVP: `docs/mvp-implementation-blocks.md`
 - Guía reusable: `learning/handbook.md`

--- a/docs/campaign-temporal-controls.md
+++ b/docs/campaign-temporal-controls.md
@@ -6,8 +6,8 @@
 - `purpose`: Definir el contrato funcional de navegación temporal y provisión/extensión de años en la pantalla principal del MVP.
 - `status`: active
 - `source_of_truth`: official
-- `last_updated`: 2026-02-23
-- `next_review`: 2026-03-09
+- `last_updated`: 2026-02-24
+- `next_review`: 2026-03-10
 
 ## Objetivo
 
@@ -83,15 +83,16 @@ No incluye:
 1. Tras confirmar, se añade **1 año** nuevo.
 1. No hay extensión automática por umbral en el MVP.
 
-## Ajuste manual de `week_cursor` (acción explícita separada)
+## Política de `week_cursor` (actualización posterior de dominio)
 
-1. `week_cursor` sigue avanzando por el flujo normal de cierre de `Week`.
-1. Además, el MVP permite un ajuste manual explícito de `week_cursor` dentro del
-   flujo de controles temporales.
-1. La acción manual de `week_cursor` es separada del click en semana de
-   navegación (por ejemplo, una acción de “Marcar como actual”).
-1. Seleccionar semana para navegar/focalizar y cambiar `week_cursor` son
-   acciones distintas.
+1. La semántica original de ajuste manual explícito de `week_cursor` definida en
+   esta issue fue **actualizada** por la Issue `#37`
+   (`docs/editability-policy.md`).
+1. En el MVP actual, `week_cursor` apunta a la **primera `Week` abierta**
+   (menor `week_number` abierta) y se recalcula tras cambios de estado de
+   `Week`.
+1. Seleccionar semana para navegar/focalizar sigue siendo una acción separada de
+   la navegación temporal y no cambia automáticamente `week_cursor`.
 
 ## Click en semana y selector de entry (patrón + intención)
 
@@ -113,6 +114,8 @@ No incluye:
   selección/creación de entry desde semana.
 - **Issue #12**: contrato de operaciones Firestore por agregado (implementación
   técnica de operaciones como provisión/extensión/cambio de cursor).
+- **Issue #37**: política de editabilidad manual del MVP y semántica derivada de
+  `week_cursor` (primera `Week` abierta), que actualiza esta decisión.
 - **Issue #18**: timestamps y desempates de orden estable entre dispositivos.
 
 ## Referencias
@@ -120,9 +123,11 @@ No incluye:
 - `docs/domain-glossary.md`
 - `docs/conflict-policy.md`
 - `docs/decision-log.md`
+- `docs/editability-policy.md`
 - `tdd.md` (legado temporal, alineado con referencia oficial)
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/9`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/13`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/14`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/18`

--- a/docs/campaign-temporal-initialization.md
+++ b/docs/campaign-temporal-initialization.md
@@ -45,6 +45,9 @@ No incluye:
   - jerarquía `campaign > year > season > week > entry`;
   - `week_number` global inmutable;
   - `week_cursor` separado de la navegación de semana.
+- `docs/editability-policy.md` (Issue #37):
+  - `week_cursor` = primera `Week` abierta;
+  - recálculo tras cambios de `Week.status`.
 - Aclaración de Kiko (fuente de verdad para `#13`):
   - `season` = **estación** (`summer|winter`);
   - orden fijo: `summer` -> `winter`;
@@ -176,7 +179,8 @@ Por cada `year_number`:
 
 - Navegar o seleccionar una semana en el control temporal superior **no**
   cambia automáticamente `campaign.week_cursor`.
-- `week_cursor` sigue siendo una acción separada y explícita del flujo temporal.
+- La política de recálculo de `week_cursor` (primera `Week` abierta) se define
+  en `docs/editability-policy.md` (Issue #37).
 - Esta especificación (#13) define la estructura temporal creada; no redefine la
   semántica funcional de navegación/cursor ya cerrada en `#9`.
 
@@ -188,7 +192,8 @@ contrato de operaciones Firestore por agregado:
 - qué crea la provisión inicial (`4` años, `80` semanas, orden fijo);
 - qué crea la extensión `+1` (un año completo, `20` semanas);
 - qué validaciones mínimas temporales deben respetarse;
-- qué no cambia (`week_cursor` por navegación de semana).
+- qué no cambia (navegación de semana no altera `week_cursor`);
+- que la semántica de recálculo de `week_cursor` se alinea con `#37`.
 
 `#13` no define:
 
@@ -233,10 +238,12 @@ contrato de operaciones Firestore por agregado:
 - `docs/campaign-temporal-controls.md`
 - `docs/domain-glossary.md`
 - `docs/conflict-policy.md`
+- `docs/editability-policy.md`
 - `docs/mvp-implementation-checklist.md`
 - `docs/mvp-implementation-blocks.md`
 - `docs/decision-log.md`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/9`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/13`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/18`

--- a/docs/conflict-policy.md
+++ b/docs/conflict-policy.md
@@ -6,8 +6,8 @@
 - `purpose`: Definir la política de resolución de conflictos concurrentes del MVP.
 - `status`: active
 - `source_of_truth`: official
-- `last_updated`: 2026-02-23
-- `next_review`: 2026-03-09
+- `last_updated`: 2026-02-24
+- `next_review`: 2026-03-10
 
 ## Objetivo
 
@@ -39,8 +39,8 @@ No incluye:
    `refresco` y `reintento`.
 1. Se mantiene la recomendación operativa de `single writer` definida en
    `docs/sync-strategy.md`.
-1. No se usa `last-write-wins` para operaciones de estado, edición de notas ni
-   `ResourceChange`.
+1. No se usa `last-write-wins` para operaciones de estado, edición de notas,
+   reordenación manual ni `ResourceChange`.
 1. La política define comportamiento esperado; el mecanismo técnico exacto de
    detección queda para la Issue #12.
 
@@ -52,7 +52,10 @@ No incluye:
 | `Session.stop` | `campaign` + `entry` + `session` | Alto | `rechazar` | `refrescar` + `reintentar` | Rechazar si la sesión activa cambió o ya fue cerrada |
 | `auto-stop` por nuevo `start` | `campaign` + `session` | Alto | `rechazar` | `refrescar` + `reintentar` | No usar LWW sobre estado de sesión |
 | `Week.close` | `week` + `campaign` | Alto | `rechazar` | `refrescar` + `reintentar` | Rechazar si `week.status` o `week_cursor` cambió |
-| `Campaign.set_week_cursor` (acción manual) | `campaign` | Alto | `rechazar` | `refrescar` + `reintentar` | Cambio de estado de campaña; sin `last-write-wins` |
+| `Week.reopen` | `week` + `campaign` | Alto | `rechazar` | `refrescar` + `reintentar` | Recalcula `week_cursor`; política de editabilidad en #37 |
+| `Week.reclose` | `week` + `campaign` | Alto | `rechazar` | `refrescar` + `reintentar` | Recalcula `week_cursor`; rechazar si dejaría cursor inválido |
+| `Entry.reorder_within_week` | `week` + `entry` | Medio/Alto | `rechazar` | `refrescar` + `reintentar` | Resecuencia densa `1..N`; detalle contractual en #12 |
+| `Session.manual_create/update/delete` | `session` + `campaign` | Alto | `rechazar` | `refrescar` + `reintentar` | Mantener `0..1` sesión activa global; detalle contractual en #12 |
 | Borrado de `Entry` activa (con cascada) | `entry` + `session` + `resource_change` | Alto | `rechazar` | `refrescar` + `reintentar` | Incluye auto-stop y borrado en cascada; contratos técnicos en #12 |
 | Edición de `Week.notes` | `week` | Medio | `rechazar` | `refrescar` + reingresar cambios | No usar `last-write-wins` en MVP |
 | Crear `ResourceChange` | `resource_change` (+ totales derivados) | Medio/Alto | `rechazar` | `refrescar` + `reintentar` | Política estricta para evitar inconsistencias silenciosas |
@@ -65,15 +68,17 @@ No incluye:
    cliente, la operación se **rechaza por conflicto**.
 1. Si una entidad fue borrada (o marcada como borrada) concurrentemente,
    prevalece el estado remoto actual y la operación local se **rechaza**.
-1. Si una operación depende de `Week.status=open` y la semana ya fue cerrada,
-   la operación se **rechaza**.
+1. Si una operación específica define como precondición `Week.status=open` y la
+   semana ya fue cerrada, la operación se **rechaza**.
 1. Si una operación depende de la sesión activa global y esa condición cambió,
    la operación se **rechaza**.
-1. Si una operación de ajuste manual de `week_cursor` encuentra que el cursor
-   cambió concurrentemente, la operación se **rechaza** y requiere `refresco`.
+1. Si una operación de cambio de estado de `Week` (`close`, `reopen`,
+   `reclose`) encuentra que `week.status` o el recálculo de `week_cursor`
+   quedó invalidado por cambios concurrentes, la operación se **rechaza** y
+   requiere `refresco`.
 1. Si el rechazo ocurre durante una operación compuesta (por ejemplo `auto-stop`
-   + `start`, cierre de semana, borrado con cascada), se considera fallo de la
-   operación completa y se requiere `refresco`.
+   + `start`, cierre/reapertura de semana, borrado con cascada), se considera
+   fallo de la operación completa y se requiere `refresco`.
 1. La precedencia de orden temporal fino y desempates entre eventos casi
    simultáneos queda fuera de esta issue y se define en la Issue #18.
 
@@ -94,6 +99,16 @@ No incluye:
 - Un dispositivo cierra una `Week` mientras otro edita `Week.notes`.
   - Resultado MVP: la edición depende del estado actual; si el estado cambió de
     forma incompatible, se rechaza y se refresca.
+- Un dispositivo reabre una `Week` mientras otro la re-cierra o cierra una week
+  distinta que afecta al `week_cursor`.
+  - Resultado MVP: una de las operaciones puede quedar obsoleta; se rechaza y
+    requiere `refresco`.
+- Dos dispositivos reordenan entries de la misma `Week` a la vez.
+  - Resultado MVP: rechazo en conflicto y reintento; no se aplica LWW.
+- Corrección manual de sesión mientras otro dispositivo ejecuta `Session.start`
+  o `Session.stop`.
+  - Resultado MVP: rechazo en conflicto si cambia la condición de sesión activa
+    global.
 - Un dispositivo borra una `Entry` activa mientras otro registra recursos sobre
   esa `Entry`.
   - Resultado MVP: una de las operaciones quedará inválida; se rechaza la que
@@ -108,6 +123,9 @@ No incluye:
 - **Issue #8**: esta política de conflictos concurrentes.
 - **Issue #12**: define el contrato técnico por agregado y el mecanismo de
   detección/validación de conflictos.
+- **Issue #37**: actualiza la política de editabilidad manual del MVP y la
+  semántica de `week_cursor`, añadiendo operaciones de corrección manual
+  que deben respetar esta política de conflictos.
 - **Issue #18**: define timestamps y desempates de orden estable entre
   dispositivos, compatibles con esta política.
 
@@ -119,4 +137,5 @@ No incluye:
 - `tdd.md` (legado temporal, alineado con referencia oficial)
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/8`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/18`

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -353,3 +353,36 @@
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/35`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/13`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/pull/34`
+
+### DEC-0022
+
+- `date`: 2026-02-24
+- `status`: accepted
+- `problem`: el dominio del MVP quedó demasiado restrictivo para el objetivo de
+  trabajo “como papel”: no permitía reordenación manual de `Entry`, no definía
+  correcciones manuales amplias de `Session` ni `Week.reopen/reclose`, y
+  mantenía una semántica de `week_cursor` incompatible con esa editabilidad
+  ampliada, lo que bloqueaba la redacción coherente de la Issue #12.
+- `decision`: introducir una política marco de editabilidad manual del MVP
+  (`docs/editability-policy.md`, Issue #37) que permite reordenación manual de
+  `Entry` dentro de la misma `Week` con `order_index` denso `1..N`, habilita
+  correcciones manuales de `Week.status` (`reopen/reclose`) y correcciones
+  manuales completas de `Session` (crear/editar/borrar, incluyendo timestamps),
+  manteniendo la invariante de `0..1` sesión activa global; además, redefinir
+  `campaign.week_cursor` para que apunte siempre a la primera `Week` abierta
+  (menor `week_number` abierta) y rechazar operaciones que dejen `0` weeks
+  abiertas provisionadas.
+- `rationale`: permite un flujo de trabajo más flexible y cercano a papel sin
+  perder invariantes críticos, y separa correctamente la decisión de dominio
+  (editabilidad/cursor) del contrato técnico Firestore por agregado (Issue #12).
+- `impact`: actualiza `docs/domain-glossary.md`, `docs/conflict-policy.md`,
+  `docs/campaign-temporal-controls.md`, `docs/campaign-temporal-initialization.md`
+  y el orden técnico en `docs/mvp-implementation-checklist.md` /
+  `docs/mvp-implementation-blocks.md`; añade `docs/editability-policy.md` como
+  fuente oficial; desplaza la ejecución de `#12` para después de `#37`.
+- `references`: `docs/editability-policy.md`, `docs/domain-glossary.md`,
+  `docs/conflict-policy.md`, `docs/campaign-temporal-controls.md`,
+  `docs/campaign-temporal-initialization.md`,
+  `docs/mvp-implementation-checklist.md`, `docs/mvp-implementation-blocks.md`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`

--- a/docs/domain-glossary.md
+++ b/docs/domain-glossary.md
@@ -21,8 +21,8 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
 
 - `campaign_id`: string fijo, valor `01`.
 - `week_cursor`: entero, semana actual activa.
-  - Puede cambiar por cierre de `Week` o por acción manual explícita del flujo
-    de controles temporales del MVP.
+  - En MVP apunta a la **primera `Week` abierta** (menor `week_number` abierta)
+    y se recalcula tras operaciones que cambian el estado de `Week`.
 - `resource_totals`: mapa `resource_key -> int` derivado del log de cambios.
 
 ### Year
@@ -47,6 +47,8 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
 
 - `entry_id`: auto-id técnico.
 - `order_index`: entero positivo para orden del timeline.
+  - En MVP puede corregirse manualmente dentro de la misma `Week` con
+    resecuenciación densa `1..N`.
 - `type`: `scenario|outpost`.
 - `scenario_ref`: entero positivo obligatorio cuando `type=scenario`.
 - `created_at_utc`, `updated_at_utc`, `deleted_at_utc`: auditoría mínima.
@@ -94,27 +96,38 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
 - Persistencia temporal en UTC.
 - `week_number` global inmutable.
 - Seleccionar `Week` para navegación/foco no implica cambiar `week_cursor`.
-- `week_cursor` puede ajustarse manualmente mediante acción explícita separada
-  del selector de semana (MVP).
+- `week_cursor` se deriva de la primera `Week` abierta (menor `week_number`
+  abierta) según `docs/editability-policy.md`.
+- Las correcciones manuales de `Week.status` (`reopen`/`reclose`) recalculan
+  `week_cursor`.
 - `year_number` y `season_type` son coherentes con `week_number` y la jerarquía.
 - En esta issue no se define provisión inicial de años (por ejemplo, crear 4
   años en bloque).
 - El detalle técnico de inicialización/extensión temporal y cardinalidad de
   semanas por estación se define en `docs/campaign-temporal-initialization.md`.
+- La política de editabilidad manual y correcciones de estado/sesiones se define
+  en `docs/editability-policy.md`.
 
 ## Invariantes operativas cerradas
 
 1. La diferenciación funcional entre entradas se hace por `Entry.type`.
 1. `order_index` define el orden de visualización del timeline.
-1. En MVP no hay reordenación manual de `Entry`.
+1. En MVP sí hay reordenación manual de `Entry`, limitada a la misma `Week`, con
+   resecuenciación densa `1..N`.
 1. Solo puede existir `0..1` `Session` activa global en la campaña.
 1. Si se inicia una nueva sesión con otra activa, se hace `auto-stop` de la
    anterior y `start` de la nueva.
 1. Si se borra una `Entry` activa, se hace `auto-stop` y luego borrado en
    cascada (`sessions` y `resource_changes`).
 1. Si se cierra `Week` con sesión activa, se hace `auto-stop` y luego cierre.
-1. `week_cursor` puede cambiar por cierre de `Week` y por acción manual
-   explícita de controles temporales; navegar semanas no cambia el cursor.
+1. `Week.status` puede corregirse manualmente (`reopen`/`reclose`) en MVP.
+1. Se permiten correcciones manuales completas de `Session` (crear/editar/
+   borrar), manteniendo `0..1` sesión activa global.
+1. `week_cursor` siempre apunta a la primera `Week` abierta (menor
+   `week_number` abierta) y se recalcula tras cambios de estado de `Week`;
+   navegar semanas no cambia el cursor.
+1. Debe existir al menos una `Week` abierta provisionada para mantener
+   `week_cursor` como entero válido.
 1. `ResourceChange.delta` es entero firmado y se valida que el estado final de
    totales no sea negativo.
 1. `scenario_ref` es obligatorio y entero positivo para `scenario`.
@@ -126,9 +139,18 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
 1. Cambios en semanas históricas no alteran `week_number`.
 1. Crear `Entry` tipo `scenario` sin `scenario_ref` debe rechazarse.
 1. Crear `Entry` tipo `outpost` sin campos extra debe aceptarse.
+1. Reordenar `Entry` solo se permite dentro de la misma `Week` y deja
+   `order_index` denso `1..N`.
 1. Iniciar sesión con otra activa debe cerrar la anterior y abrir la nueva.
+1. Correcciones manuales de `Session` deben rechazar estados que produzcan más
+   de una sesión activa global.
 1. Borrar `Entry` debe eliminar en cascada sus hijos.
+1. Reabrir o re-cerrar una `Week` recalcula `week_cursor` a la primera `Week`
+   abierta.
+1. No se permite cerrar/re-cerrar una `Week` si la operación dejaría `0` weeks
+   abiertas provisionadas.
 1. Operaciones que dejen totales finales negativos deben rechazarse.
-1. Cerrar `Week` con sesión activa debe cerrar sesión y avanzar cursor.
+1. Cerrar `Week` con sesión activa debe cerrar sesión y recalcular `week_cursor`
+   según la primera `Week` abierta.
 1. Seleccionar una semana en el control temporal superior no debe cambiar
    `week_cursor` sin acción explícita adicional.

--- a/docs/editability-policy.md
+++ b/docs/editability-policy.md
@@ -1,0 +1,286 @@
+# Política de Editabilidad Manual y Correcciones (MVP)
+
+## Metadatos
+
+- `doc_id`: DOC-EDITABILITY-POLICY
+- `purpose`: Definir la política de editabilidad manual del MVP ("como papel") y las correcciones de orden, estado y sesiones que actualizan invariantes del dominio antes del contrato Firestore por agregado.
+- `status`: active
+- `source_of_truth`: official
+- `last_updated`: 2026-02-24
+- `next_review`: 2026-03-10
+
+## Objetivo
+
+Cerrar una decisión marco de dominio para el MVP que permita correcciones
+manuales amplias ("como papel"), manteniendo consistencia explícita en
+invariantes críticos y dejando trazado el impacto sobre las Issues `#12`, `#14`,
+`#15`, `#17` y `#19`.
+
+## Alcance y no alcance
+
+Incluye:
+
+- reordenación manual de `Entry` dentro de una misma `Week`;
+- corrección manual de `Week.status` (`reopen`/`reclose`);
+- correcciones manuales completas de `Session` (crear/editar/borrar,
+  incluyendo timestamps);
+- política derivada de `campaign.week_cursor` como primera `Week` abierta;
+- matriz de operaciones manuales permitidas y sus límites;
+- impacto documental sobre dominio, conflictos y orden técnico downstream.
+
+No incluye:
+
+- contrato Firestore por agregado (Issue `#12`);
+- política de timestamps y desempates (Issue `#18`);
+- diseño de UI detallado de flujos y pantallas (Issues `#14`, `#16`);
+- implementación de código de app.
+
+## Entradas y prerrequisitos
+
+- `docs/domain-glossary.md` (modelo de dominio e invariantes actuales)
+- `docs/conflict-policy.md` (política de conflictos concurrentes MVP)
+- `docs/campaign-temporal-controls.md` (controles temporales y semántica previa de `week_cursor`)
+- `docs/campaign-temporal-initialization.md` (estructura temporal y provisión)
+- Decisiones de Kiko para esta issue marco:
+  - reordenación manual de `Entry`: sí, con operación "mover una entry";
+  - alcance de reordenación: solo dentro de la misma `Week`;
+  - `order_index`: secuencia densa `1..N`;
+  - `Week.reopen/reclose`: sí;
+  - correcciones manuales de `Session`: completo (crear/editar/borrar, con timestamps);
+  - `week_cursor`: primera `Week` abierta (menor `week_number` entre abiertas);
+  - borrado para `#12`: hard delete real (insumo downstream);
+  - `Entry.update` para `#12`: amplio (insumo downstream);
+  - atomicidad en `#12`: solo comportamiento (insumo downstream).
+
+## Principio de editabilidad del MVP ("como papel")
+
+1. El MVP prioriza permitir correcciones manuales amplias para trabajar "como en
+   papel", pero con mayor orden y trazabilidad.
+1. La editabilidad amplia no elimina invariantes críticos; los redefine de
+   forma explícita cuando sea necesario.
+1. Las correcciones manuales se documentan primero a nivel de dominio; el
+   contrato Firestore por agregado se define después en la Issue `#12`.
+1. La política de conflictos concurrentes del MVP sigue siendo de rechazo con
+   `refresco` y `reintento`; esta decisión actualiza qué operaciones existen y
+   qué precondiciones funcionales aplican.
+
+## Matriz de operaciones manuales permitidas (MVP)
+
+| Operación manual | Agregado principal | Permitida en MVP | Alcance | Notas |
+| --- | --- | --- | --- | --- |
+| `Entry.reorder_within_week` | `week` + `entry` | Sí | Mover una `Entry` dentro de la misma `Week` | Resecuencia `order_index` densa `1..N` |
+| `Entry.update` | `entry` | Sí | Amplio (campos funcionales de `Entry`) | Contrato detallado en `#12`; no cambia de `Week` aquí |
+| `Week.update_notes` | `week` | Sí | Weeks abiertas o cerradas | Editabilidad de contenido amplia |
+| `Week.reopen` | `week` + `campaign` | Sí | `closed -> open` | Recalcula `week_cursor` |
+| `Week.reclose` | `week` + `campaign` | Sí | `open -> closed` | Recalcula `week_cursor` |
+| `Session.manual_create` | `session` + `campaign` | Sí | Histórica o activa | Preserva `0..1` sesión activa global |
+| `Session.manual_update` | `session` + `campaign` | Sí | Corrección de timestamps y estado | Preserva `0..1` sesión activa global |
+| `Session.manual_delete` | `session` + `campaign` | Sí | Borrado real | Preserva `0..1` sesión activa global |
+| `ResourceChange.create/update/delete` | `resource_change` | Sí | Weeks abiertas o cerradas | Sigue validación de totales no negativos |
+
+## Reglas por agregado
+
+### `Entry` / orden del timeline
+
+1. Se permite reordenación manual de `Entry` en el MVP.
+1. La operación funcional documentada es **mover una `Entry`** a una nueva
+   posición dentro de la **misma `Week`**.
+1. No se permite mover `Entry` entre weeks en esta decisión.
+1. Tras una reordenación válida, `order_index` se recalcula a secuencia **densa
+   `1..N`** dentro de la `Week`.
+1. Rechazos esperados a nivel funcional:
+   - `Entry` inexistente o ya borrada;
+   - `Week` de referencia inconsistente;
+   - colisión o resecuenciación imposible por estado obsoleto concurrente.
+
+### `Week` / estado y notas
+
+1. `Week.notes` es editable tanto en `open` como en `closed`.
+1. Se permite corrección manual de `Week.status`:
+   - `Week.reopen`: `closed -> open`
+   - `Week.reclose`: `open -> closed`
+1. Las operaciones de estado (`reopen/reclose`) son correcciones manuales
+   explícitas y no equivalen a navegación temporal.
+1. Las operaciones que dependan de `Week.status=open` deben declararlo
+   explícitamente en sus contratos (`#12`, `#14`, `#15`).
+
+### `Session`
+
+1. Se permiten correcciones manuales completas:
+   - crear sesión manualmente;
+   - editar sesión manualmente;
+   - borrar sesión manualmente.
+1. La edición manual incluye, como mínimo, corrección de timestamps
+   (`started_at_utc`, `ended_at_utc`).
+1. Se mantiene la invariante de `0..1` `Session` activa global en la campaña.
+1. Si una corrección manual produciría más de una sesión activa global, la
+   operación debe rechazarse.
+1. `auto-stop` sigue existiendo como comportamiento de `Session.start` (flujo
+   normal), pero las correcciones manuales no deben introducir cambios implícitos
+   opacos; el contrato detallado se fija en `#12` y el flujo en `#14`.
+
+### `ResourceChange`
+
+1. Se mantiene la editabilidad de `ResourceChange` (crear/editar/borrar) con
+   correcciones manuales en el MVP.
+1. La política de editabilidad amplia no elimina la validación de totales
+   finales no negativos.
+1. El contrato detallado de pre/postcondiciones y rechazos se define en `#12`.
+
+## Reglas de estado y cursor (`Week.status`, `week_cursor`)
+
+### Política global de `week_cursor`
+
+1. `campaign.week_cursor` apunta a la **primera `Week` abierta**, definida como
+   la `Week` abierta con **menor `week_number`** entre las weeks provisionadas.
+1. Navegar o seleccionar una `Week` para foco/edición no cambia automáticamente
+   `week_cursor`.
+1. `week_cursor` pasa a ser un valor derivado de la estructura de weeks abiertas
+   y sus estados, en lugar de una selección manual libre.
+
+### Reglas de recálculo
+
+`week_cursor` se recalcula tras operaciones que puedan cambiar la primera week
+abierta:
+
+- `Week.close`
+- `Week.reopen`
+- `Week.reclose`
+- provisión inicial / extensión temporal
+
+### Relación con el ajuste manual previo de `week_cursor`
+
+1. La semántica de `Campaign.set_week_cursor` como ajuste manual explícito (Issue
+   `#9`) queda **sustituida** en MVP por la política derivada de cursor de esta
+   decisión (`#37`).
+1. El detalle de la transición contractual se alinea en:
+   - `docs/campaign-temporal-controls.md`
+   - `docs/campaign-temporal-initialization.md`
+   - `#12` (contrato por agregado)
+
+### Invariante de existencia de week abierta (soporte del cursor)
+
+1. Debe existir al menos una `Week` abierta provisionada para mantener
+   `week_cursor` como entero válido.
+1. Si una operación (`Week.close`/`Week.reclose`) dejara **0 weeks abiertas**,
+   la operación se rechaza.
+
+## Reglas para sesiones manuales
+
+### `Session.manual_create`
+
+1. Puede crear una sesión histórica (con `ended_at_utc` definido) o activa
+   (`ended_at_utc=null`).
+1. Si crea una sesión activa, debe validarse que no exista otra sesión activa
+   global en la campaña.
+
+### `Session.manual_update`
+
+1. Permite corregir timestamps de una sesión existente.
+1. Si la corrección cambia el estado a activa (`ended_at_utc=null`), debe
+   validarse la unicidad de sesión activa global.
+1. Si la corrección cambia una sesión activa a cerrada, la sesión deja de contar
+   como activa sin requerir `auto-stop`.
+
+### `Session.manual_delete`
+
+1. Permite borrar manualmente una sesión histórica o activa.
+1. Si se borra una sesión activa, el resultado debe mantener `0..1` sesiones
+   activas globales (normalmente `0`).
+
+## Invariantes preservadas y modificadas
+
+### Invariantes preservadas
+
+- `0..1` `Session` activa global en la campaña.
+- `week_number` global inmutable.
+- Validación de totales finales no negativos en recursos.
+- Jerarquía temporal `campaign > year > season > week > entry`.
+
+### Invariantes modificadas / ampliadas
+
+- Se sustituye “sin reordenación manual de `Entry` en MVP” por:
+  - reordenación manual permitida dentro de la misma `Week` con secuencia densa
+    `1..N`.
+- Se amplía la mutabilidad de `Week.status`:
+  - se permiten `reopen` y `reclose`.
+- Se amplía la mutabilidad de `Session`:
+  - correcciones manuales completas (crear/editar/borrar).
+- Se redefine `week_cursor`:
+  - pasa a ser la primera `Week` abierta (menor `week_number` abierta).
+
+## Impacto sobre conflictos y contratos downstream
+
+### Impacto sobre `docs/conflict-policy.md` / Issue `#8`
+
+- Se añaden/ajustan operaciones concurrentes de:
+  - `Week.reopen`
+  - `Week.reclose`
+  - correcciones manuales de `Session`
+  - reordenación manual de `Entry`
+- Se mantiene la política de rechazo con `refresco` y `reintento`.
+
+### Impacto sobre `#12` (contrato Firestore por agregado)
+
+- Añade operaciones y precondiciones nuevas a documentar.
+- Debe alinearse con:
+  - hard delete real (input ya acordado)
+  - `Entry.update` amplio (input ya acordado)
+  - atomicidad descrita como comportamiento (sin técnica obligatoria)
+
+### Impacto sobre `#14`, `#15`, `#17`, `#19`
+
+- `#14`: flujo de sesión activa / `auto-stop` debe coexistir con correcciones
+  manuales de sesión y `Week.reopen/reclose`.
+- `#15`: reglas de recursos deben considerar editabilidad en weeks cerradas y
+  correcciones amplias.
+- `#17`: matriz de edge cases debe incorporar reordenación, reopen/reclose y
+  correcciones manuales de sesión.
+- `#19`: el plan de pruebas de invariantes debe incluir los nuevos casos de
+  cursor derivado y mutabilidad ampliada.
+
+## Casos de aceptación / verificación documental
+
+1. **Mover `Entry` dentro de una `Week`**
+   - `order_index` queda denso `1..N`.
+   - No hay movimiento entre weeks.
+1. **Reabrir una `Week` cerrada**
+   - `Week.status` cambia a `open`.
+   - `week_cursor` se recalcula a la primera week abierta.
+1. **Re-cerrar una `Week` reabierta**
+   - `Week.status` vuelve a `closed`.
+   - `week_cursor` se recalcula con la misma regla global.
+1. **Corrección manual completa de `Session`**
+   - Se permiten create/edit/delete con timestamps.
+   - No se rompe la invariante `0..1` sesión activa global.
+1. **Límite de cursor válido**
+   - Se rechaza una operación que deje `0` weeks abiertas provisionadas.
+1. **Alineación con conflictos**
+   - `docs/conflict-policy.md` queda coherente con la nueva editabilidad.
+1. **Desbloqueo de `#12`**
+   - `#12` puede redactarse con dominio actualizado y trazabilidad explícita.
+
+## Riesgos y límites
+
+- Riesgo de ampliar demasiado el alcance de `#12` si no se separa claramente
+  esta decisión de dominio del contrato Firestore.
+- Riesgo de contradicción temporal si no se alinean `#9`, `#13` y esta decisión
+  respecto a `week_cursor`.
+- Riesgo de aumentar edge cases concurrentes; se asume mitigación mediante la
+  política de rechazo ya vigente en `#8`.
+
+## Referencias
+
+- `AGENTS.md`
+- `docs/domain-glossary.md`
+- `docs/conflict-policy.md`
+- `docs/campaign-temporal-controls.md`
+- `docs/campaign-temporal-initialization.md`
+- `docs/mvp-implementation-checklist.md`
+- `docs/mvp-implementation-blocks.md`
+- `docs/decision-log.md`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/8`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/14`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/15`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`

--- a/docs/mvp-implementation-blocks.md
+++ b/docs/mvp-implementation-blocks.md
@@ -3,7 +3,7 @@
 ## Metadatos
 
 - `doc_id`: DOC-MVP-IMPLEMENTATION-BLOCKS
-- `purpose`: Desglosar el checklist técnico base de implementación MVP en bloques y subbloques ejecutables con trazabilidad.
+- `purpose`: Desglosar el checklist técnico base de implementación MVP en bloques y subbloques ejecutables con trazabilidad, incluyendo decisiones marco posteriores que alteren el orden técnico.
 - `status`: active
 - `source_of_truth`: official
 - `last_updated`: 2026-02-24
@@ -19,7 +19,8 @@ la preparación de implementación del MVP, sin codificar todavía.
 
 Incluye:
 
-- desglose detallado de las Issues `#12`–`#20` por subbloques ejecutables;
+- desglose detallado de las Issues `#12`–`#20` y decisiones marco intermedias
+  que afecten su secuencia (actualmente `#37`) por subbloques ejecutables;
 - responsables por rol (`Codex`, `Kiko`, `Codex+Kiko`);
 - entregables, dependencias y criterios de finalización por subbloque;
 - riesgos y bloqueos por issue;
@@ -28,7 +29,8 @@ Incluye:
 No incluye:
 
 - implementación de código de app;
-- cierre de las Issues `#12`–`#20` en este documento;
+- cierre de las Issues `#12`–`#20` (ni de decisiones marco intermedias como
+  `#37`) en este documento;
 - gate final de “listo para codificar” (solo su desglose planificado);
 - redefinir por sí mismo reglas globales de repo (eso se formaliza en la issue
   de proceso correspondiente).
@@ -92,17 +94,18 @@ No incluye:
 
 | Issue | Tipo | Estado inicial | Orden técnico recomendado | ¿Puede iniciar borrador? | Cierre condicionado por | Entregable principal |
 | --- | --- | --- | --- | --- | --- | --- |
-| #12 | `decision` | `draftable` | 2.º dentro del bloque B | Sí | Alineación con #13 (cierre recomendado con #13 cerrada) | Contrato de operaciones Firestore por agregado |
-| #13 | `task` | `ready` | 2.º del bloque B (1.º dentro de B) | Sí | Coherencia con #9 y dominio | Estrategia técnica de inicialización/extensión temporal |
+| #13 | `task` | `ready` | 1.º dentro del bloque B | Sí | Coherencia con #9 y dominio | Estrategia técnica de inicialización/extensión temporal |
+| #37 | `decision` | `ready` | 2.º dentro del bloque B | Sí | Coherencia con #8/#9/#13 y dominio | Política de editabilidad manual y correcciones de dominio |
+| #12 | `decision` | `draftable` | 3.º dentro del bloque B | Sí | Alineación con #13 y #37 (cierre recomendado con ambas cerradas) | Contrato de operaciones Firestore por agregado |
 | #14 | `task` | `draftable` | 1.º del bloque C | Sí | Alineación con #12 para cierre | Flujo de sesión activa y `auto-stop` |
 | #15 | `task` | `draftable` | 2.º del bloque C | Sí | Alineación con #12 para cierre | Reglas de validación y recálculo de recursos |
 | #16 | `task` | `draftable` | 1.º del bloque D | Sí | Compatibilidad con #18 para cierre | Inventario mínimo de consultas y orden/paginación |
 | #17 | `task` | `draftable` | 2.º del bloque D | Sí | Mayor valor tras #12/#14/#15/#18 | Matriz de edge cases de concurrencia/sincronización |
-| #18 | `decision` | `draftable` | 3.º dentro del bloque B | Sí | Compatibilidad con #12 y lecturas | Política de timestamps y desempate estable |
+| #18 | `decision` | `draftable` | 4.º dentro del bloque B | Sí | Compatibilidad con #12 y lecturas | Política de timestamps y desempate estable |
 | #19 | `task` | `draftable` | 3.º del bloque D | Sí | Insumos suficientes de contratos/flows | Plan de pruebas de invariantes |
 | #20 | `task` | `final_gate` | Último (bloque E) | No (cierre final) | Base de #10 + derivadas relevantes | Gate de listo para codificar |
 
-## Detalle por issue (`#12`–`#20`)
+## Detalle por issue (`#12`–`#20`) y decisión marco intermedia (`#37`)
 
 ### Issue #12 — Definir contrato de operaciones Firestore por agregado de dominio
 
@@ -111,33 +114,36 @@ No incluye:
 - `tipo`: `decision`
 - `estado_inicial`: `draftable`
 - `responsable_de_coordinación`: `Codex+Kiko`
-- `dependencias_de_cierre`: `#13` (alineación temporal estable), más coherencia
-  con `#7`, `#8`, `#9` (ya resueltas)
+- `dependencias_de_cierre`: `#13` (alineación temporal estable), `#37`
+  (editabilidad e invariantes actualizadas), más coherencia con `#7`, `#8`,
+  `#9` (ya resueltas)
 - `impacta_a`: `#14`, `#15`, `#16`, `#17`, `#18`, `#19`, `#20`
 
 #### Subbloques ejecutables
 
 | subbloque_id | objetivo | responsable | depende_de | entregable | criterio_de_finalización | estado_inicial |
 | --- | --- | --- | --- | --- | --- | --- |
-| `I12-S1` | Inventariar operaciones por agregado (`campaign`, `week`, `entry`, `session`, `resource_change`) y casos de uso | `Codex` | `#7`, `#8`, `#9` | Tabla de operaciones por agregado | Inventario completo y sin solapes obvios | `draftable` |
+| `I12-S1` | Inventariar operaciones por agregado (`campaign`, `week`, `entry`, `session`, `resource_change`) y casos de uso | `Codex` | `#7`, `#8`, `#9`, `#37` | Tabla de operaciones por agregado | Inventario completo y sin solapes obvios con mutabilidad vigente | `draftable` |
 | `I12-S2` | Definir contrato por agregado (precondiciones, postcondiciones, validaciones, rechazo por conflicto, atomicidad esperada) | `Codex` | `I12-S1` | Tabla de contrato por agregado | Cada agregado tiene contrato explícito y coherente con `#8` | `draftable` |
-| `I12-S3` | Alinear operaciones temporales con la especificación de `#13` (provisión/extensión/cambio de `week_cursor`) | `Codex+Kiko` | `I12-S2`, `#13` | Nota/tabla de alineación `#12` ↔ `#13` | No quedan contradicciones con flujo temporal | `draftable` |
+| `I12-S3` | Alinear operaciones temporales y de cursor con `#13` y `#37` (provisión/extensión/`week_cursor` derivado) | `Codex+Kiko` | `I12-S2`, `#13`, `#37` | Nota/tabla de alineación `#12` ↔ (`#13`, `#37`) | No quedan contradicciones con flujo temporal ni editabilidad | `draftable` |
 | `I12-S4` | Cerrar la decisión (revisión interactiva, trazabilidad y referencias) | `Codex+Kiko` | `I12-S3` | Documento final + registro de decisión | Aprobación explícita de Kiko y PR mergeada | `draftable` |
 
 #### Riesgos y bloqueos
 
-- Riesgo de cerrar contrato desalineado con `#13` si se adelanta demasiado.
+- Riesgo de cerrar contrato desalineado con `#13` y/o `#37` si se adelanta demasiado.
 - Riesgo de duplicar lógica ya fijada por `#8` (conflictos) y `#9` (temporal).
 
 #### Criterio de cierre de la issue
 
 - Existe contrato de operaciones por agregado con pre/postcondiciones,
-  validaciones y reglas de rechazo, alineado con `#13` y consistente con `#8`.
+  validaciones y reglas de rechazo, alineado con `#13`, `#37` y consistente con
+  `#8`.
 
 #### Notas de secuencia / paralelización
 
-- Puede iniciarse en borrador antes de cerrar `#13`.
-- El cierre se recomienda después de `#13` para reducir retrabajo.
+- Puede iniciarse en borrador con base en `#7/#8/#9`, pero requiere alineación
+  con `#37` para cerrar.
+- El cierre se recomienda después de `#13` y `#37` para reducir retrabajo.
 
 ### Issue #13 — Especificar estrategia de inicialización de años, estaciones (`season`) y semanas
 
@@ -174,6 +180,47 @@ No incluye:
 - Es el primer candidato técnico recomendado tras `#11`.
 - Su cierre reduce incertidumbre para `#12`.
 
+### Issue #37 — Definir política de editabilidad manual y correcciones de estado/sesiones (MVP)
+
+#### Ficha de bloque
+
+- `tipo`: `decision`
+- `estado_inicial`: `ready`
+- `responsable_de_coordinación`: `Codex+Kiko`
+- `dependencias_de_cierre`: coherencia con `#8`, `#9`, `#13` y
+  `docs/domain-glossary.md`
+- `impacta_a`: `#12`, `#14`, `#15`, `#17`, `#19`, `#20`
+
+#### Subbloques ejecutables
+
+| subbloque_id | objetivo | responsable | depende_de | entregable | criterio_de_finalización | estado_inicial |
+| --- | --- | --- | --- | --- | --- | --- |
+| `I37-S1` | Definir matriz de operaciones manuales permitidas (editabilidad "como papel") y límites | `Codex+Kiko` | `#8`, `#9`, `docs/domain-glossary.md` | Matriz de mutabilidad por agregado | Quedan cerradas operaciones manuales permitidas y su alcance MVP | `ready` |
+| `I37-S2` | Formalizar reglas de `Entry.reorder`, `Week.reopen/reclose` y correcciones manuales de `Session` | `Codex+Kiko` | `I37-S1` | Reglas por agregado e invariantes | No quedan ambigüedades funcionales sobre mutabilidad de orden/estado/sesiones | `ready` |
+| `I37-S3` | Redefinir semántica de `week_cursor` (primera `Week` abierta) y su recálculo | `Codex+Kiko` | `I37-S2`, `#13` | Reglas de cursor y alineación temporal | `week_cursor` queda coherente con temporalidad y editabilidad | `ready` |
+| `I37-S4` | Actualizar trazabilidad (`glossary`, conflictos, checklist/bloques) y cerrar decisión | `Codex+Kiko` | `I37-S3` | Documento final + referencias + registro de decisión | Aprobación explícita de Kiko y PR mergeada | `ready` |
+
+#### Riesgos y bloqueos
+
+- Riesgo de dejar `#12` parcialmente redactada con invariantes viejas si `#37`
+  no se cierra antes.
+- Riesgo de contradicción entre semántica de `week_cursor` en temporal (#9/#13)
+  y mutabilidad de estado si no se alinea explícitamente.
+
+#### Criterio de cierre de la issue
+
+- Existe una decisión marco de editabilidad manual del MVP ("como papel") que
+  fija reordenación manual de `Entry` (intra-`Week`), `Week.reopen/reclose`,
+  correcciones manuales completas de `Session` y `week_cursor` como primera
+  `Week` abierta, con trazabilidad a `#12/#14/#15/#17/#19`.
+
+#### Notas de secuencia / paralelización
+
+- Debe cerrarse antes de `#12` para evitar retrabajo inmediato del contrato por
+  agregado.
+- Comparte naturaleza `type:decision`; requiere revisión interactiva con Kiko
+  para cierre.
+
 ### Issue #14 — Diseñar flujo de sesión activa y reglas de auto-stop
 
 #### Ficha de bloque
@@ -181,7 +228,7 @@ No incluye:
 - `tipo`: `task`
 - `estado_inicial`: `draftable`
 - `responsable_de_coordinación`: `Codex+Kiko`
-- `dependencias_de_cierre`: coherencia con `#8` y alineación con `#12`
+- `dependencias_de_cierre`: coherencia con `#8`, `#37` y alineación con `#12`
 - `impacta_a`: `#17`, `#19`, `#20`
 
 #### Subbloques ejecutables
@@ -191,7 +238,7 @@ No incluye:
 | `I14-S1` | Definir diagrama/tabla de estados y transiciones (`start`, `stop`, `auto-stop`) | `Codex` | `#8`, `docs/domain-glossary.md` | Diagrama/tabla de estados | Todas las transiciones principales están cubiertas | `draftable` |
 | `I14-S2` | Especificar reglas operativas por evento y errores esperados | `Codex` | `I14-S1` | Reglas por evento | Se cubren `start`, `stop`, `auto-stop` y errores esperables | `draftable` |
 | `I14-S3` | Definir interacción con cierre de semana y efectos sobre sesión activa | `Codex` | `I14-S2`, `#8` | Reglas de cierre de semana + sesión | No rompe invariante `0..1` sesión activa global | `draftable` |
-| `I14-S4` | Alinear comportamiento con contrato de operaciones (`#12`) para cierre | `Codex+Kiko` | `I14-S3`, `#12` | Alineación final `#14` ↔ `#12` | No quedan ambigüedades operativas/atómicas para implementar | `draftable` |
+| `I14-S4` | Alinear comportamiento con editabilidad (`#37`) y contrato de operaciones (`#12`) para cierre | `Codex+Kiko` | `I14-S3`, `#37`, `#12` | Alineación final `#14` ↔ (`#37`, `#12`) | No quedan ambigüedades operativas/atómicas para implementar | `draftable` |
 
 #### Riesgos y bloqueos
 
@@ -206,7 +253,7 @@ No incluye:
 #### Notas de secuencia / paralelización
 
 - Puede iniciarse en borrador con `#8` ya resuelta.
-- Conviene cerrar tras avances sustanciales en `#12`.
+- Conviene cerrar tras avances sustanciales en `#37` y `#12`.
 
 ### Issue #15 — Diseñar reglas de validación y recálculo de recursos
 
@@ -215,7 +262,7 @@ No incluye:
 - `tipo`: `task`
 - `estado_inicial`: `draftable`
 - `responsable_de_coordinación`: `Codex+Kiko`
-- `dependencias_de_cierre`: coherencia con `#8` y alineación con `#12`
+- `dependencias_de_cierre`: coherencia con `#8`, `#37` y alineación con `#12`
 - `impacta_a`: `#17`, `#19`, `#20`
 
 #### Subbloques ejecutables
@@ -225,7 +272,7 @@ No incluye:
 | `I15-S1` | Inventariar operaciones sobre `ResourceChange` (crear, editar, borrar, corregir) | `Codex` | `#8`, `docs/domain-glossary.md` | Inventario de operaciones de recursos | Operaciones y efectos quedan enumerados | `draftable` |
 | `I15-S2` | Definir reglas de validación de `delta` y restricción de totales no negativos | `Codex` | `I15-S1` | Reglas de validación | Casos válidos/inválidos y rechazos quedan cerrados | `draftable` |
 | `I15-S3` | Definir estrategia de recálculo y consistencia de totales globales | `Codex` | `I15-S2` | Estrategia de recálculo | Se documenta consistencia y comportamiento esperado tras correcciones | `draftable` |
-| `I15-S4` | Alinear matriz de rechazos con `#8` y contrato de operaciones (`#12`) | `Codex+Kiko` | `I15-S3`, `#12` | Alineación final de rechazos y operaciones | No quedan contradicciones con concurrencia ni contrato | `draftable` |
+| `I15-S4` | Alinear matriz de rechazos con `#8`, editabilidad (`#37`) y contrato de operaciones (`#12`) | `Codex+Kiko` | `I15-S3`, `#37`, `#12` | Alineación final de rechazos y operaciones | No quedan contradicciones con concurrencia ni contrato | `draftable` |
 
 #### Riesgos y bloqueos
 
@@ -240,7 +287,7 @@ No incluye:
 #### Notas de secuencia / paralelización
 
 - Puede avanzar en borrador antes de `#12`.
-- Conviene cerrar después de aclarar contrato por agregado en `#12`.
+- Conviene cerrar después de aclarar editabilidad (`#37`) y contrato por agregado en `#12`.
 
 ### Issue #16 — Definir consultas mínimas para timeline y panel de foco
 
@@ -284,7 +331,7 @@ No incluye:
 - `tipo`: `task`
 - `estado_inicial`: `draftable`
 - `responsable_de_coordinación`: `Codex+Kiko`
-- `dependencias_de_cierre`: mayor valor con `#12`, `#14`, `#15`, `#18`
+- `dependencias_de_cierre`: mayor valor con `#37`, `#12`, `#14`, `#15`, `#18`
 - `impacta_a`: `#19`, `#20`
 
 #### Subbloques ejecutables
@@ -294,7 +341,7 @@ No incluye:
 | `I17-S1` | Definir taxonomía de casos (sesiones, entries, recursos, temporales, lecturas) | `Codex` | `#7`, `#8` | Taxonomía de edge cases | Taxonomía cubre las familias críticas del MVP | `draftable` |
 | `I17-S2` | Construir matriz caso → resultado esperado → severidad → prioridad | `Codex` | `I17-S1` | Matriz de edge cases | Cada caso tiene expectativa y prioridad verificable | `draftable` |
 | `I17-S3` | Seleccionar casos críticos de verificación del MVP | `Codex+Kiko` | `I17-S2` | Lista priorizada de casos críticos | Quedan definidos casos críticos mínimos a validar | `draftable` |
-| `I17-S4` | Alinear matriz con contratos y flujos (`#12`, `#14`, `#15`, `#18`) antes de cierre | `Codex+Kiko` | `I17-S2`, `#12`, `#14`, `#15`, `#18` | Revisión final de consistencia | No hay expectativas en conflicto con docs previas | `draftable` |
+| `I17-S4` | Alinear matriz con mutabilidad y contratos/flujos (`#37`, `#12`, `#14`, `#15`, `#18`) antes de cierre | `Codex+Kiko` | `I17-S2`, `#37`, `#12`, `#14`, `#15`, `#18` | Revisión final de consistencia | No hay expectativas en conflicto con docs previas | `draftable` |
 
 #### Riesgos y bloqueos
 
@@ -310,7 +357,7 @@ No incluye:
 #### Notas de secuencia / paralelización
 
 - Puede arrancar con taxonomía y borrador de matriz.
-- Su cierre gana calidad después de `#12`, `#14`, `#15` y `#18`.
+- Su cierre gana calidad después de `#37`, `#12`, `#14`, `#15` y `#18`.
 
 ### Issue #18 — Definir política de timestamps y orden estable entre dispositivos
 
@@ -365,7 +412,7 @@ No incluye:
 | `I19-S1` | Seleccionar invariantes críticas del dominio (a partir de `docs/domain-glossary.md` y decisiones cerradas) | `Codex` | `docs/domain-glossary.md`, `#7`, `#8`, `#9` | Lista priorizada de invariantes | Invariantes críticas quedan seleccionadas y justificadas | `draftable` |
 | `I19-S2` | Diseñar casos de prueba por invariante (precondición, acción, resultado esperado) | `Codex` | `I19-S1` | Matriz de casos por invariante | Cada invariante tiene casos verificables | `draftable` |
 | `I19-S3` | Definir estrategia de evidencia y repetibilidad | `Codex` | `I19-S2` | Estrategia de evidencia | Queda claro cómo registrar y repetir validaciones | `draftable` |
-| `I19-S4` | Priorizar ejecución de pruebas para soportar `#20` | `Codex+Kiko` | `I19-S2`, `I19-S3`, `#12`, `#14`, `#15`, `#18` | Priorización para readiness | El plan sirve como insumo directo para el gate de `#20` | `draftable` |
+| `I19-S4` | Priorizar ejecución de pruebas para soportar `#20` | `Codex+Kiko` | `I19-S2`, `I19-S3`, `#37`, `#12`, `#14`, `#15`, `#18` | Priorización para readiness | El plan sirve como insumo directo para el gate de `#20` | `draftable` |
 
 #### Riesgos y bloqueos
 
@@ -381,7 +428,7 @@ No incluye:
 #### Notas de secuencia / paralelización
 
 - Puede comenzar con selección de invariantes y estructura de casos.
-- El cierre se fortalece con `#12`, `#14`, `#15` y `#18` resueltas.
+- El cierre se fortalece con `#37`, `#12`, `#14`, `#15` y `#18` resueltas.
 
 ### Issue #20 — Definir criterios de listo para codificar en Fase 1
 
@@ -391,14 +438,14 @@ No incluye:
 - `estado_inicial`: `final_gate`
 - `responsable_de_coordinación`: `Codex+Kiko`
 - `dependencias_de_cierre`: checklist base (`#10`) y derivados relevantes
-  (`#11`–`#19`) según criterios definidos
+  (`#11`–`#19`, más `#37`) según criterios definidos
 - `impacta_a`: paso a implementación
 
 #### Subbloques ejecutables
 
 | subbloque_id | objetivo | responsable | depende_de | entregable | criterio_de_finalización | estado_inicial |
 | --- | --- | --- | --- | --- | --- | --- |
-| `I20-S1` | Inventariar precondiciones y dependencias críticas de readiness | `Codex` | `#10`, `#11` y estado de `#12`–`#19` | Inventario de precondiciones | Dependencias críticas quedan listadas y clasificadas | `final_gate` |
+| `I20-S1` | Inventariar precondiciones y dependencias críticas de readiness | `Codex` | `#10`, `#11` y estado de `#12`–`#19` + `#37` | Inventario de precondiciones | Dependencias críticas quedan listadas y clasificadas | `final_gate` |
 | `I20-S2` | Definir checklist de bloqueo/desbloqueo para entrada a codificación | `Codex` | `I20-S1` | Checklist de readiness | El gate de entrada es explícito y verificable | `final_gate` |
 | `I20-S3` | Definir evidencia mínima exigida (documental y trazabilidad) | `Codex` | `I20-S2` | Reglas de evidencia | Queda claro qué evidencia se exige para habilitar código | `final_gate` |
 | `I20-S4` | Definir flujo de validación final (Codex prepara, Kiko valida) y criterio de cierre | `Codex+Kiko` | `I20-S3` | Protocolo de validación final | El cierre de `#20` queda operable y sin ambigüedades | `final_gate` |
@@ -406,7 +453,7 @@ No incluye:
 #### Riesgos y bloqueos
 
 - Riesgo de cerrar `#20` demasiado pronto y convertirlo en gate vacío.
-- Riesgo de duplicar detalle de `#11` o reabrir decisiones de `#12`/`#18`.
+- Riesgo de duplicar detalle de `#11` o reabrir decisiones de `#12`/`#18`/`#37`.
 
 #### Criterio de cierre de la issue
 
@@ -432,9 +479,12 @@ No incluye:
 
 ### Reglas de ejecución (operativas)
 
-1. Priorizar PRs abiertas antes de iniciar trabajo nuevo.
+1. Priorizar primero **unidad pendiente de cierre** (trabajo local/rama/PR/issue
+   pendiente de cierre) antes de iniciar trabajo nuevo.
+1. Si no existe unidad pendiente de cierre, priorizar PRs abiertas.
 1. Usar el **orden técnico recomendado** del documento más específico disponible
-   para elegir el siguiente trabajo cuando no haya PRs abiertas.
+   para elegir el siguiente trabajo cuando no haya unidad pendiente de cierre
+   ni PRs abiertas.
 1. Si el siguiente item técnico no es cerrable, saltar al siguiente cerrable.
 1. Si no hay cerrables, avanzar en el primer `draftable`.
 1. Si no existe orden técnico aplicable, usar la issue abierta con número más
@@ -442,12 +492,13 @@ No incluye:
 1. Mantener trazabilidad de estado (`ready`, `draftable`, `blocked`,
    `final_gate`) al revisar el plan.
 
-## Seguimiento inicial de bloques
+## Seguimiento de bloques
 
-### Estado de bloques (tras cerrar #11)
+### Estado de bloques (actualizado tras cerrar #13 y #37)
 
 - [x] `#11` Desglose en bloques ejecutables (este documento)
-- [ ] `#13` Inicialización temporal detallada (`ready`)
+- [x] `#13` Inicialización temporal detallada (`ready`)
+- [x] `#37` Política de editabilidad manual y correcciones de dominio (`ready`)
 - [ ] `#12` Contrato Firestore por agregado (`draftable`)
 - [ ] `#18` Timestamps y orden estable (`draftable`)
 - [ ] `#14` Flujo de sesión activa y `auto-stop` (`draftable`)
@@ -459,8 +510,7 @@ No incluye:
 
 ### Próxima secuencia técnica esperada (según orden actual)
 
-1. `#13` (cerrable)
-1. `#12` (borrador/cierre condicionado por alineación con `#13`)
+1. `#12` (borrador/cierre condicionado por alineación con `#13` y `#37`)
 1. `#18`
 1. `#14`
 1. `#15`
@@ -479,12 +529,14 @@ No incluye:
 - `docs/conflict-policy.md`
 - `docs/campaign-temporal-controls.md`
 - `docs/campaign-temporal-initialization.md`
+- `docs/editability-policy.md`
 - `docs/domain-glossary.md`
 - `docs/context-checklists.md`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/10`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/11`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/13`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/14`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/15`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/16`

--- a/docs/mvp-implementation-checklist.md
+++ b/docs/mvp-implementation-checklist.md
@@ -6,8 +6,8 @@
 - `purpose`: Checklist técnico base para preparar la implementación del MVP con orden, dependencias y verificación mínima.
 - `status`: active
 - `source_of_truth`: official
-- `last_updated`: 2026-02-23
-- `next_review`: 2026-03-09
+- `last_updated`: 2026-02-24
+- `next_review`: 2026-03-10
 
 ## Objetivo
 
@@ -46,6 +46,15 @@ este checklist:
   `docs/campaign-temporal-controls.md`
   - selector temporal superior, provisión inicial de 4 años, extensión manual
     `+1`, separación entre navegación de semana y `week_cursor`.
+- **Inicialización temporal de campaña (técnica)** (Issue #13):
+  `docs/campaign-temporal-initialization.md`
+  - estructura temporal fija del MVP (`summer -> winter`, 10 semanas por
+    estación), provisión inicial y extensión `+1`.
+- **Política de editabilidad manual MVP** (Issue #37):
+  `docs/editability-policy.md`
+  - editabilidad amplia ("como papel"), reordenación manual de `Entry`,
+    `Week.reopen/reclose`, correcciones manuales de `Session` y semántica
+    derivada de `week_cursor`.
 
 ## Corte de responsabilidades entre `#10`, `#11` y `#20`
 
@@ -84,14 +93,18 @@ este checklist:
 
 ### Bloque B — Contratos de dominio para implementación (núcleo)
 
-- **Issues**: #13, #12, #18
+- **Issues**: #13, #37, #12, #18
 - **Orden recomendado**:
   1. #13 — inicialización temporal detallada.
-  1. #12 — contrato de operaciones Firestore por agregado, alineado con #13.
+  1. #37 — política de editabilidad manual y correcciones de dominio (marco).
+  1. #12 — contrato de operaciones Firestore por agregado, alineado con #13 y #37.
   1. #18 — timestamps y orden estable entre dispositivos.
 - **Justificación**:
   - #13 concreta la provisión/extensión temporal decidida en #9.
-  - #12 necesita alineación con provisión temporal (#9) y detalle técnico (#13).
+  - #37 actualiza invariantes/mutabilidad del dominio antes de cerrar contratos
+    por agregado.
+  - #12 necesita alineación con provisión temporal (#9), detalle técnico (#13)
+    y política de editabilidad (#37).
   - #18 cierra orden estable para lecturas y logs entre dispositivos.
 
 ### Bloque C — Flujos funcionales e invariantes de operación
@@ -127,11 +140,12 @@ este checklist:
 | Bloque / Issue | Tipo | Depende de | ¿Puede empezar en paralelo? | Condición de cierre | Impacta a |
 | --- | --- | --- | --- | --- | --- |
 | Bloque A / #11 | `task` | #10 | Sí, como borrador parcial; no cerrar antes de #10 | Desglose completo y trazable | #12, #13, #14, #15, #16, #17, #19, #20 |
-| Bloque B / #13 | `task` | #9 (resuelta) | Sí | Flujo temporal detallado sin contradicciones | #12, #16, #20 |
-| Bloque B / #12 | `decision` | #7, #8, #9 (resueltas) + alineación con #13 | Borrador sí; cierre recomendado tras #13 | Contrato por agregado con pre/postcondiciones | #14, #15, #16, #17, #18, #19, #20 |
+| Bloque B / #13 | `task` | #9 (resuelta) | Sí | Flujo temporal detallado sin contradicciones | #37, #12, #16, #20 |
+| Bloque B / #37 | `decision` | #8, #9 (resueltas) + coherencia con #13 | Borrador sí; cierre recomendado tras #13 | Política de editabilidad manual e invariantes actualizadas | #12, #14, #15, #17, #19, #20 |
+| Bloque B / #12 | `decision` | #7, #8, #9 (resueltas) + alineación con #13 y #37 | Borrador sí; cierre recomendado tras #13 y #37 | Contrato por agregado con pre/postcondiciones | #14, #15, #16, #17, #18, #19, #20 |
 | Bloque B / #18 | `decision` | #7, #8 (resueltas) | Sí, pero cierre recomendado tras #12 | Política de timestamps y desempate estable | #16, #17, #19, #20 |
-| Bloque C / #14 | `task` | #8 (resuelta) | Sí, parcial | Flujo de sesión + `auto-stop` sin romper invariantes | #17, #19, #20 |
-| Bloque C / #15 | `task` | #8 (resuelta) | Sí, parcial | Reglas de validación y recálculo trazables | #17, #19, #20 |
+| Bloque C / #14 | `task` | #8 (resuelta) + alineación con #37 | Sí, parcial | Flujo de sesión + `auto-stop` sin romper invariantes | #17, #19, #20 |
+| Bloque C / #15 | `task` | #8 (resuelta) + alineación con #37 | Sí, parcial | Reglas de validación y recálculo trazables | #17, #19, #20 |
 | Bloque D / #16 | `task` | #7, #9 (resueltas) | Sí | Inventario mínimo de consultas y orden estable | #19, #20 |
 | Bloque D / #17 | `task` | #7, #8 (resueltas) | Sí, pero gana valor tras #12/#14/#15/#18 | Matriz de edge cases con expectativa verificable | #19, #20 |
 | Bloque D / #19 | `task` | #7, #8, #9 (resueltas) | Sí, parcial | Plan de pruebas de invariantes con evidencia repetible | #20 |
@@ -160,12 +174,12 @@ Usar esta plantilla mínima en cada issue/bloque del checklist:
 
 - **Solape #10 / #11 / #20**: evitar que #10 se convierta en desglose fino (#11)
   o en gate definitivo (#20).
-- **Cerrar #12 antes de #13**: puede introducir contrato Firestore desalineado
-  con provisión temporal detallada.
+- **Cerrar #12 antes de #13/#37**: puede introducir contrato Firestore
+  desalineado con provisión temporal y/o mutabilidad real del dominio.
 - **Cerrar #16 sin #18**: riesgo de definir orden de lectura sin desempate
   estable documentado.
-- **Matriz #17 demasiado temprana**: puede quedar incompleta si faltan contratos
-  y flujos clave (#12, #14, #15, #18).
+- **Matriz #17 demasiado temprana**: puede quedar incompleta si faltan
+  contratos, flujos y mutabilidad clave (#37, #12, #14, #15, #18).
 
 ### Reglas de paralelización (recomendadas)
 
@@ -176,12 +190,13 @@ Usar esta plantilla mínima en cada issue/bloque del checklist:
 - Las issues `type:decision` (#12, #18) requieren revisión interactiva con Kiko
   antes de cerrar.
 
-## Checklist de seguimiento (estado inicial)
+## Checklist de seguimiento (estado actual)
 
 - [x] Prerrequisitos base resueltos: #7, #8, #9
 - [x] Checklist técnico base definido (Issue #10)
 - [x] Desglose en bloques ejecutables (Issue #11)
-- [ ] Inicialización temporal detallada (Issue #13)
+- [x] Inicialización temporal detallada (Issue #13)
+- [x] Política de editabilidad manual y correcciones de dominio (Issue #37)
 - [ ] Contrato de operaciones Firestore por agregado (Issue #12)
 - [ ] Política de timestamps y orden estable (Issue #18)
 - [ ] Flujo de sesión activa y `auto-stop` (Issue #14)
@@ -200,12 +215,15 @@ Usar esta plantilla mínima en cada issue/bloque del checklist:
 - `docs/sync-strategy.md`
 - `docs/conflict-policy.md`
 - `docs/campaign-temporal-controls.md`
+- `docs/campaign-temporal-initialization.md`
+- `docs/editability-policy.md`
 - `docs/domain-glossary.md`
 - `docs/context-checklists.md`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/10`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/11`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/13`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/14`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/15`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/16`

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -38,6 +38,8 @@ Este documento permite que una persona o agente nuevo entienda rápidamente:
 - `docs/campaign-temporal-initialization.md`
   - Estrategia técnica de inicialización/extensión de años y creación de
     `year/season/week` del MVP.
+- `docs/editability-policy.md`
+  - Política de editabilidad manual y correcciones de estado/sesiones del MVP.
 - `docs/mvp-implementation-checklist.md`
   - Checklist técnico base para preparar la implementación del MVP.
 - `docs/mvp-implementation-blocks.md`
@@ -89,6 +91,7 @@ Este documento permite que una persona o agente nuevo entienda rápidamente:
 - Conflictos concurrentes MVP -> `docs/conflict-policy.md`
 - Controles temporales de campaña -> `docs/campaign-temporal-controls.md`
 - Inicialización temporal técnica -> `docs/campaign-temporal-initialization.md`
+- Editabilidad manual MVP -> `docs/editability-policy.md`
 - Checklist técnico MVP -> `docs/mvp-implementation-checklist.md`
 - Bloques de implementación MVP -> `docs/mvp-implementation-blocks.md`
 - Estado de fase -> `docs/context-governance.md`


### PR DESCRIPTION
﻿## Resumen

Cierra la decisión marco de editabilidad manual del MVP (“como papel”) antes de `#12`.

## Cambios

- añade `docs/editability-policy.md` como documento oficial
- formaliza reordenación manual de `Entry` dentro de la misma `Week` (`order_index` denso `1..N`)
- permite `Week.reopen/reclose`
- permite correcciones manuales completas de `Session` (create/update/delete, con timestamps)
- redefine `campaign.week_cursor` como primera `Week` abierta
- alinea glosario, política de conflictos y docs temporales con la nueva semántica
- actualiza checklist/bloques para insertar `#37` antes de `#12`
- registra `DEC-0022`

## Validación

- `git diff --cached --check`

## Nota de aprobación

Esta PR implementa una decisión `type:decision` con inputs y aprobación explícita de Kiko en conversación (petición directa de implementar el plan de `#37`).

Closes #37
