### PR TITLE
docs(domain): redefinir modelo de recursos por Entry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,7 @@ Cada interacción termina con un menú numerado fijo de 3 a 5 siguientes pasos.
 - Estrategia de sincronización MVP: `docs/sync-strategy.md`
 - Política de conflictos concurrentes MVP: `docs/conflict-policy.md`
 - Contrato de operaciones Firestore por agregado (MVP): `docs/firestore-operation-contract.md`
+- Modelo de recursos por `Entry` (MVP): `docs/resource-delta-model.md`
 - Controles temporales de campaña: `docs/campaign-temporal-controls.md`
 - Inicialización temporal de campaña (técnica): `docs/campaign-temporal-initialization.md`
 - Política de editabilidad manual MVP: `docs/editability-policy.md`

--- a/docs/conflict-policy.md
+++ b/docs/conflict-policy.md
@@ -40,7 +40,7 @@ No incluye:
 1. Se mantiene la recomendación operativa de `single writer` definida en
    `docs/sync-strategy.md`.
 1. No se usa `last-write-wins` para operaciones de estado, edición de notas,
-   reordenación manual ni `ResourceChange`.
+   reordenación manual ni edición de `Entry.resource_deltas`.
 1. La política define comportamiento esperado; el mecanismo técnico exacto de
    detección queda para la Issue #12.
 
@@ -56,11 +56,11 @@ No incluye:
 | `Week.reclose` | `week` + `campaign` | Alto | `rechazar` | `refrescar` + `reintentar` (conflicto) / error local (transición inválida/validación) | Recalcula `week_cursor`; rechazar si dejaría cursor inválido |
 | `Entry.reorder_within_week` | `week` + `entry` | Medio/Alto | `rechazar` | `refrescar` + `reintentar` | Resecuencia densa `1..N`; detalle contractual en #12 |
 | `Session.manual_create/update/delete` | `session` + `campaign` | Alto | `rechazar` | `refrescar` + `reintentar` | Mantener `0..1` sesión activa global; detalle contractual en #12 |
-| Borrado de `Entry` activa (con cascada) | `entry` + `session` + `resource_change` | Alto | `rechazar` | `refrescar` + `reintentar` | Incluye auto-stop y borrado en cascada; contratos técnicos en #12 |
+| Borrado de `Entry` activa (con cascada) | `entry` + `session` + `campaign` | Alto | `rechazar` | `refrescar` + `reintentar` | Incluye auto-stop; borra `sessions` y elimina `resource_deltas` embebidos con la `Entry`; contrato técnico en #12 |
 | Edición de `Week.notes` | `week` | Medio | `rechazar` | `refrescar` + reingresar cambios | No usar `last-write-wins` en MVP |
-| Crear `ResourceChange` | `resource_change` (+ totales derivados) | Medio/Alto | `rechazar` | `refrescar` + `reintentar` | Política estricta para evitar inconsistencias silenciosas |
-| Editar `ResourceChange` | `resource_change` | Alto | `rechazar` | `refrescar` + `reintentar` | Rechazar si el cambio fue modificado o borrado concurrentemente |
-| Borrar `ResourceChange` | `resource_change` | Alto | `rechazar` | `refrescar` + `reintentar` | Rechazar si ya fue alterado o eliminado |
+| `Entry.adjust_resource_delta` | `entry` (+ totales derivados) | Medio/Alto | `rechazar` | `refrescar` + `reintentar` | Ajusta delta neto en `Entry.resource_deltas`; valida totales finales no negativos |
+| `Entry.set_resource_delta` | `entry` (+ totales derivados) | Alto | `rechazar` | `refrescar` + `reintentar` | Edición manual directa del delta neto; opera sobre `Entry` y totales |
+| `Entry.clear_resource_delta` | `entry` (+ totales derivados) | Medio/Alto | `rechazar` | `refrescar` + `reintentar` | Elimina clave del mapa (`delta -> 0`); rechazar si base está obsoleta |
 
 ## Reglas de precedencia y rechazo
 
@@ -123,7 +123,7 @@ No incluye:
   esa `Entry`.
   - Resultado MVP: una de las operaciones quedará inválida; se rechaza la que
     opere sobre estado obsoleto.
-- Ediciones concurrentes sobre el mismo `ResourceChange`.
+- Ediciones concurrentes sobre `Entry.resource_deltas` de la misma `Entry`.
   - Resultado MVP: rechazo en conflicto; no `last-write-wins`.
 
 ## Dependencias y relación con otras Issues
@@ -137,6 +137,9 @@ No incluye:
 - **Issue #37**: actualiza la política de editabilidad manual del MVP y la
   semántica de `week_cursor`, añadiendo operaciones de corrección manual
   que deben respetar esta política de conflictos.
+- **Issue #40**: redefine el modelo de recursos del MVP como
+  `Entry.resource_deltas` (sin entidad `ResourceChange`) y actualiza la matriz
+  de conflictos de recursos sobre `Entry`.
 - **Issue #18**: define timestamps y desempates de orden estable entre
   dispositivos, compatibles con esta política.
 
@@ -146,8 +149,10 @@ No incluye:
 - `docs/sync-strategy.md`
 - `docs/decision-log.md`
 - `docs/firestore-operation-contract.md`
+- `docs/resource-delta-model.md`
 - `tdd.md` (legado temporal, alineado con referencia oficial)
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/8`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/40`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/18`

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -421,3 +421,37 @@
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/13`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`
+
+### DEC-0024
+
+- `date`: 2026-02-24
+- `status`: accepted
+- `problem`: el modelo MVP de recursos basado en `ResourceChange` (log `0..N`
+  por `Entry`) quedó desalineado con la intención de edición manual "como
+  papel", y dejaba complejidad innecesaria en contratos y conflictos justo
+  antes de cerrar la política de timestamps/orden estable (`#18`).
+- `decision`: sustituir `ResourceChange` como entidad MVP por un campo
+  `Entry.resource_deltas` con tipo lógico `map<resource_key, int>` y semántica
+  de delta neto editable por recurso dentro de cada `Entry`; mantener solo
+  claves con delta `!= 0` (ausencia de clave = `0`), eliminar la clave cuando
+  el delta neto resulte `0`, reutilizar únicamente la auditoría de `Entry` (sin
+  timestamps por recurso) y parchear `docs/firestore-operation-contract.md`
+  para reemplazar `ResourceChange.*` por operaciones sobre
+  `Entry.resource_deltas` sin reabrir la Issue `#12`.
+- `rationale`: simplifica el modelo de dominio y la edición de recursos en el
+  MVP, alinea el comportamiento con la editabilidad amplia definida en `#37`,
+  reduce complejidad de concurrencia/contratos y evita arrastrar un log
+  incremental intra-entry que no aporta valor al MVP actual.
+- `impact`: añade `docs/resource-delta-model.md` como fuente oficial; elimina
+  `ResourceChange` del glosario MVP activo; actualiza `docs/conflict-policy.md`
+  y parchea parcialmente `docs/firestore-operation-contract.md` (supersesión
+  parcial de la parte de recursos de `DEC-0023`); reordena el bloque técnico
+  para ejecutar esta decisión antes de `#18`, y deja `#18` como siguiente paso
+  tras su cierre.
+- `references`: `docs/resource-delta-model.md`, `docs/domain-glossary.md`,
+  `docs/firestore-operation-contract.md`, `docs/conflict-policy.md`,
+  `docs/editability-policy.md`, `docs/mvp-implementation-checklist.md`,
+  `docs/mvp-implementation-blocks.md`, `AGENTS.md`, `docs/system-map.md`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/40`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/18`

--- a/docs/domain-glossary.md
+++ b/docs/domain-glossary.md
@@ -23,7 +23,8 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
 - `week_cursor`: entero, semana actual activa.
   - En MVP apunta a la **primera `Week` abierta** (menor `week_number` abierta)
     y se recalcula tras operaciones que cambian el estado de `Week`.
-- `resource_totals`: mapa `resource_key -> int` derivado del log de cambios.
+- `resource_totals`: mapa `resource_key -> int` derivado de la suma de
+  `Entry.resource_deltas` en la campaña.
 
 ### Year
 
