### PR TITLE
docs(domain): politica de timestamps y orden estable (Issue #18)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,7 @@ Cada interacción termina con un menú numerado fijo de 3 a 5 siguientes pasos.
 - Política de conflictos concurrentes MVP: `docs/conflict-policy.md`
 - Contrato de operaciones Firestore por agregado (MVP): `docs/firestore-operation-contract.md`
 - Modelo de recursos por `Entry` (MVP): `docs/resource-delta-model.md`
+- Política de timestamps y orden estable (MVP): `docs/timestamp-order-policy.md`
 - Controles temporales de campaña: `docs/campaign-temporal-controls.md`
 - Inicialización temporal de campaña (técnica): `docs/campaign-temporal-initialization.md`
 - Política de editabilidad manual MVP: `docs/editability-policy.md`

--- a/docs/conflict-policy.md
+++ b/docs/conflict-policy.md
@@ -150,6 +150,7 @@ No incluye:
 - `docs/decision-log.md`
 - `docs/firestore-operation-contract.md`
 - `docs/resource-delta-model.md`
+- `docs/timestamp-order-policy.md`
 - `tdd.md` (legado temporal, alineado con referencia oficial)
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/8`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -455,3 +455,42 @@
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/40`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/18`
+
+### DEC-0025
+
+- `date`: 2026-02-24
+- `status`: accepted
+- `problem`: faltaba una política oficial de timestamps de auditoría y
+  desempate de orden estable entre dispositivos para evitar divergencias
+  visuales en listas del MVP (timeline, sesiones y selectores), y seguían
+  abiertas decisiones sobre `deleted_at_utc`, orden canónico y reparto
+  query/cliente.
+- `decision`: aceptar `docs/timestamp-order-policy.md` como política oficial de
+  timestamps y orden estable del MVP; usar `created_at_utc` y `updated_at_utc`
+  como timestamps de auditoría **server-only**; eliminar `deleted_at_utc` del
+  MVP (hard delete real); ampliar auditoría temporal a
+  `campaign/year/season/week/entry/session`; actualizar `updated_at_utc` en
+  toda escritura persistida, también derivada/sistémica; definir una matriz de
+  orden canónico por lista (alcance UI + `#16`) con prefijo de query + orden
+  canónico final en cliente; usar desempate final por `document_id`
+  lexicográfico ascendente; priorizar orden de dominio (`week_number`,
+  `order_index`) sobre timestamps cuando exista; y considerar que el orden final
+  con `serverTimestamp` pendiente solo se garantiza tras `refresh`.
+- `rationale`: separa claramente auditoría/orden estable de los contratos por
+  operación (`#12`), reduce ambigüedad para `#16/#17/#19`, y deja reglas
+  trazables para listas de dominio y listas temporales sin adelantar técnica
+  Firestore específica.
+- `impact`: añade `docs/timestamp-order-policy.md` como fuente oficial;
+  actualiza `docs/domain-glossary.md` (auditoría y eliminación de
+  `deleted_at_utc`), `docs/firestore-operation-contract.md` (referencia a la
+  política final de `#18`), y el seguimiento técnico en
+  `docs/mvp-implementation-checklist.md` / `docs/mvp-implementation-blocks.md`;
+  deja `#14` como siguiente paso técnico tras cerrar `#18`.
+- `references`: `docs/timestamp-order-policy.md`, `docs/domain-glossary.md`,
+  `docs/firestore-operation-contract.md`, `docs/conflict-policy.md`,
+  `docs/resource-delta-model.md`, `docs/mvp-implementation-checklist.md`,
+  `docs/mvp-implementation-blocks.md`, `AGENTS.md`, `docs/system-map.md`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/18`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/16`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/40`

--- a/docs/domain-glossary.md
+++ b/docs/domain-glossary.md
@@ -25,10 +25,12 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
     y se recalcula tras operaciones que cambian el estado de `Week`.
 - `resource_totals`: mapa `resource_key -> int` derivado de la suma de
   `Entry.resource_deltas` en la campaña.
+- `created_at_utc`, `updated_at_utc`: auditoría mínima (server-only).
 
 ### Year
 
 - `year_number`: entero positivo.
+- `created_at_utc`, `updated_at_utc`: auditoría mínima (server-only).
 
 ### Season
 
@@ -36,13 +38,14 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
 - `year_number`: entero positivo.
 - En castellano, `season` se traduce como **estación** (`verano|invierno`), no
   “temporada”.
+- `created_at_utc`, `updated_at_utc`: auditoría mínima (server-only).
 
 ### Week
 
 - `week_number`: entero global `1..N`, inmutable y trazable.
 - `status`: `open|closed`.
 - `notes`: texto opcional.
-- `created_at_utc`, `updated_at_utc`, `deleted_at_utc`: auditoría mínima.
+- `created_at_utc`, `updated_at_utc`: auditoría mínima (server-only).
 
 ### Entry
 
@@ -54,14 +57,14 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
 - `scenario_ref`: entero positivo obligatorio cuando `type=scenario`.
 - `resource_deltas`: mapa `resource_key -> int` (delta neto por recurso en la
   `Entry`; solo claves con delta `!= 0`, ausencia de clave = `0`).
-- `created_at_utc`, `updated_at_utc`, `deleted_at_utc`: auditoría mínima.
+- `created_at_utc`, `updated_at_utc`: auditoría mínima (server-only).
 
 ### Session
 
 - Cuelga de una `Entry` (owner implícito por ruta, sin `owner_type`).
 - `started_at_utc`: timestamp UTC.
 - `ended_at_utc`: timestamp UTC o `null` si está activa.
-- `created_at_utc`, `updated_at_utc`, `deleted_at_utc`: auditoría mínima.
+- `created_at_utc`, `updated_at_utc`: auditoría mínima (server-only).
 
 ## Recursos MVP (`resource_key`)
 
@@ -102,6 +105,8 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
   semanas por estación se define en `docs/campaign-temporal-initialization.md`.
 - La política de editabilidad manual y correcciones de estado/sesiones se define
   en `docs/editability-policy.md`.
+- La política de timestamps de auditoría y orden estable se define en
+  `docs/timestamp-order-policy.md`.
 
 ## Invariantes operativas cerradas
 
@@ -132,6 +137,8 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
 ## Casos borde y validación
 
 1. Se reconstruye owner de `Session` únicamente por ruta.
+1. `created_at_utc` y `updated_at_utc` son server-only en las entidades
+   auditadas del MVP; no se usa `deleted_at_utc`.
 1. Cambios en semanas históricas no alteran `week_number`.
 1. Crear `Entry` tipo `scenario` sin `scenario_ref` debe rechazarse.
 1. Crear `Entry` tipo `outpost` sin campos extra debe aceptarse.

--- a/docs/firestore-operation-contract.md
+++ b/docs/firestore-operation-contract.md
@@ -32,7 +32,8 @@ No incluye:
 - implementación concreta en Firestore (transacciones, batch, técnica de
   precondiciones);
 - consultas/lecturas (`#16`);
-- timestamps/desempates de orden estable (`#18`);
+- timestamps/desempates de orden estable (se definen en
+  `docs/timestamp-order-policy.md`, Issue `#18`);
 - diseño de UI o flujos de pantalla (`#14`, `#16`);
 - código de app.
 
@@ -44,6 +45,7 @@ No incluye:
 - `docs/campaign-temporal-initialization.md` (Issue `#13`)
 - `docs/editability-policy.md` (Issue `#37`)
 - `docs/resource-delta-model.md` (Issue `#40`, supersesión parcial de recursos)
+- `docs/timestamp-order-policy.md` (Issue `#18`)
 - `docs/domain-glossary.md`
 
 ## Convenciones del contrato
@@ -230,7 +232,9 @@ Operaciones compuestas mínimas:
 
 - La técnica exacta para garantizar atomicidad en Firestore queda diferida a la
   implementación.
-- La política de timestamps y desempate estable sigue diferida a `#18`.
+- La política de timestamps y desempate estable se define en
+  `docs/timestamp-order-policy.md` (Issue `#18`) y este contrato no la
+  reespecifica.
 - El contrato no define lecturas ni consultas (`#16`).
 - La parte de recursos de este contrato fue parcialmente supersedida por
   `docs/resource-delta-model.md` (Issue `#40`) y parcheada con operaciones
@@ -247,6 +251,7 @@ Operaciones compuestas mínimas:
 - `docs/campaign-temporal-initialization.md`
 - `docs/editability-policy.md`
 - `docs/resource-delta-model.md`
+- `docs/timestamp-order-policy.md`
 - `docs/decision-log.md`
 - `docs/mvp-implementation-checklist.md`
 - `docs/mvp-implementation-blocks.md`
@@ -254,3 +259,4 @@ Operaciones compuestas mínimas:
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/13`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/40`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/18`

--- a/docs/mvp-implementation-blocks.md
+++ b/docs/mvp-implementation-blocks.md
@@ -538,14 +538,14 @@ No incluye:
 
 ## Seguimiento de bloques
 
-### Estado de bloques (actualizado tras cerrar #13, #37, #12 y #40)
+### Estado de bloques (actualizado tras cerrar #13, #37, #12, #40 y #18)
 
 - [x] `#11` Desglose en bloques ejecutables (este documento)
 - [x] `#13` Inicialización temporal detallada (`ready`)
 - [x] `#37` Política de editabilidad manual y correcciones de dominio (`ready`)
 - [x] `#12` Contrato Firestore por agregado (`draftable`)
 - [x] `#40` Modelo de recursos por `Entry` (delta neto; `draftable`)
-- [ ] `#18` Timestamps y orden estable (`draftable`)
+- [x] `#18` Timestamps y orden estable (`draftable`)
 - [ ] `#14` Flujo de sesión activa y `auto-stop` (`draftable`)
 - [ ] `#15` Validación y recálculo de recursos (`draftable`)
 - [ ] `#16` Consultas mínimas para timeline/foco (`draftable`)
@@ -555,7 +555,6 @@ No incluye:
 
 ### Próxima secuencia técnica esperada (según orden actual)
 
-1. `#18`
 1. `#14`
 1. `#15`
 1. `#16`
@@ -573,6 +572,7 @@ No incluye:
 - `docs/conflict-policy.md`
 - `docs/firestore-operation-contract.md`
 - `docs/resource-delta-model.md`
+- `docs/timestamp-order-policy.md`
 - `docs/campaign-temporal-controls.md`
 - `docs/campaign-temporal-initialization.md`
 - `docs/editability-policy.md`

--- a/docs/mvp-implementation-checklist.md
+++ b/docs/mvp-implementation-checklist.md
@@ -31,7 +31,7 @@ No incluye:
 - codificación de la app;
 - desglose fino en bloques ejecutables con responsables y entregables (Issue #11);
 - gate final de "listo para codificar" (Issue #20);
-- cierre de decisiones de dominio pendientes (por ejemplo #18).
+- cierre de decisiones de dominio pendientes (si las hay).
 
 ## Entradas ya cerradas (prerrequisitos disponibles)
 
@@ -59,6 +59,10 @@ este checklist:
   `docs/resource-delta-model.md`
   - `ResourceChange` se sustituye por `Entry.resource_deltas` (delta neto por
     recurso), con supersesión parcial de la parte de recursos en `#12`.
+- **Política de timestamps y orden estable** (Issue #18):
+  `docs/timestamp-order-policy.md`
+  - auditoría temporal server-only, sin `deleted_at_utc` en MVP, y matriz de
+    orden canónico por lista para UI + `#16`.
 
 ## Corte de responsabilidades entre `#10`, `#11` y `#20`
 
@@ -207,7 +211,7 @@ Usar esta plantilla mínima en cada issue/bloque del checklist:
 - [x] Política de editabilidad manual y correcciones de dominio (Issue #37)
 - [x] Contrato de operaciones Firestore por agregado (Issue #12)
 - [x] Modelo de recursos por `Entry` (delta neto; Issue #40)
-- [ ] Política de timestamps y orden estable (Issue #18)
+- [x] Política de timestamps y orden estable (Issue #18)
 - [ ] Flujo de sesión activa y `auto-stop` (Issue #14)
 - [ ] Reglas de validación y recálculo de recursos (Issue #15)
 - [ ] Consultas mínimas para timeline/foco (Issue #16)
@@ -225,6 +229,7 @@ Usar esta plantilla mínima en cada issue/bloque del checklist:
 - `docs/conflict-policy.md`
 - `docs/firestore-operation-contract.md`
 - `docs/resource-delta-model.md`
+- `docs/timestamp-order-policy.md`
 - `docs/campaign-temporal-controls.md`
 - `docs/campaign-temporal-initialization.md`
 - `docs/editability-policy.md`

--- a/docs/resource-delta-model.md
+++ b/docs/resource-delta-model.md
@@ -162,8 +162,8 @@ Se sustituyen operaciones `ResourceChange.*` por operaciones sobre
    define operaciones sobre `Entry.resource_deltas`.
 1. `docs/conflict-policy.md` modela conflictos de recursos sobre `Entry` (más
    totales derivados), no sobre `ResourceChange`.
-1. Tras cerrar esta decisión, `#18` vuelve a quedar como siguiente paso técnico
-   recomendado.
+1. La decisión deja a `#18` (timestamps y orden estable) con menor ambigüedad
+   de inventario, al eliminar el log `ResourceChange` del MVP.
 
 ## Riesgos, límites y decisiones diferidas
 
@@ -171,7 +171,8 @@ Se sustituyen operaciones `ResourceChange.*` por operaciones sobre
   simplicidad de edición neta (aceptado en MVP).
 - La estrategia exacta de persistencia/atomicidad Firestore sigue diferida a la
   implementación.
-- La política de timestamps y orden estable sigue diferida a `#18`.
+- La política de timestamps y orden estable se define en
+  `docs/timestamp-order-policy.md` (Issue `#18`).
 
 ## Referencias
 
@@ -179,6 +180,7 @@ Se sustituyen operaciones `ResourceChange.*` por operaciones sobre
 - `docs/conflict-policy.md`
 - `docs/firestore-operation-contract.md`
 - `docs/editability-policy.md`
+- `docs/timestamp-order-policy.md`
 - `docs/decision-log.md`
 - `docs/mvp-implementation-checklist.md`
 - `docs/mvp-implementation-blocks.md`

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -37,6 +37,8 @@ Este documento permite que una persona o agente nuevo entienda rápidamente:
   - Contrato de operaciones de escritura por agregado del MVP.
 - `docs/resource-delta-model.md`
   - Modelo de recursos del MVP por `Entry` (`resource_deltas`, delta neto).
+- `docs/timestamp-order-policy.md`
+  - Política de timestamps de auditoría y orden estable entre dispositivos.
 - `docs/campaign-temporal-controls.md`
   - Controles temporales de campaña y provisión/extensión de años del MVP.
 - `docs/campaign-temporal-initialization.md`
@@ -95,6 +97,7 @@ Este documento permite que una persona o agente nuevo entienda rápidamente:
 - Conflictos concurrentes MVP -> `docs/conflict-policy.md`
 - Contrato Firestore por agregado -> `docs/firestore-operation-contract.md`
 - Modelo de recursos por `Entry` -> `docs/resource-delta-model.md`
+- Timestamps y orden estable -> `docs/timestamp-order-policy.md`
 - Controles temporales de campaña -> `docs/campaign-temporal-controls.md`
 - Inicialización temporal técnica -> `docs/campaign-temporal-initialization.md`
 - Editabilidad manual MVP -> `docs/editability-policy.md`

--- a/docs/timestamp-order-policy.md
+++ b/docs/timestamp-order-policy.md
@@ -1,0 +1,212 @@
+# Política de Timestamps y Orden Estable entre Dispositivos (MVP)
+
+## Metadatos
+
+- `doc_id`: DOC-TIMESTAMP-ORDER-POLICY
+- `purpose`: Definir la política MVP de auditoría temporal y orden estable entre dispositivos (timestamps server-only, reglas de escritura y tuplas canónicas por lista).
+- `status`: active
+- `source_of_truth`: official
+- `last_updated`: 2026-02-24
+- `next_review`: 2026-03-10
+
+## Objetivo
+
+Cerrar una decisión documental oficial para la auditoría temporal del MVP y el
+orden estable entre dispositivos, de forma compatible con sincronización,
+conflictos, contrato de operaciones por agregado y modelo de recursos vigente.
+
+## Alcance y no alcance
+
+Incluye:
+
+- política de `created_at_utc` / `updated_at_utc` (server-only);
+- reglas de escritura de timestamps en create/update/side-effects/hard delete;
+- matriz explícita de orden canónico por lista (alcance UI + consultas mínimas
+  de `#16`);
+- manejo de timestamps pendientes (`serverTimestamp` no confirmado);
+- alineación con `#12`, `#16`, `#40` y `docs/domain-glossary.md`.
+
+No incluye:
+
+- técnica Firestore exacta para materializar `serverTimestamp`;
+- diseño de queries finales de `#16` (solo reglas de orden y prefijos);
+- UX detallada de indicadores de estado provisional;
+- código de app.
+
+## Entradas y prerrequisitos
+
+- `docs/sync-strategy.md` (Issue `#7`)
+- `docs/conflict-policy.md` (Issue `#8`)
+- `docs/firestore-operation-contract.md` (Issue `#12`)
+- `docs/campaign-temporal-controls.md` (Issue `#9`)
+- `docs/campaign-temporal-initialization.md` (Issue `#13`)
+- `docs/editability-policy.md` (Issue `#37`)
+- `docs/resource-delta-model.md` (Issue `#40`)
+- `docs/domain-glossary.md`
+- `docs/mvp-implementation-checklist.md`
+- `docs/mvp-implementation-blocks.md`
+
+## Decisiones cerradas de esta issue
+
+1. Alcance de matriz de orden: listas visibles del MVP + consultas mínimas de
+   `#16`.
+1. Auditoría temporal: `server-only`.
+1. `deleted_at_utc`: fuera del MVP.
+1. Matriz de orden estable explícita por lista.
+1. Orden canónico: prefijo de query + normalización final en cliente.
+1. Último desempate global: `document_id` lexicográfico ascendente.
+1. Sesiones en listas combinadas: activa primero.
+1. Histórico de sesiones: `started_at_utc` descendente.
+1. Timeline: orden de dominio (`week_number`, `order_index`) primero; timestamps
+   solo como fallback/desempate.
+1. Timestamps pendientes: orden canónico final solo garantizado tras `refresh`.
+1. Auditoría ampliada a `campaign/year/season/week/entry/session`.
+1. Forma de auditoría por entidad: `created_at_utc` + `updated_at_utc` en todas
+   las entidades auditadas.
+1. `updated_at_utc` cambia en toda escritura persistida, también derivada.
+1. La matriz incluye también listas con orden de dominio (timestamps `N/A` o
+   fallback), para dejar `#16` más cerrada.
+
+## Política de auditoría temporal (server-only)
+
+### Regla de origen
+
+- `created_at_utc` y `updated_at_utc` se escriben como timestamps de servidor.
+- El cliente no persiste timestamps “definitivos” locales para auditoría.
+
+### Regla de escritura
+
+1. En creación de documento se escriben `created_at_utc` y `updated_at_utc` en
+   la misma operación lógica.
+1. En actualización se preserva `created_at_utc` y se actualiza
+   `updated_at_utc`.
+1. Si una operación compuesta/derivada modifica un documento (por ejemplo
+   `auto-stop`, recálculo o side-effect), ese documento también actualiza su
+   `updated_at_utc`.
+1. En hard delete no se usa `deleted_at_utc`; el documento se elimina
+   directamente.
+
+## Entidades auditadas y campos por entidad
+
+| entity | created_at_utc | updated_at_utc | deleted_at_utc_mvp | timestamp_fields_adicionales | notas |
+| --- | --- | --- | --- | --- | --- |
+| `campaign` | Sí | Sí | No | `week_cursor` / `resource_totals` son datos, no timestamps | `updated_at_utc` cambia en provisión/extensión y cambios persistidos de campaña |
+| `year` | Sí | Sí | No | Ninguno | Auditoría de documento temporal aunque su mutabilidad sea baja |
+| `season` | Sí | Sí | No | Ninguno | Auditoría de documento temporal aunque su mutabilidad sea baja |
+| `week` | Sí | Sí | No | Ninguno | Incluye cierres/reaperturas y `notes` |
+| `entry` | Sí | Sí | No | Ninguno | Incluye cambios de `resource_deltas` y reordenación si el doc cambia |
+| `session` | Sí | Sí | No | `started_at_utc`, `ended_at_utc` | `started_at_utc`/`ended_at_utc` modelan el intervalo; auditoría es aparte |
+
+## Reglas de escritura de timestamps (create/update/side-effects/hard delete)
+
+| familia_operacion | docs_que_crea | docs_que_actualiza | campos_timestamp_en_create | campos_timestamp_en_update | side_effects_actualizan_updated_at | notas |
+| --- | --- | --- | --- | --- | --- | --- |
+| `Campaign.provision_initial_years` | `campaign` (si aplica), `year`, `season`, `week` | `campaign` | `created_at_utc`, `updated_at_utc` | `updated_at_utc` | Sí | `campaign.updated_at_utc` refleja provisión/ajuste de cursor/totales si cambian |
+| `Campaign.extend_years_plus_one` | `year`, `season`, `week` | `campaign` | `created_at_utc`, `updated_at_utc` | `updated_at_utc` | Sí | Incluye postcondición de `week_cursor` |
+| `Week.*` (`close/reopen/reclose/update_notes`) | Ninguno | `week` (y `session` si `auto-stop`) | N/A | `updated_at_utc` | Sí | `auto-stop` actualiza `session.updated_at_utc` |
+| `Entry.create/update/reorder` | `entry` (create) | `entry` | `created_at_utc`, `updated_at_utc` | `updated_at_utc` | Sí | `reorder` puede afectar múltiples entries; las entries modificadas actualizan `updated_at_utc` |
+| `Entry.resource_deltas` (`adjust/set/clear`) | Ninguno | `entry`, `campaign` | N/A | `updated_at_utc` | Sí | `Entry` y `campaign` actualizan `updated_at_utc` si persisten cambios |
+| `Entry.delete` | Ninguno | `session` (auto-stop previo, si aplica) | N/A | `updated_at_utc` (en la sesión antes de borrar) | Sí | Hard delete de `entry` y `session`; sin `deleted_at_utc` |
+| `Session.start/stop/auto_stop/manual_*` | `session` (start/manual_create) | `session` (stop/auto/manual_update) | `created_at_utc`, `updated_at_utc` | `updated_at_utc` | Sí | `started_at_utc`/`ended_at_utc` son campos funcionales del intervalo |
+
+## Política de orden estable (query + cliente)
+
+### Regla general
+
+1. Cada lista define una **tupla canónica de orden**.
+1. La query aplica el prefijo de orden que Firestore puede garantizar.
+1. El cliente completa la tupla canónica y reordena localmente.
+1. El último desempate canónico es `document_id` lexicográfico ascendente.
+
+### Regla de dominio vs timestamp
+
+Cuando exista orden de dominio explícito (por ejemplo `week_number` u
+`order_index`), ese orden es primario. Los timestamps se usan como fallback o
+desempate estable, no como reemplazo del orden funcional del dominio.
+
+## Manejo de timestamps pendientes
+
+- El orden canónico final solo se garantiza con timestamps de servidor ya
+  confirmados.
+- Antes de confirmación puede existir estado/lista provisional en UI.
+- Tras `refresh`, el cliente reaplica la tupla canónica final.
+- Esta política no obliga a ocultar elementos pendientes; solo evita prometer
+  estabilidad final antes del `refresh`.
+
+## Matriz de listas y tuplas canónicas
+
+| logical_list_id | uso_ui_o_lectura | query_order_prefix | client_canonical_tuple | timestamp_role | null_handling | pending_timestamp_behavior | notas |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `year_selector_list` | Selector temporal de año (UI) | `year_number ASC` (si aplica) | `(year_number ASC)` | `N/A` | `N/A` | `N/A` | Lista de dominio |
+| `season_list_within_year` | Navegación/estructura dentro de año | Sin prefijo natural útil por orden semántico | `(season_rank ASC, season_type ASC)` con `summer=0`, `winter=1` | `N/A` | `N/A` | `N/A` | Orden canónico fijo `summer -> winter` |
+| `week_selector_list` | Selector temporal de semana (UI) | `week_number ASC` | `(week_number ASC)` | `N/A` | `N/A` | `N/A` | Lista de dominio |
+| `timeline_week_groups` | Grupos/secciones de week en timeline | `week_number ASC` | `(week_number ASC)` | `N/A` | `N/A` | `N/A` | Compatible con `#16` |
+| `week_entries_list` | Lista de entries de una `Week` (panel foco / selector de entry) | `order_index ASC` | `(order_index ASC, created_at_utc ASC, entry_id ASC)` | Fallback/desempate | `N/A` | `created_at_utc` pendiente puede dar orden provisional hasta `refresh` | `updated_at_utc` no se usa para evitar drift visual por ediciones no relacionadas con orden |
+| `timeline_entries_flat` | Timeline aplanado multi-week (si `#16` lo define) | Prefijo máximo posible según query de `#16` | `(week_number ASC, order_index ASC, created_at_utc ASC, entry_id ASC)` | Fallback/desempate | `N/A` | `created_at_utc` pendiente => orden provisional | Lista condicional según diseño de `#16` |
+| `entry_sessions_combined_list` | Sesiones de una `Entry` (activa + histórico) | `started_at_utc DESC` | `(is_active DESC, started_at_utc DESC, updated_at_utc DESC, session_id ASC)` | Principal + desempate | `ended_at_utc = null` => `is_active=1` | timestamps pendientes => orden provisional hasta `refresh` | Activa primero por regla de dominio |
+| `entry_sessions_history_list` | Histórico de sesiones (sin activa o filtrando activas) | `started_at_utc DESC` | `(started_at_utc DESC, updated_at_utc DESC, session_id ASC)` | Principal + desempate | `N/A` | timestamps pendientes => orden provisional hasta `refresh` | Histórico descendente |
+
+## Alineación con #12, #16 y #40
+
+### `#12` (`docs/firestore-operation-contract.md`)
+
+- `#12` sigue definiendo contrato por operación (pre/post/rechazos/atomicidad).
+- `#18` define auditoría temporal y orden estable por lista.
+- `#12` debe referenciar este documento y dejar de decir que la política de
+  timestamps/desempates está “diferida”.
+
+### `#16` (consultas mínimas)
+
+- `#16` queda desbloqueada con una matriz de orden explícita por lista.
+- `#16` puede centrarse en inventario de consultas, paginación y coste,
+  reutilizando las tuplas canónicas definidas aquí.
+
+### `#40` (modelo de recursos por `Entry`)
+
+- No existe log `ResourceChange` en el MVP activo.
+- `#18` no necesita inventariar listas/eventos de `ResourceChange`.
+- Los cambios de recursos quedan cubiertos por auditoría/orden del documento
+  `Entry` cuando el contexto de UI lo requiera.
+
+## Casos de aceptación / verificación documental
+
+1. La política elimina `deleted_at_utc` del MVP y documenta hard delete sin
+   soft delete.
+1. `Campaign`, `Year`, `Season`, `Week`, `Entry` y `Session` quedan con
+   `created_at_utc` + `updated_at_utc`.
+1. `updated_at_utc` se actualiza también en side-effects (`auto-stop`,
+   recálculos, etc.) cuando el documento cambia persistentemente.
+1. Las listas de dominio (`year/season/week`) tienen orden canónico explícito
+   aunque no usen timestamps como criterio principal.
+1. El timeline de entries usa orden de dominio primero (`week_number`,
+   `order_index`) y timestamps solo como fallback/desempate.
+1. La lista combinada de sesiones pone la activa primero y mantiene histórico
+   estable con desempates.
+1. Los timestamps pendientes solo garantizan orden provisional hasta `refresh`.
+1. `#12`, `#16` y `#40` quedan alineadas sin contradicciones de orden/timestamps.
+
+## Riesgos, límites y decisiones diferidas
+
+- La técnica exacta para resolver `serverTimestamp` pendiente en la UI queda a
+  implementación.
+- La forma exacta de índices/`orderBy` en Firestore se concreta en `#16` y
+  código.
+- La paginación real de listas largas (si aplica) se define en `#16`.
+
+## Referencias
+
+- `docs/domain-glossary.md`
+- `docs/sync-strategy.md`
+- `docs/conflict-policy.md`
+- `docs/firestore-operation-contract.md`
+- `docs/campaign-temporal-controls.md`
+- `docs/campaign-temporal-initialization.md`
+- `docs/editability-policy.md`
+- `docs/resource-delta-model.md`
+- `docs/decision-log.md`
+- `docs/mvp-implementation-checklist.md`
+- `docs/mvp-implementation-blocks.md`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/18`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/16`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/40`


### PR DESCRIPTION
## Resumen
- cierra la decisi?n de timestamps de auditor?a (server-only) y orden estable entre dispositivos
- elimina `deleted_at_utc` del MVP en la documentaci?n oficial
- a?ade matriz de orden can?nico por lista (UI + `#16`)
- alinea glosario, contrato Firestore (`#12`), tracking y decision log

## Validaci?n
- `git diff --check`

Closes #18