@@ -51,6 +52,8 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
     resecuenciación densa `1..N`.
 - `type`: `scenario|outpost`.
 - `scenario_ref`: entero positivo obligatorio cuando `type=scenario`.
+- `resource_deltas`: mapa `resource_key -> int` (delta neto por recurso en la
+  `Entry`; solo claves con delta `!= 0`, ausencia de clave = `0`).
 - `created_at_utc`, `updated_at_utc`, `deleted_at_utc`: auditoría mínima.
 
 ### Session
@@ -58,13 +61,6 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
 - Cuelga de una `Entry` (owner implícito por ruta, sin `owner_type`).
 - `started_at_utc`: timestamp UTC.
 - `ended_at_utc`: timestamp UTC o `null` si está activa.
-- `created_at_utc`, `updated_at_utc`, `deleted_at_utc`: auditoría mínima.
-
-### ResourceChange
-
-- Cuelga de una `Entry` (owner implícito por ruta, sin `owner_type`).
-- `resource_key`: recurso del MVP.
-- `delta`: entero firmado (`+/-`, distinto de cero).
 - `created_at_utc`, `updated_at_utc`, `deleted_at_utc`: auditoría mínima.
 
 ## Recursos MVP (`resource_key`)
@@ -89,7 +85,6 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
 - `campaigns/01/years/{year_number}/seasons/{season_type}/weeks/{week_number}`
 - `.../weeks/{week_number}/entries/{entry_id}`
 - `.../entries/{entry_id}/sessions/{session_id}`
-- `.../entries/{entry_id}/resource_changes/{change_id}`
 
 ## Reglas temporales
 
@@ -118,7 +113,8 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
 1. Si se inicia una nueva sesión con otra activa, se hace `auto-stop` de la
    anterior y `start` de la nueva.
 1. Si se borra una `Entry` activa, se hace `auto-stop` y luego borrado en
-   cascada (`sessions` y `resource_changes`).
+   cascada de `sessions`; sus `resource_deltas` se eliminan al borrar la
+   `Entry`.
 1. Si se cierra `Week` con sesión activa, se hace `auto-stop` y luego cierre.
 1. `Week.status` puede corregirse manualmente (`reopen`/`reclose`) en MVP.
 1. Se permiten correcciones manuales completas de `Session` (crear/editar/
@@ -128,14 +124,14 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
    navegar semanas no cambia el cursor.
 1. Debe existir al menos una `Week` abierta provisionada para mantener
    `week_cursor` como entero válido.
-1. `ResourceChange.delta` es entero firmado y se valida que el estado final de
-   totales no sea negativo.
+1. Cada `Entry.resource_deltas[resource_key]` es entero firmado y se valida que
+   el estado final de totales no sea negativo.
 1. `scenario_ref` es obligatorio y entero positivo para `scenario`.
 1. No se fija cardinalidad explícita de `outpost` en esta issue.
 
 ## Casos borde y validación
 
-1. Se reconstruye owner de `Session` y `ResourceChange` únicamente por ruta.
+1. Se reconstruye owner de `Session` únicamente por ruta.
 1. Cambios en semanas históricas no alteran `week_number`.
 1. Crear `Entry` tipo `scenario` sin `scenario_ref` debe rechazarse.
 1. Crear `Entry` tipo `outpost` sin campos extra debe aceptarse.
@@ -145,6 +141,8 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
 1. Correcciones manuales de `Session` deben rechazar estados que produzcan más
    de una sesión activa global.
 1. Borrar `Entry` debe eliminar en cascada sus hijos.
+1. Si el delta neto de un recurso en `Entry.resource_deltas` llega a `0`, la
+   clave se elimina del mapa.
 1. Reabrir o re-cerrar una `Week` recalcula `week_cursor` a la primera `Week`
    abierta.
 1. No se permite cerrar/re-cerrar una `Week` si la operación dejaría `0` weeks

--- a/docs/editability-policy.md
+++ b/docs/editability-policy.md
@@ -76,7 +76,7 @@ No incluye:
 | `Session.manual_create` | `session` + `campaign` | Sí | Histórica o activa | Preserva `0..1` sesión activa global |
 | `Session.manual_update` | `session` + `campaign` | Sí | Corrección de timestamps y estado | Preserva `0..1` sesión activa global |
 | `Session.manual_delete` | `session` + `campaign` | Sí | Borrado real | Preserva `0..1` sesión activa global |
-| `ResourceChange.create/update/delete` | `resource_change` | Sí | Weeks abiertas o cerradas | Sigue validación de totales no negativos |
+| `Entry.adjust/set/clear_resource_delta` | `entry` | Sí | Weeks abiertas o cerradas | Edita `Entry.resource_deltas` (delta neto por recurso) con validación de totales no negativos |
 
 ## Reglas por agregado
 
@@ -119,13 +119,18 @@ No incluye:
    normal), pero las correcciones manuales no deben introducir cambios implícitos
    opacos; el contrato detallado se fija en `#12` y el flujo en `#14`.
 
-### `ResourceChange`
+### Recursos en `Entry` (`resource_deltas`)
 
-1. Se mantiene la editabilidad de `ResourceChange` (crear/editar/borrar) con
-   correcciones manuales en el MVP.
+1. La editabilidad de recursos se mantiene en el MVP, pero se expresa sobre
+   `Entry.resource_deltas` (delta neto por `resource_key`), no mediante una
+   entidad `ResourceChange`.
+1. Se permiten ajustes incrementales (`+/-`), edición manual directa del delta
+   neto y limpieza de clave cuando el resultado es `0`.
 1. La política de editabilidad amplia no elimina la validación de totales
    finales no negativos.
-1. El contrato detallado de pre/postcondiciones y rechazos se define en `#12`.
+1. El modelo detallado se define en `docs/resource-delta-model.md` y el
+   contrato de pre/postcondiciones/rechazos en `#12` (parcheado por supersesión
+   parcial de recursos).
 
 ## Reglas de estado y cursor (`Week.status`, `week_cursor`)
 
@@ -233,7 +238,7 @@ abierta:
 - `#14`: flujo de sesión activa / `auto-stop` debe coexistir con correcciones
   manuales de sesión y `Week.reopen/reclose`.
 - `#15`: reglas de recursos deben considerar editabilidad en weeks cerradas y
-  correcciones amplias.
+  correcciones amplias sobre `Entry.resource_deltas`.
 - `#17`: matriz de edge cases debe incorporar reordenación, reopen/reclose y
   correcciones manuales de sesión.
 - `#19`: el plan de pruebas de invariantes debe incluir los nuevos casos de
@@ -278,9 +283,11 @@ abierta:
 - `docs/campaign-temporal-initialization.md`
 - `docs/mvp-implementation-checklist.md`
 - `docs/mvp-implementation-blocks.md`
+- `docs/resource-delta-model.md`
 - `docs/decision-log.md`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/8`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/14`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/15`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/40`

--- a/docs/firestore-operation-contract.md
+++ b/docs/firestore-operation-contract.md
@@ -21,7 +21,7 @@ técnica concreta de Firestore.
 Incluye:
 
 - inventario de operaciones de escritura por agregado (`campaign`, `week`,
-  `entry`, `session`, `resource_change`);
+  `entry` incluidas mutaciones de `resource_deltas`, `session`);
 - precondiciones, validaciones, postcondiciones y rechazos esperados;
 - operaciones compuestas y atomicidad esperada de comportamiento;
 - alineación explícita con `#13` (temporal) y `#37` (editabilidad);
@@ -43,6 +43,7 @@ No incluye:
 - `docs/campaign-temporal-controls.md` (Issue `#9`, con actualización por `#37`)
 - `docs/campaign-temporal-initialization.md` (Issue `#13`)
 - `docs/editability-policy.md` (Issue `#37`)
+- `docs/resource-delta-model.md` (Issue `#40`, supersesión parcial de recursos)
 - `docs/domain-glossary.md`
 
 ## Convenciones del contrato
@@ -56,8 +57,9 @@ No incluye:
    cambian estado de `Week` o estructura temporal.
 1. `Session` no usa un campo `state`; una sesión activa se define por
    `ended_at_utc = null`.
-1. Ownership de `Session` y `ResourceChange` se deriva de la ruta; no se
-   redefine por campos.
+1. Ownership de `Session` se deriva de la ruta; no se redefine por campos.
+1. Los cambios de recursos del MVP se modelan como `Entry.resource_deltas`
+   (mapa embebido), no como entidad `ResourceChange`.
 
 ## Agregados y operaciones cubiertas
 
@@ -74,6 +76,9 @@ No incluye:
   - `Entry.update`
   - `Entry.delete`
   - `Entry.reorder_within_week`
+  - `Entry.adjust_resource_delta`
+  - `Entry.set_resource_delta`
+  - `Entry.clear_resource_delta`
 - `session`
   - `Session.start`
   - `Session.stop`
@@ -81,11 +86,6 @@ No incluye:
   - `Session.manual_create`
   - `Session.manual_update`
   - `Session.manual_delete`
-- `resource_change`
-  - `ResourceChange.create`
-  - `ResourceChange.update`
-  - `ResourceChange.delete`
-
 ## Operaciones excluidas del contrato activo MVP
 
 - `Campaign.set_week_cursor_manual`
@@ -107,17 +107,17 @@ No incluye:
 | `Week.update_notes` | `week` | `week` | `simple` | edición de notas | `activa` | `#8`, `#37` | permitido en `open|closed` |
 | `Entry.create` | `entry` | `entry`, `week` | `compuesta` | creación manual de entry | `activa` | `#37`, glosario | auto-normaliza `order_index` si detecta secuencia inconsistente |
 | `Entry.update` | `entry` | `entry` | `simple` | edición manual de entry | `activa` | `#37`, glosario | alcance amplio; sin mover de `Week` |
-| `Entry.delete` | `entry` | `entry`, `session`, `resource_change`, `campaign` | `compuesta` | borrado manual de entry | `activa` | glosario, `#37` | hard delete real; cascada; auto-stop si entry activa |
+| `Entry.delete` | `entry` | `entry`, `session`, `campaign` | `compuesta` | borrado manual de entry | `activa` | glosario, `#37`, `#40` | hard delete real; auto-stop si entry activa; elimina `resource_deltas` con la entry |
 | `Entry.reorder_within_week` | `entry` | `entry`, `week` | `compuesta` | mover una entry en la misma week | `activa` | `#8`, `#37` | resecuencia densa `1..N` |
+| `Entry.adjust_resource_delta` | `entry` | `entry`, `campaign` | `compuesta` | tap `+/-` de recurso en una entry | `activa` | `#8`, `#37`, `#40`, glosario | ajusta delta neto en `Entry.resource_deltas` y valida totales |
+| `Entry.set_resource_delta` | `entry` | `entry`, `campaign` | `compuesta` | edición manual de delta neto | `activa` | `#8`, `#37`, `#40`, glosario | reemplaza delta neto; elimina clave si queda en `0` |
+| `Entry.clear_resource_delta` | `entry` | `entry`, `campaign` | `compuesta` | limpieza explícita de recurso en la entry | `activa` | `#8`, `#37`, `#40`, glosario | elimina clave de `resource_deltas`; valida totales |
 | `Session.start` | `session` | `campaign`, `entry`, `session` | `compuesta` | iniciar sesión de juego | `activa` | `#8`, glosario | permitido en week `open|closed`; auto-stop si hay activa |
 | `Session.stop` | `session` | `campaign`, `entry`, `session` | `simple` | detener sesión activa | `activa` | `#8`, glosario | inválida si la sesión ya no está activa |
 | `Session.auto_stop` | `session` | `campaign`, `entry`, `session` | `derivada` | `start`, `Week.close/reclose`, `Entry.delete` | `activa` | glosario, `#37` | no es acción manual principal |
 | `Session.manual_create` | `session` | `campaign`, `entry`, `session` | `simple` | corrección manual | `activa` | `#37`, glosario | histórica o activa; permitido en week `open|closed` |
 | `Session.manual_update` | `session` | `campaign`, `entry`, `session` | `simple` | corrección manual | `activa` | `#37`, glosario | corrige timestamps; `null <-> valor`; sin reparenting |
 | `Session.manual_delete` | `session` | `campaign`, `entry`, `session` | `simple` | corrección manual | `activa` | `#37`, glosario | hard delete; permitido en week `open|closed` |
-| `ResourceChange.create` | `resource_change` | `resource_change`, `campaign` | `compuesta` | registro manual de recursos | `activa` | `#8`, glosario | valida no-negatividad final |
-| `ResourceChange.update` | `resource_change` | `resource_change`, `campaign` | `compuesta` | corrección manual | `activa` | `#8`, glosario | valida no-negatividad final |
-| `ResourceChange.delete` | `resource_change` | `resource_change`, `campaign` | `compuesta` | corrección manual | `activa` | `#8`, glosario | valida consistencia de totales tras eliminación |
 
 ## Contrato por operación
 
@@ -131,18 +131,17 @@ No incluye:
 | `Week.update_notes` | week existe | base de `updated_at_utc`/versión no obsoleta | edición de texto válida; permitido en `open|closed` | `notes` actualizadas | base obsoleta; payload inválido | `conflicto` / `validacion` | una actualización simple | `refrescar + reingresar cambios` si conflicto; error local si payload inválido | sin LWW |
 | `Entry.create` | week existe; ownership por ruta válido | base de orden (`entries` de la week) no obsoleta para inserción | `Entry.type` válido; `scenario_ref` obligatorio si `scenario`; si secuencia `order_index` inconsistente, auto-normalizar denso `1..N` antes/asociado a inserción | nueva entry creada con `order_index` válido y secuencia consistente | payload inválido; week inexistente; base obsoleta no resoluble | `validacion` / `conflicto` | normalización de orden + creación forman operación lógica única | error local si payload inválido; `refrescar + reintentar` si conflicto | permitido en week `open|closed` |
 | `Entry.update` | entry existe | base de entry no obsoleta | edición amplia de campos funcionales; `scenario_ref` consistente; no cambiar de `Week` | entry actualizada en la misma week | payload inválido; intento de mover de week; base obsoleta | `validacion` / `conflicto` | actualización simple | error local si validación; `refrescar + reintentar` si conflicto | sin reparenting |
-| `Entry.delete` | entry existe | base de entry e hijos relevantes no obsoletas | hard delete; si entry activa, `auto-stop`; borrado en cascada de `sessions` y `resource_changes` | entry y descendientes eliminados; no queda sesión activa asociada a esa entry | entry ya borrada; base obsoleta; cascada inválida por conflicto | `transicion_invalida` / `conflicto` | auto-stop + cascada + borrado se tratan como operación lógica única | error local si ya no existe; `refrescar + reintentar` si conflicto | hard delete real (sin soft delete funcional) |
+| `Entry.delete` | entry existe | base de entry e hijos relevantes no obsoletas | hard delete; si entry activa, `auto-stop`; borrado de `sessions`; eliminación implícita de `resource_deltas` con la `Entry` | entry eliminada con sus `sessions` y `resource_deltas`; no queda sesión activa asociada a esa entry | entry ya borrada; base obsoleta; cascada inválida por conflicto | `transicion_invalida` / `conflicto` | auto-stop + borrado de hijos + borrado de entry se tratan como operación lógica única | error local si ya no existe; `refrescar + reintentar` si conflicto | hard delete real (sin soft delete funcional) |
 | `Entry.reorder_within_week` | entry existe y pertenece a la week objetivo; misma week | base del orden de la week no obsoleta | posición destino válida; resecuencia densa `1..N`; no mover entre weeks | orden de entries de la week queda consistente | entry inexistente; week inconsistente; base obsoleta | `validacion` / `conflicto` | mover + resecuencia como operación lógica única | error local si validación; `refrescar + reintentar` si conflicto | permitido en week `open|closed` |
+| `Entry.adjust_resource_delta` | entry existe; `resource_key` pertenece al catálogo MVP | base de entry y `resource_totals` relevantes no obsoletas | ajuste entero firmado; cálculo de delta neto; eliminar clave si resultado `0`; totales finales no negativos | `Entry.resource_deltas` actualizado (neto); `campaign.resource_totals` consistente | `resource_key` inválida; payload inválido; totales negativos; base obsoleta | `validacion` / `conflicto` | recálculo de totales + actualización de `Entry.resource_deltas` como operación lógica única | error local si validación; `refrescar + reintentar` si conflicto | permitido en week `open|closed`; no crea log incremental |
+| `Entry.set_resource_delta` | entry existe; `resource_key` válida | base de entry y totales relevantes no obsoletas | delta entero firmado; si delta final `0`, eliminar clave; totales finales no negativos | delta neto fijado (o clave eliminada) y totales consistentes | `resource_key` inválida; payload inválido; totales negativos; base obsoleta | `validacion` / `conflicto` | recálculo de totales + escritura del mapa como operación lógica única | error local si validación; `refrescar + reintentar` si conflicto | edición manual directa del delta neto |
+| `Entry.clear_resource_delta` | entry existe | base de entry y totales relevantes no obsoletas | `resource_key` válida; recálculo mantiene totales no negativos | clave eliminada de `resource_deltas` (o permanece ausente si se trata como idempotente) y totales consistentes | `resource_key` inválida; totales negativos; base obsoleta | `validacion` / `conflicto` | recálculo de totales + limpieza de clave como operación lógica única | error local si validación; `refrescar + reintentar` si conflicto | limpiar clave inexistente puede tratarse como idempotente (sin error) |
 | `Session.start` | entry existe; sesión activa global puede ser 0..1; week `open|closed` permitida | base de sesión activa global no obsoleta | si ya hay sesión activa, `auto-stop` previo; garantizar unicidad `0..1` activa | nueva sesión activa (o transición equivalente) creada; unicidad preservada | unicidad violada; entry inválida; base obsoleta | `validacion` / `conflicto` | `auto-stop + start` (si aplica) como operación lógica única | error local si validación; `refrescar + reintentar` si conflicto | actividad derivada por `ended_at_utc=null` |
 | `Session.stop` | sesión objetivo existe y está activa (`ended_at_utc=null`) | base de sesión no obsoleta | sesión sigue activa al momento de aplicar stop | sesión queda cerrada (`ended_at_utc` definido) | sesión ya cerrada/no activa; base obsoleta | `transicion_invalida` / `conflicto` | actualización simple | error local si transición inválida; `refrescar + reintentar` si conflicto | distingue conflicto de transición inválida |
 | `Session.auto_stop` | sesión activa previa existe | base de sesión activa no obsoleta | trigger válido (`start`, `Week.close/reclose`, `Entry.delete`) | sesión activa previa queda cerrada | sesión ya no activa; base obsoleta | `transicion_invalida` / `conflicto` | se evalúa dentro de la operación compuesta disparadora | heredada de la operación padre | no se expone como acción manual principal |
 | `Session.manual_create` | entry existe; ownership por ruta válido | base de sesión activa global no obsoleta si crea una activa | timestamps válidos; histórica o activa; unicidad `0..1` activa global | sesión manual creada | timestamps inválidos; unicidad violada; base obsoleta | `validacion` / `conflicto` | creación simple | error local si validación; `refrescar + reintentar` si conflicto | permitido en week `open|closed` |
 | `Session.manual_update` | sesión existe; ownership por ruta inmutable | base de la sesión y de unicidad global no obsoletas | corrige `started_at_utc`/`ended_at_utc`; permite `null <-> valor`; sin reparenting; unicidad de activa global | sesión corregida; unicidad preservada | timestamps inválidos; reparenting intentado; unicidad violada; base obsoleta | `validacion` / `conflicto` | actualización simple | error local si validación; `refrescar + reintentar` si conflicto | no existe campo `state` separado |
 | `Session.manual_delete` | sesión existe | base de sesión no obsoleta | hard delete; preservar `0..1` activa global | sesión eliminada | sesión ya borrada; base obsoleta | `transicion_invalida` / `conflicto` | borrado simple | error local si transición inválida; `refrescar + reintentar` si conflicto | permitido en week `open|closed` |
-| `ResourceChange.create` | entry existe; ownership por ruta válido | base de `resource_totals` / log relevante no obsoleta | `resource_key` válido; `delta != 0`; totales finales no negativos | cambio creado; totales resultantes válidos | payload inválido; totales negativos; base obsoleta | `validacion` / `conflicto` | cálculo + creación como operación lógica única | error local si validación; `refrescar + reintentar` si conflicto | permitido en week `open|closed` |
-| `ResourceChange.update` | change existe | base de change y totales relevantes no obsoletas | payload válido; totales finales no negativos | change actualizado; totales resultantes válidos | change inexistente/alterado; totales negativos; base obsoleta | `transicion_invalida` / `validacion` / `conflicto` | cálculo + actualización como operación lógica única | error local si validación/transición; `refrescar + reintentar` si conflicto | sin LWW |
-| `ResourceChange.delete` | change existe | base de change y totales relevantes no obsoletas | recálculo mantiene totales no negativos | change eliminado; totales resultantes válidos | change ya borrado; totales inválidos; base obsoleta | `transicion_invalida` / `validacion` / `conflicto` | cálculo + borrado como operación lógica única | error local si validación/transición; `refrescar + reintentar` si conflicto | hard delete real |
-
 ## Operaciones compuestas y atomicidad esperada (comportamiento)
 
 Este documento exige atomicidad a nivel de **resultado observable** (éxito
@@ -153,10 +152,12 @@ Operaciones compuestas mínimas:
 
 1. `Session.start` con `auto-stop` previo cuando ya existe sesión activa.
 1. `Week.close` / `Week.reclose` con `auto-stop` + recálculo de `week_cursor`.
-1. `Entry.delete` activa con `auto-stop` + cascada (`sessions`,
-   `resource_changes`).
+1. `Entry.delete` activa con `auto-stop` + borrado de `sessions` (y eliminación
+   implícita de `resource_deltas` al borrar la `Entry`).
 1. `Entry.create` con auto-normalización de `order_index` cuando la secuencia de
    la week llega inconsistente.
+1. `Entry.adjust_resource_delta`, `Entry.set_resource_delta` y
+   `Entry.clear_resource_delta` con recálculo de `campaign.resource_totals`.
 1. `Campaign.provision_initial_years` y `Campaign.extend_years_plus_one` con
    estructura temporal completa + cursor derivado válido.
 
@@ -167,14 +168,14 @@ Operaciones compuestas mínimas:
 | `Campaign.provision_initial_years` | 4 años iniciales, `summer->winter`, 10 semanas/estación, `week_number` correlativo | cursor derivado; no dejar 0 abiertas | creación completa con duplicados rechazados y cursor derivado válido | técnica Firestore | estructura temporal inconsistente / cursor inválido |
 | `Campaign.extend_years_plus_one` | +1 año, continuidad `year_number`/`week_number` | cursor derivado | extensión exacta de 1 año; sin reprovisión; sin duplicados | técnica Firestore | numeración rota o duplicados |
 | `Week.close/reopen/reclose` | coherencia `week_number`/jerarquía | recálculo de cursor; transición manual | cambio de estado + postcondición de `week_cursor` | timestamp/desempate | cursor incoherente o estado inválido |
-| `Entry`/`Session`/`ResourceChange` sobre weeks históricas | weeks siguen existiendo y `week_number` no cambia | editabilidad amplia en `open|closed` | operaciones permitidas en weeks `closed` salvo validación específica | política UI | bloqueos artificiales o contradicción con `#37` |
+| `Entry`/`Session` (incluyendo `Entry.resource_deltas`) sobre weeks históricas | weeks siguen existiendo y `week_number` no cambia | editabilidad amplia en `open|closed` | operaciones permitidas en weeks `closed` salvo validación específica | política UI | bloqueos artificiales o contradicción con `#37` |
 
 ## Alineación de editabilidad e invariantes con #37
 
 1. `Campaign.set_week_cursor_manual` se documenta como exclusión activa del MVP.
 1. `week_cursor` es derivado (postcondición) y nunca selección manual libre.
 1. `Week.status=closed` es marcador informativo; no bloquea por sí mismo
-   mutaciones de `Entry`, `Session` o `ResourceChange`.
+   mutaciones de `Entry` (incluyendo `resource_deltas`) ni `Session`.
 1. `Entry.reorder_within_week` está limitado a la misma `Week` y resecuencia
    densa `1..N`.
 1. `Session.manual_update` no cambia ownership por ruta y puede corregir
@@ -220,6 +221,8 @@ Operaciones compuestas mínimas:
    inconsistente.
 1. `Entry.reorder_within_week` funciona también en weeks `closed` y resecuencia
    a `1..N`.
+1. Las operaciones de recursos del contrato se expresan sobre
+   `Entry.resource_deltas` (`adjust/set/clear`) y no sobre `ResourceChange`.
 1. `Campaign.set_week_cursor_manual` aparece como exclusión activa del contrato
    MVP.
 
@@ -229,6 +232,9 @@ Operaciones compuestas mínimas:
   implementación.
 - La política de timestamps y desempate estable sigue diferida a `#18`.
 - El contrato no define lecturas ni consultas (`#16`).
+- La parte de recursos de este contrato fue parcialmente supersedida por
+  `docs/resource-delta-model.md` (Issue `#40`) y parcheada con operaciones
+  sobre `Entry.resource_deltas`.
 - La UX exacta para errores de conflicto vs transición inválida se concreta en
   issues de flujo (`#14`) y UI.
 
@@ -240,9 +246,11 @@ Operaciones compuestas mínimas:
 - `docs/campaign-temporal-controls.md`
 - `docs/campaign-temporal-initialization.md`
 - `docs/editability-policy.md`
+- `docs/resource-delta-model.md`
 - `docs/decision-log.md`
 - `docs/mvp-implementation-checklist.md`
 - `docs/mvp-implementation-blocks.md`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/13`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/40`

--- a/docs/mvp-implementation-blocks.md
+++ b/docs/mvp-implementation-blocks.md
@@ -20,7 +20,8 @@ la preparación de implementación del MVP, sin codificar todavía.
 Incluye:
 
 - desglose detallado de las Issues `#12`–`#20` y decisiones marco intermedias
-  que afecten su secuencia (actualmente `#37`) por subbloques ejecutables;
+  que afecten su secuencia (actualmente `#37` y `#40`) por subbloques
+  ejecutables;
 - responsables por rol (`Codex`, `Kiko`, `Codex+Kiko`);
 - entregables, dependencias y criterios de finalización por subbloque;
 - riesgos y bloqueos por issue;
@@ -97,15 +98,16 @@ No incluye:
 | #13 | `task` | `ready` | 1.º dentro del bloque B | Sí | Coherencia con #9 y dominio | Estrategia técnica de inicialización/extensión temporal |
 | #37 | `decision` | `ready` | 2.º dentro del bloque B | Sí | Coherencia con #8/#9/#13 y dominio | Política de editabilidad manual y correcciones de dominio |
 | #12 | `decision` | `draftable` | 3.º dentro del bloque B | Sí | Alineación con #13 y #37 (cierre recomendado con ambas cerradas) | Contrato de operaciones Firestore por agregado |
+| #40 | `decision` | `draftable` | 4.º dentro del bloque B | Sí | Coherencia con #12/#37 y glosario; supersesión parcial de recursos | Modelo de recursos por `Entry` (`resource_deltas`) |
 | #14 | `task` | `draftable` | 1.º del bloque C | Sí | Alineación con #12 para cierre | Flujo de sesión activa y `auto-stop` |
 | #15 | `task` | `draftable` | 2.º del bloque C | Sí | Alineación con #12 para cierre | Reglas de validación y recálculo de recursos |
 | #16 | `task` | `draftable` | 1.º del bloque D | Sí | Compatibilidad con #18 para cierre | Inventario mínimo de consultas y orden/paginación |
 | #17 | `task` | `draftable` | 2.º del bloque D | Sí | Mayor valor tras #12/#14/#15/#18 | Matriz de edge cases de concurrencia/sincronización |
-| #18 | `decision` | `draftable` | 4.º dentro del bloque B | Sí | Compatibilidad con #12 y lecturas | Política de timestamps y desempate estable |
+| #18 | `decision` | `draftable` | 5.º dentro del bloque B | Sí | Compatibilidad con #12, #40 y lecturas | Política de timestamps y desempate estable |
 | #19 | `task` | `draftable` | 3.º del bloque D | Sí | Insumos suficientes de contratos/flows | Plan de pruebas de invariantes |
 | #20 | `task` | `final_gate` | Último (bloque E) | No (cierre final) | Base de #10 + derivadas relevantes | Gate de listo para codificar |
 
-## Detalle por issue (`#12`–`#20`) y decisión marco intermedia (`#37`)
+## Detalle por issue (`#12`–`#20`) y decisiones marco intermedias (`#37`, `#40`)
 
 ### Issue #12 — Definir contrato de operaciones Firestore por agregado de dominio
 
@@ -123,7 +125,7 @@ No incluye:
 
 | subbloque_id | objetivo | responsable | depende_de | entregable | criterio_de_finalización | estado_inicial |
 | --- | --- | --- | --- | --- | --- | --- |
-| `I12-S1` | Inventariar operaciones por agregado (`campaign`, `week`, `entry`, `session`, `resource_change`) y casos de uso | `Codex` | `#7`, `#8`, `#9`, `#37` | Tabla de operaciones por agregado | Inventario completo y sin solapes obvios con mutabilidad vigente | `draftable` |
+| `I12-S1` | Inventariar operaciones por agregado (`campaign`, `week`, `entry` incl. `resource_deltas`, `session`) y casos de uso | `Codex` | `#7`, `#8`, `#9`, `#37` | Tabla de operaciones por agregado | Inventario completo y sin solapes obvios con mutabilidad vigente | `draftable` |
 | `I12-S2` | Definir contrato por agregado (precondiciones, postcondiciones, validaciones, rechazo por conflicto/transición inválida, atomicidad esperada) | `Codex` | `I12-S1` | Tabla de contrato por agregado | Cada agregado tiene contrato explícito y coherente con `#8` y `#37` | `draftable` |
 | `I12-S3` | Alinear operaciones temporales y de cursor con `#13` y `#37` (provisión/extensión/`week_cursor` derivado) | `Codex+Kiko` | `I12-S2`, `#13`, `#37` | Nota/tabla de alineación `#12` ↔ (`#13`, `#37`) | No quedan contradicciones con flujo temporal ni editabilidad | `draftable` |
 | `I12-S4` | Cerrar la decisión (revisión interactiva, trazabilidad y referencias) | `Codex+Kiko` | `I12-S3` | Documento final + registro de decisión | Aprobación explícita de Kiko y PR mergeada | `draftable` |
@@ -262,22 +264,23 @@ No incluye:
 - `tipo`: `task`
 - `estado_inicial`: `draftable`
 - `responsable_de_coordinación`: `Codex+Kiko`
-- `dependencias_de_cierre`: coherencia con `#8`, `#37` y alineación con `#12`
+- `dependencias_de_cierre`: coherencia con `#8`, `#37`, `#40` y alineación con `#12`
 - `impacta_a`: `#17`, `#19`, `#20`
 
 #### Subbloques ejecutables
 
 | subbloque_id | objetivo | responsable | depende_de | entregable | criterio_de_finalización | estado_inicial |
 | --- | --- | --- | --- | --- | --- | --- |
-| `I15-S1` | Inventariar operaciones sobre `ResourceChange` (crear, editar, borrar, corregir) | `Codex` | `#8`, `docs/domain-glossary.md` | Inventario de operaciones de recursos | Operaciones y efectos quedan enumerados | `draftable` |
-| `I15-S2` | Definir reglas de validación de `delta` y restricción de totales no negativos | `Codex` | `I15-S1` | Reglas de validación | Casos válidos/inválidos y rechazos quedan cerrados | `draftable` |
-| `I15-S3` | Definir estrategia de recálculo y consistencia de totales globales | `Codex` | `I15-S2` | Estrategia de recálculo | Se documenta consistencia y comportamiento esperado tras correcciones | `draftable` |
-| `I15-S4` | Alinear matriz de rechazos con `#8`, editabilidad (`#37`) y contrato de operaciones (`#12`) | `Codex+Kiko` | `I15-S3`, `#37`, `#12` | Alineación final de rechazos y operaciones | No quedan contradicciones con concurrencia ni contrato | `draftable` |
+| `I15-S1` | Inventariar operaciones sobre `Entry.resource_deltas` (ajustar, fijar, limpiar delta neto) | `Codex` | `#8`, `docs/domain-glossary.md`, `#40` | Inventario de operaciones de recursos | Operaciones y efectos quedan enumerados con modelo embebido | `draftable` |
+| `I15-S2` | Definir reglas de validación de deltas netos y restricción de totales no negativos | `Codex` | `I15-S1` | Reglas de validación | Casos válidos/inválidos y rechazos quedan cerrados | `draftable` |
+| `I15-S3` | Definir estrategia de recálculo y consistencia de totales globales desde `Entry.resource_deltas` | `Codex` | `I15-S2`, `#40` | Estrategia de recálculo | Se documenta consistencia y comportamiento esperado tras correcciones | `draftable` |
+| `I15-S4` | Alinear matriz de rechazos con `#8`, editabilidad (`#37`), modelo de recursos (`#40`) y contrato de operaciones (`#12`) | `Codex+Kiko` | `I15-S3`, `#37`, `#40`, `#12` | Alineación final de rechazos y operaciones | No quedan contradicciones con concurrencia ni contrato | `draftable` |
 
 #### Riesgos y bloqueos
 
 - Riesgo de definir validaciones incompatibles con atomicidad esperada de `#12`.
-- Riesgo de subestimar casos de corrección/borrado y recálculo.
+- Riesgo de subestimar casos de corrección/borrado y recálculo en el modelo
+  embebido (`Entry.resource_deltas`).
 
 #### Criterio de cierre de la issue
 
@@ -287,7 +290,8 @@ No incluye:
 #### Notas de secuencia / paralelización
 
 - Puede avanzar en borrador antes de `#12`.
-- Conviene cerrar después de aclarar editabilidad (`#37`) y contrato por agregado en `#12`.
+- Conviene cerrar después de aclarar editabilidad (`#37`), modelo de recursos
+  (`#40`) y contrato por agregado en `#12`.
 
 ### Issue #16 — Definir consultas mínimas para timeline y panel de foco
 
@@ -359,6 +363,46 @@ No incluye:
 - Puede arrancar con taxonomía y borrador de matriz.
 - Su cierre gana calidad después de `#37`, `#12`, `#14`, `#15` y `#18`.
 
+### Issue #40 — Redefinir modelo de recursos por `Entry` (delta neto por recurso, sin `ResourceChange`)
+
+#### Ficha de bloque
+
+- `tipo`: `decision`
+- `estado_inicial`: `draftable` (cerrada en seguimiento; este bloque conserva el estado inicial del plan)
+- `responsable_de_coordinación`: `Codex+Kiko`
+- `dependencias_de_cierre`: coherencia con `#8`, `#12`, `#37` y
+  `docs/domain-glossary.md`
+- `impacta_a`: `#15`, `#17`, `#18`, `#19`, `#20`
+
+#### Subbloques ejecutables
+
+| subbloque_id | objetivo | responsable | depende_de | entregable | criterio_de_finalización | estado_inicial |
+| --- | --- | --- | --- | --- | --- | --- |
+| `I40-S1` | Definir el modelo de recursos por `Entry` (`resource_deltas`) y eliminar `ResourceChange` como entidad MVP | `Codex+Kiko` | `docs/domain-glossary.md`, `#37` | Decisión de modelo (`docs/resource-delta-model.md`) | Semántica neta por recurso cerrada y sin ambigüedad | `draftable` |
+| `I40-S2` | Parchear consistencia en glosario, conflictos y contrato `#12` (supersesión parcial de recursos) | `Codex` | `I40-S1`, `#12`, `#8` | Docs oficiales alineados | No quedan referencias activas contradictorias a `ResourceChange` en el MVP | `draftable` |
+| `I40-S3` | Actualizar orden técnico/trazabilidad downstream (`#15`, `#17`, `#18`, `#19`) | `Codex` | `I40-S2` | Checklist/bloques/referencias actualizados | `#18` vuelve a quedar como siguiente paso técnico tras `#40` | `draftable` |
+| `I40-S4` | Cerrar la decisión (revisión interactiva, registro en decision-log, PR mergeada) | `Codex+Kiko` | `I40-S3` | Decisión aceptada + `DEC-0024` + PR mergeada | Aprobación explícita de Kiko y cierre end-to-end | `draftable` |
+
+#### Riesgos y bloqueos
+
+- Riesgo de dejar `#12` contradictoria si se cambia el dominio de recursos sin
+  parchear el contrato de operaciones.
+- Riesgo de que `#18` inventarie eventos/listas innecesarios si se mantiene el
+  modelo antiguo de `ResourceChange`.
+
+#### Criterio de cierre de la issue
+
+- Existe decisión de dominio oficial que sustituye `ResourceChange` por
+  `Entry.resource_deltas` (delta neto por recurso) y deja glosario, conflictos
+  y contrato `#12` alineados mediante supersesión parcial explícita.
+
+#### Notas de secuencia / paralelización
+
+- Debe cerrarse antes de `#18` para evitar retrabajo en inventario de eventos y
+  contratos de recursos.
+- Comparte naturaleza `type:decision`; requiere revisión interactiva con Kiko
+  para cierre.
+
 ### Issue #18 — Definir política de timestamps y orden estable entre dispositivos
 
 #### Ficha de bloque
@@ -367,7 +411,7 @@ No incluye:
 - `estado_inicial`: `draftable`
 - `responsable_de_coordinación`: `Codex+Kiko`
 - `dependencias_de_cierre`: coherencia con `#7`, `#8`; compatibilidad con
-  `#12` y lecturas (`#16`)
+  `#12`, `#40` y lecturas (`#16`)
 - `impacta_a`: `#16`, `#17`, `#19`, `#20`
 
 #### Subbloques ejecutables
@@ -382,7 +426,7 @@ No incluye:
 #### Riesgos y bloqueos
 
 - Riesgo de definir desempate incompatible con consultas mínimas (`#16`) o
-  contrato de operaciones (`#12`).
+  contratos/modelo de datos (`#12`, `#40`).
 - Riesgo de cerrar sin inventario completo de eventos ordenables.
 
 #### Criterio de cierre de la issue
@@ -494,12 +538,13 @@ No incluye:
 
 ## Seguimiento de bloques
 
-### Estado de bloques (actualizado tras cerrar #13 y #37)
+### Estado de bloques (actualizado tras cerrar #13, #37, #12 y #40)
 
 - [x] `#11` Desglose en bloques ejecutables (este documento)
 - [x] `#13` Inicialización temporal detallada (`ready`)
 - [x] `#37` Política de editabilidad manual y correcciones de dominio (`ready`)
 - [x] `#12` Contrato Firestore por agregado (`draftable`)
+- [x] `#40` Modelo de recursos por `Entry` (delta neto; `draftable`)
 - [ ] `#18` Timestamps y orden estable (`draftable`)
 - [ ] `#14` Flujo de sesión activa y `auto-stop` (`draftable`)
 - [ ] `#15` Validación y recálculo de recursos (`draftable`)
@@ -527,6 +572,7 @@ No incluye:
 - `docs/sync-strategy.md`
 - `docs/conflict-policy.md`
 - `docs/firestore-operation-contract.md`
+- `docs/resource-delta-model.md`
 - `docs/campaign-temporal-controls.md`
 - `docs/campaign-temporal-initialization.md`
 - `docs/editability-policy.md`
@@ -537,6 +583,7 @@ No incluye:
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/13`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/40`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/14`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/15`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/16`

--- a/docs/mvp-implementation-checklist.md
+++ b/docs/mvp-implementation-checklist.md
@@ -31,7 +31,7 @@ No incluye:
 - codificación de la app;
 - desglose fino en bloques ejecutables con responsables y entregables (Issue #11);
 - gate final de "listo para codificar" (Issue #20);
-- cierre de decisiones de dominio pendientes (por ejemplo #12, #18).
+- cierre de decisiones de dominio pendientes (por ejemplo #18).
 
 ## Entradas ya cerradas (prerrequisitos disponibles)
 
@@ -55,6 +55,10 @@ este checklist:
   - editabilidad amplia ("como papel"), reordenación manual de `Entry`,
     `Week.reopen/reclose`, correcciones manuales de `Session` y semántica
     derivada de `week_cursor`.
+- **Modelo de recursos por `Entry` (delta neto)** (Issue #40):
+  `docs/resource-delta-model.md`
+  - `ResourceChange` se sustituye por `Entry.resource_deltas` (delta neto por
+    recurso), con supersesión parcial de la parte de recursos en `#12`.
 
 ## Corte de responsabilidades entre `#10`, `#11` y `#20`
 
@@ -93,11 +97,12 @@ este checklist:
 
 ### Bloque B — Contratos de dominio para implementación (núcleo)
 
-- **Issues**: #13, #37, #12, #18
+- **Issues**: #13, #37, #12, #40, #18
 - **Orden recomendado**:
   1. #13 — inicialización temporal detallada.
   1. #37 — política de editabilidad manual y correcciones de dominio (marco).
   1. #12 — contrato de operaciones Firestore por agregado, alineado con #13 y #37.
+  1. #40 — modelo de recursos por `Entry` (delta neto; supersesión parcial de recursos).
   1. #18 — timestamps y orden estable entre dispositivos.
 - **Justificación**:
   - #13 concreta la provisión/extensión temporal decidida en #9.
@@ -105,6 +110,8 @@ este checklist:
     por agregado.
   - #12 necesita alineación con provisión temporal (#9), detalle técnico (#13)
     y política de editabilidad (#37).
+  - #40 corrige el modelo de recursos del MVP y reduce ambigüedad antes de #15
+    y del inventario ordenable de #18.
   - #18 cierra orden estable para lecturas y logs entre dispositivos.
 
 ### Bloque C — Flujos funcionales e invariantes de operación
@@ -115,7 +122,7 @@ este checklist:
   1. #15 — validación y recálculo de recursos.
 - **Dependencias mínimas**:
   - #14 requiere #8 (resuelta) y se beneficia del contrato #12.
-  - #15 requiere #8 (resuelta) y debe alinearse con #12.
+  - #15 requiere #8 (resuelta) y debe alinearse con #12 y #40.
 
 ### Bloque D — Lecturas, edge cases y verificación
 
@@ -143,9 +150,10 @@ este checklist:
 | Bloque B / #13 | `task` | #9 (resuelta) | Sí | Flujo temporal detallado sin contradicciones | #37, #12, #16, #20 |
 | Bloque B / #37 | `decision` | #8, #9 (resueltas) + coherencia con #13 | Borrador sí; cierre recomendado tras #13 | Política de editabilidad manual e invariantes actualizadas | #12, #14, #15, #17, #19, #20 |
 | Bloque B / #12 | `decision` | #7, #8, #9 (resueltas) + alineación con #13 y #37 | Borrador sí; cierre recomendado tras #13 y #37 | Contrato por agregado con pre/postcondiciones | #14, #15, #16, #17, #18, #19, #20 |
-| Bloque B / #18 | `decision` | #7, #8 (resueltas) | Sí, pero cierre recomendado tras #12 | Política de timestamps y desempate estable | #16, #17, #19, #20 |
+| Bloque B / #40 | `decision` | #8, #12, #37 (resueltas) + coherencia con glosario | Sí, pero cierre recomendado antes de #18 y #15 | Modelo de recursos por `Entry` (`resource_deltas`) y parche de consistencia | #15, #17, #18, #19, #20 |
+| Bloque B / #18 | `decision` | #7, #8 (resueltas) + coherencia con #12 y #40 | Sí, pero cierre recomendado tras #12 y #40 | Política de timestamps y desempate estable | #16, #17, #19, #20 |
 | Bloque C / #14 | `task` | #8 (resuelta) + alineación con #37 | Sí, parcial | Flujo de sesión + `auto-stop` sin romper invariantes | #17, #19, #20 |
-| Bloque C / #15 | `task` | #8 (resuelta) + alineación con #37 | Sí, parcial | Reglas de validación y recálculo trazables | #17, #19, #20 |
+| Bloque C / #15 | `task` | #8 (resuelta) + alineación con #37 y #40 | Sí, parcial | Reglas de validación y recálculo trazables | #17, #19, #20 |
 | Bloque D / #16 | `task` | #7, #9 (resueltas) | Sí | Inventario mínimo de consultas y orden estable | #19, #20 |
 | Bloque D / #17 | `task` | #7, #8 (resueltas) | Sí, pero gana valor tras #12/#14/#15/#18 | Matriz de edge cases con expectativa verificable | #19, #20 |
 | Bloque D / #19 | `task` | #7, #8, #9 (resueltas) | Sí, parcial | Plan de pruebas de invariantes con evidencia repetible | #20 |
@@ -198,6 +206,7 @@ Usar esta plantilla mínima en cada issue/bloque del checklist:
 - [x] Inicialización temporal detallada (Issue #13)
 - [x] Política de editabilidad manual y correcciones de dominio (Issue #37)
 - [x] Contrato de operaciones Firestore por agregado (Issue #12)
+- [x] Modelo de recursos por `Entry` (delta neto; Issue #40)
 - [ ] Política de timestamps y orden estable (Issue #18)
 - [ ] Flujo de sesión activa y `auto-stop` (Issue #14)
 - [ ] Reglas de validación y recálculo de recursos (Issue #15)
@@ -215,6 +224,7 @@ Usar esta plantilla mínima en cada issue/bloque del checklist:
 - `docs/sync-strategy.md`
 - `docs/conflict-policy.md`
 - `docs/firestore-operation-contract.md`
+- `docs/resource-delta-model.md`
 - `docs/campaign-temporal-controls.md`
 - `docs/campaign-temporal-initialization.md`
 - `docs/editability-policy.md`
@@ -225,6 +235,7 @@ Usar esta plantilla mínima en cada issue/bloque del checklist:
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/13`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/40`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/14`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/15`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/16`

--- a/docs/resource-delta-model.md
+++ b/docs/resource-delta-model.md
@@ -1,0 +1,188 @@
+# Modelo de Recursos por Entry (MVP)
+
+## Metadatos
+
+- `doc_id`: DOC-RESOURCE-DELTA-MODEL
+- `purpose`: Definir el modelo MVP de recursos como delta neto por `resource_key` dentro de `Entry`, sustituyendo el modelo previo basado en `ResourceChange`.
+- `status`: active
+- `source_of_truth`: official
+- `last_updated`: 2026-02-24
+- `next_review`: 2026-03-10
+
+## Objetivo
+
+Cerrar una decisión de dominio para el MVP que sustituya la entidad
+`ResourceChange` por un modelo de recursos embebido en `Entry`, con semántica
+de delta neto editable por recurso y trazabilidad suficiente para alinear
+dominio, conflictos y contrato de operaciones.
+
+## Alcance y no alcance
+
+Incluye:
+
+- modelo lógico/persistido de recursos del MVP dentro de `Entry`;
+- semántica de edición (`+/-` y edición manual) sobre deltas netos;
+- invariantes y validaciones de recursos;
+- impacto documental sobre `docs/domain-glossary.md`, `docs/conflict-policy.md`
+  y `docs/firestore-operation-contract.md`;
+- impacto downstream sobre `#15`, `#17`, `#18` y `#19`.
+
+No incluye:
+
+- implementación de código de app;
+- técnica Firestore concreta (transacciones, batches, índices);
+- política de timestamps/desempates de orden estable (`#18`);
+- diseño de UI detallado de controles de recursos.
+
+## Entradas y prerrequisitos
+
+- `docs/domain-glossary.md`
+- `docs/conflict-policy.md`
+- `docs/firestore-operation-contract.md` (Issue `#12`)
+- `docs/editability-policy.md` (Issue `#37`)
+- Decisiones de Kiko para esta unidad:
+  - eliminar `ResourceChange` como entidad/log incremental del MVP;
+  - usar un mapa en `Entry` con delta neto por `resource_key`;
+  - eliminar la clave si el delta neto queda en `0`;
+  - mantener solo auditoría de `Entry` (sin timestamps por recurso);
+  - parchear `#12` por supersesión parcial sin reabrir la issue.
+
+## Problema del modelo previo (log `ResourceChange`)
+
+1. El modelo `ResourceChange` como log `0..N` por `Entry` no encaja con la
+   intención de edición manual "como papel" para recursos en el MVP.
+1. Registrar múltiples cambios del mismo recurso dentro de una sola `Entry`
+   introduce complejidad adicional (historial intra-entry) que no aporta valor
+   al MVP actual.
+1. El contrato de operaciones y la política de conflictos se vuelven más
+   complejos al tratar recursos como entidad hija separada cuando el objetivo es
+   editar un **resultado neto** por recurso en la `Entry`.
+
+## Decisión de modelo (delta neto por recurso en `Entry`)
+
+1. Se elimina `ResourceChange` como entidad persistida/documentada del MVP.
+1. Los cambios de recursos del MVP se modelan en `Entry` como un mapa
+   `resource_deltas`.
+1. Cada `resource_key` puede aparecer **como máximo una vez** dentro de una
+   `Entry` (delta neto por recurso).
+1. Repetidos `+/-` sobre el mismo recurso en la misma `Entry` actualizan el
+   **mismo delta neto**.
+1. Si el delta neto resultante de un recurso pasa a `0`, la clave se elimina
+   del mapa (`ausencia == delta 0`).
+1. No existe historial incremental intra-entry por recurso en el MVP.
+
+## Estructura de datos del MVP
+
+### `Entry.resource_deltas`
+
+- tipo lógico: `map<resource_key, int>`
+- semántica: delta neto por recurso dentro de esa `Entry`
+- cardinalidad efectiva:
+  - por `resource_key`: `0..1`
+  - por `Entry`: `0..N` claves (solo recursos con delta `!= 0`)
+
+### Reglas de representación
+
+1. `resource_key` debe pertenecer al catálogo de recursos MVP definido en
+   `docs/domain-glossary.md`.
+1. `delta` es un entero firmado (`int`).
+1. No se persisten claves con valor `0`.
+1. La ausencia de una clave equivale a delta `0` para esa `Entry`.
+
+## Semántica de edición (`+/-` y edición manual)
+
+1. Acciones UI `+/-` sobre un recurso dentro de una `Entry` ajustan el delta
+   neto existente para esa `resource_key`.
+1. La edición manual de recursos puede:
+   - reemplazar el delta neto;
+   - ajustarlo;
+   - borrarlo explícitamente (o implícitamente al llegar a `0`).
+1. Si una operación deja el delta neto en `0`, la clave se elimina del mapa.
+1. No se conserva un historial de microcambios del mismo recurso dentro de una
+   `Entry` en el MVP.
+
+## Validaciones e invariantes
+
+1. Los totales globales (`Campaign.resource_totals`) siguen derivándose de la
+   suma de `Entry.resource_deltas` a través de las `Entry` de la campaña.
+1. Se mantiene la validación de **totales finales no negativos**.
+1. La editabilidad de recursos es compatible con weeks `open|closed` (alineado
+   con `#37`).
+1. No hay auditoría por recurso; la auditoría de recursos usa la auditoría de
+   `Entry` (`updated_at_utc`, etc.).
+1. El borrado de `Entry` elimina implícitamente sus deltas de recursos al
+   eliminar el documento `Entry` (sin subcolección `resource_changes`).
+
+## Impacto en contratos y conflictos
+
+### Supersesión parcial de `#12`
+
+1. `DEC-0023` y `docs/firestore-operation-contract.md` quedan **parcialmente
+   supersedidos** en la parte de operaciones `ResourceChange.*`.
+1. La Issue `#12` permanece cerrada; la corrección se documenta mediante esta
+   nueva decisión y un parche de consistencia en el contrato.
+
+### Parche esperado en `docs/firestore-operation-contract.md`
+
+Se sustituyen operaciones `ResourceChange.*` por operaciones sobre
+`Entry.resource_deltas`:
+
+- `Entry.adjust_resource_delta`
+- `Entry.set_resource_delta`
+- `Entry.clear_resource_delta`
+
+### Alineación con `docs/conflict-policy.md`
+
+1. Las colisiones de recursos pasan a modelarse como conflicto sobre `Entry`
+   (y totales derivados), no sobre una entidad `ResourceChange`.
+1. Se mantiene la política estricta de `rechazar` + `refrescar` + `reintentar`
+   para conflictos concurrentes reales.
+1. Se mantiene la validación de totales finales no negativos.
+
+## Impacto en issues downstream (`#15`, `#17`, `#18`, `#19`)
+
+- `#15`: debe definir reglas de validación y recálculo sobre
+  `Entry.resource_deltas`, no sobre `ResourceChange`.
+- `#17`: sustituir edge cases de concurrencia sobre `ResourceChange` por casos
+  de edición concurrente de `Entry.resource_deltas`.
+- `#18`: se simplifica el inventario de eventos/listas ordenables al eliminar el
+  log de `ResourceChange` por `Entry`.
+- `#19`: el plan de pruebas debe cubrir deltas netos por recurso y eliminación
+  de clave al llegar a `0`.
+
+## Casos de aceptación / verificación documental
+
+1. Múltiples taps sobre el mismo recurso en una `Entry` terminan en un único
+   delta neto por `resource_key`.
+1. Si el delta neto llega a `0`, la clave se elimina de `resource_deltas`.
+1. La edición de recursos en weeks `closed` sigue permitida (alineado con `#37`)
+   y mantiene validación de totales no negativos.
+1. `docs/domain-glossary.md` ya no define `ResourceChange` como entidad MVP.
+1. `docs/firestore-operation-contract.md` ya no expone `ResourceChange.*` y
+   define operaciones sobre `Entry.resource_deltas`.
+1. `docs/conflict-policy.md` modela conflictos de recursos sobre `Entry` (más
+   totales derivados), no sobre `ResourceChange`.
+1. Tras cerrar esta decisión, `#18` vuelve a quedar como siguiente paso técnico
+   recomendado.
+
+## Riesgos, límites y decisiones diferidas
+
+- Se pierde historial detallado intra-entry de cambios de recursos en favor de
+  simplicidad de edición neta (aceptado en MVP).
+- La estrategia exacta de persistencia/atomicidad Firestore sigue diferida a la
+  implementación.
+- La política de timestamps y orden estable sigue diferida a `#18`.
+
+## Referencias
+
+- `docs/domain-glossary.md`
+- `docs/conflict-policy.md`
+- `docs/firestore-operation-contract.md`
+- `docs/editability-policy.md`
+- `docs/decision-log.md`
+- `docs/mvp-implementation-checklist.md`
+- `docs/mvp-implementation-blocks.md`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/40`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/15`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/18`

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -35,6 +35,8 @@ Este documento permite que una persona o agente nuevo entienda rápidamente:
   - Política de conflictos concurrentes del MVP.
 - `docs/firestore-operation-contract.md`
   - Contrato de operaciones de escritura por agregado del MVP.
+- `docs/resource-delta-model.md`
+  - Modelo de recursos del MVP por `Entry` (`resource_deltas`, delta neto).
 - `docs/campaign-temporal-controls.md`
   - Controles temporales de campaña y provisión/extensión de años del MVP.
 - `docs/campaign-temporal-initialization.md`
@@ -92,6 +94,7 @@ Este documento permite que una persona o agente nuevo entienda rápidamente:
 - Sincronización MVP -> `docs/sync-strategy.md`
 - Conflictos concurrentes MVP -> `docs/conflict-policy.md`
 - Contrato Firestore por agregado -> `docs/firestore-operation-contract.md`
+- Modelo de recursos por `Entry` -> `docs/resource-delta-model.md`
 - Controles temporales de campaña -> `docs/campaign-temporal-controls.md`
 - Inicialización temporal técnica -> `docs/campaign-temporal-initialization.md`
 - Editabilidad manual MVP -> `docs/editability-policy.md`


### PR DESCRIPTION
## Resumen
- redefine el modelo MVP de recursos como `Entry.resource_deltas` (delta neto por `resource_key`)
- elimina `ResourceChange` como entidad MVP en docs oficiales
- parchea la parte de recursos de `docs/firestore-operation-contract.md` (`#12`) por supersesi?n parcial
- actualiza conflictos, glosario, editabilidad y tracking para dejar `#18` como siguiente paso

## Notas
- supersesi?n parcial de la parte de recursos de `DEC-0023` / `#12` sin reabrir la issue
- trabajo documental (sin c?digo de app)

Closes #40
