### PR TITLE
docs(resources): validacion y recalculo de recursos (Issue #15)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,7 @@ Cada interacción termina con un menú numerado fijo de 3 a 5 siguientes pasos.
 - Política de conflictos concurrentes MVP: `docs/conflict-policy.md`
 - Contrato de operaciones Firestore por agregado (MVP): `docs/firestore-operation-contract.md`
 - Modelo de recursos por `Entry` (MVP): `docs/resource-delta-model.md`
+- Reglas de validación y recálculo de recursos (MVP): `docs/resource-validation-recalculation.md`
 - Política de timestamps y orden estable (MVP): `docs/timestamp-order-policy.md`
 - Flujo de sesión activa y `auto-stop` (MVP): `docs/active-session-flow.md`
 - Controles temporales de campaña: `docs/campaign-temporal-controls.md`

--- a/docs/conflict-policy.md
+++ b/docs/conflict-policy.md
@@ -140,6 +140,9 @@ No incluye:
 - **Issue #40**: redefine el modelo de recursos del MVP como
   `Entry.resource_deltas` (sin entidad `ResourceChange`) y actualiza la matriz
   de conflictos de recursos sobre `Entry`.
+- **Issue #15**: detalla validación y recálculo de recursos (`Entry.resource_deltas`
+  y `campaign.resource_totals`) y alinea la clasificación de rechazos sobre
+  recursos con esta política.
 - **Issue #18**: define timestamps y desempates de orden estable entre
   dispositivos, compatibles con esta política.
 
@@ -150,10 +153,12 @@ No incluye:
 - `docs/decision-log.md`
 - `docs/firestore-operation-contract.md`
 - `docs/resource-delta-model.md`
+- `docs/resource-validation-recalculation.md`
 - `docs/timestamp-order-policy.md`
 - `tdd.md` (legado temporal, alineado con referencia oficial)
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/8`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/40`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/15`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/18`

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -529,3 +529,42 @@
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/18`
+
+### DEC-0027
+
+- `date`: 2026-02-24
+- `status`: accepted
+- `problem`: faltaban reglas documentales explícitas para validar operaciones
+  sobre `Entry.resource_deltas` y recalcular `campaign.resource_totals` de forma
+  consistente, con clasificación clara de rechazos (`validacion` vs
+  `conflicto`) y manejo de correcciones/borrados tras el cambio de modelo de
+  recursos de `#40`.
+- `decision`: aceptar `docs/resource-validation-recalculation.md` como contrato
+  oficial de validación y recálculo de recursos del MVP; cubrir
+  `Entry.adjust_resource_delta`, `Entry.set_resource_delta`,
+  `Entry.clear_resource_delta` y el impacto de recursos de `Entry.delete`;
+  validar `resource_key` contra catálogo MVP, deltas enteros y no negatividad
+  de totales finales; definir equivalencia de resultado con recálculo desde
+  `Entry.resource_deltas`; normalizar claves con valor `0` fuera de
+  `entry.resource_deltas` y `campaign.resource_totals`; aceptar `clear` de clave
+  inexistente y no-ops triviales (`adjust=0`, `set` al mismo valor) como
+  idempotentes; y clasificar inconsistencias detectadas de base/totales como
+  `conflicto` para forzar `refrescar + reintentar`.
+- `rationale`: completa el detalle que `#12` dejó a nivel de contrato de
+  comportamiento y que `#40` dejó a nivel de modelo, reduce ambigüedad para
+  `#17/#19/#20` y mantiene coherencia con la política estricta de conflictos de
+  `#8`.
+- `impact`: añade `docs/resource-validation-recalculation.md` como fuente
+  oficial; actualiza referencias en glosario, conflictos, contrato Firestore y
+  modelo de recursos; actualiza tracking en `docs/mvp-implementation-checklist.md`
+  y `docs/mvp-implementation-blocks.md`; deja `#16` como siguiente paso técnico.
+- `references`: `docs/resource-validation-recalculation.md`,
+  `docs/domain-glossary.md`, `docs/conflict-policy.md`,
+  `docs/firestore-operation-contract.md`, `docs/resource-delta-model.md`,
+  `docs/editability-policy.md`, `docs/mvp-implementation-checklist.md`,
+  `docs/mvp-implementation-blocks.md`, `AGENTS.md`, `docs/system-map.md`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/15`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/8`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/40`

--- a/docs/domain-glossary.md
+++ b/docs/domain-glossary.md
@@ -25,6 +25,7 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
     y se recalcula tras operaciones que cambian el estado de `Week`.
 - `resource_totals`: mapa `resource_key -> int` derivado de la suma de
   `Entry.resource_deltas` en la campaña.
+  - Ausencia de clave = total `0` (normalización de claves `0` fuera del mapa).
 - `created_at_utc`, `updated_at_utc`: auditoría mínima (server-only).
 
 ### Year
@@ -107,6 +108,8 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
   en `docs/editability-policy.md`.
 - La política de timestamps de auditoría y orden estable se define en
   `docs/timestamp-order-policy.md`.
+- Las reglas de validación y recálculo de recursos se definen en
+  `docs/resource-validation-recalculation.md`.
 
 ## Invariantes operativas cerradas
 

--- a/docs/firestore-operation-contract.md
+++ b/docs/firestore-operation-contract.md
@@ -45,6 +45,7 @@ No incluye:
 - `docs/campaign-temporal-initialization.md` (Issue `#13`)
 - `docs/editability-policy.md` (Issue `#37`)
 - `docs/resource-delta-model.md` (Issue `#40`, supersesión parcial de recursos)
+- `docs/resource-validation-recalculation.md` (Issue `#15`, detalle de validación y recálculo de recursos)
 - `docs/timestamp-order-policy.md` (Issue `#18`)
 - `docs/domain-glossary.md`
 
@@ -238,7 +239,9 @@ Operaciones compuestas mínimas:
 - El contrato no define lecturas ni consultas (`#16`).
 - La parte de recursos de este contrato fue parcialmente supersedida por
   `docs/resource-delta-model.md` (Issue `#40`) y parcheada con operaciones
-  sobre `Entry.resource_deltas`.
+  sobre `Entry.resource_deltas`; el detalle de validación y recálculo de
+  recursos se especifica en `docs/resource-validation-recalculation.md`
+  (Issue `#15`).
 - La UX exacta para errores de conflicto vs transición inválida se concreta en
   issues de flujo (`#14`) y UI.
 
@@ -251,6 +254,7 @@ Operaciones compuestas mínimas:
 - `docs/campaign-temporal-initialization.md`
 - `docs/editability-policy.md`
 - `docs/resource-delta-model.md`
+- `docs/resource-validation-recalculation.md`
 - `docs/timestamp-order-policy.md`
 - `docs/decision-log.md`
 - `docs/mvp-implementation-checklist.md`
@@ -259,4 +263,5 @@ Operaciones compuestas mínimas:
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/13`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/40`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/15`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/18`

--- a/docs/mvp-implementation-blocks.md
+++ b/docs/mvp-implementation-blocks.md
@@ -538,7 +538,7 @@ No incluye:
 
 ## Seguimiento de bloques
 
-### Estado de bloques (actualizado tras cerrar #13, #37, #12, #40, #18 y #14)
+### Estado de bloques (actualizado tras cerrar #13, #37, #12, #40, #18, #14 y #15)
 
 - [x] `#11` Desglose en bloques ejecutables (este documento)
 - [x] `#13` Inicialización temporal detallada (`ready`)
@@ -547,7 +547,7 @@ No incluye:
 - [x] `#40` Modelo de recursos por `Entry` (delta neto; `draftable`)
 - [x] `#18` Timestamps y orden estable (`draftable`)
 - [x] `#14` Flujo de sesión activa y `auto-stop` (`draftable`)
-- [ ] `#15` Validación y recálculo de recursos (`draftable`)
+- [x] `#15` Validación y recálculo de recursos (`draftable`)
 - [ ] `#16` Consultas mínimas para timeline/foco (`draftable`)
 - [ ] `#17` Matriz de edge cases (`draftable`)
 - [ ] `#19` Plan de pruebas de invariantes (`draftable`)
@@ -555,7 +555,6 @@ No incluye:
 
 ### Próxima secuencia técnica esperada (según orden actual)
 
-1. `#15`
 1. `#16`
 1. `#17`
 1. `#19`
@@ -571,6 +570,7 @@ No incluye:
 - `docs/conflict-policy.md`
 - `docs/firestore-operation-contract.md`
 - `docs/resource-delta-model.md`
+- `docs/resource-validation-recalculation.md`
 - `docs/timestamp-order-policy.md`
 - `docs/active-session-flow.md`
 - `docs/campaign-temporal-controls.md`

--- a/docs/mvp-implementation-checklist.md
+++ b/docs/mvp-implementation-checklist.md
@@ -67,6 +67,10 @@ este checklist:
   `docs/active-session-flow.md`
   - separación entre `current week`, selección y `Entry` activa; reglas de
     `start/stop/auto-stop` y recuperación por `conflicto`/`transicion_invalida`.
+- **Validación y recálculo de recursos** (Issue #15):
+  `docs/resource-validation-recalculation.md`
+  - reglas por operación (`adjust/set/clear`), recálculo de `campaign.resource_totals`
+    y clasificación de rechazos de recursos.
 
 ## Corte de responsabilidades entre `#10`, `#11` y `#20`
 
@@ -217,7 +221,7 @@ Usar esta plantilla mínima en cada issue/bloque del checklist:
 - [x] Modelo de recursos por `Entry` (delta neto; Issue #40)
 - [x] Política de timestamps y orden estable (Issue #18)
 - [x] Flujo de sesión activa y `auto-stop` (Issue #14)
-- [ ] Reglas de validación y recálculo de recursos (Issue #15)
+- [x] Reglas de validación y recálculo de recursos (Issue #15)
 - [ ] Consultas mínimas para timeline/foco (Issue #16)
 - [ ] Matriz de edge cases de concurrencia y sincronización (Issue #17)
 - [ ] Plan de pruebas para invariantes (Issue #19)
@@ -233,6 +237,7 @@ Usar esta plantilla mínima en cada issue/bloque del checklist:
 - `docs/conflict-policy.md`
 - `docs/firestore-operation-contract.md`
 - `docs/resource-delta-model.md`
+- `docs/resource-validation-recalculation.md`
 - `docs/timestamp-order-policy.md`
 - `docs/active-session-flow.md`
 - `docs/campaign-temporal-controls.md`

--- a/docs/resource-delta-model.md
+++ b/docs/resource-delta-model.md
@@ -142,7 +142,8 @@ Se sustituyen operaciones `ResourceChange.*` por operaciones sobre
 ## Impacto en issues downstream (`#15`, `#17`, `#18`, `#19`)
 
 - `#15`: debe definir reglas de validación y recálculo sobre
-  `Entry.resource_deltas`, no sobre `ResourceChange`.
+  `Entry.resource_deltas`, no sobre `ResourceChange` (cerrado en
+  `docs/resource-validation-recalculation.md`).
 - `#17`: sustituir edge cases de concurrencia sobre `ResourceChange` por casos
   de edición concurrente de `Entry.resource_deltas`.
 - `#18`: se simplifica el inventario de eventos/listas ordenables al eliminar el
@@ -179,6 +180,7 @@ Se sustituyen operaciones `ResourceChange.*` por operaciones sobre
 - `docs/domain-glossary.md`
 - `docs/conflict-policy.md`
 - `docs/firestore-operation-contract.md`
+- `docs/resource-validation-recalculation.md`
 - `docs/editability-policy.md`
 - `docs/timestamp-order-policy.md`
 - `docs/decision-log.md`

--- a/docs/resource-validation-recalculation.md
+++ b/docs/resource-validation-recalculation.md
@@ -1,0 +1,277 @@
+# Reglas de Validación y Recálculo de Recursos (MVP)
+
+## Metadatos
+
+- `doc_id`: DOC-RESOURCE-VALIDATION-RECALCULATION
+- `purpose`: Definir las reglas del MVP para validar operaciones sobre `Entry.resource_deltas` y recalcular/consistir `campaign.resource_totals` sin permitir totales finales negativos.
+- `status`: active
+- `source_of_truth`: official
+- `last_updated`: 2026-02-24
+- `next_review`: 2026-03-10
+
+## Objetivo
+
+Cerrar las reglas documentales de validación y recálculo de recursos del MVP
+para que las operaciones sobre `Entry.resource_deltas` produzcan resultados
+trazables, consistentes y alineados con concurrencia (`#8`), contrato por
+agregado (`#12`) y modelo embebido de recursos (`#40`).
+
+## Alcance y no alcance
+
+Incluye:
+
+- inventario de operaciones de recursos del MVP (`adjust`, `set`, `clear`);
+- validaciones por operación sobre `Entry.resource_deltas`;
+- estrategia de recálculo y consistencia de `campaign.resource_totals`;
+- reglas de rechazo esperadas y respuesta cliente recomendada;
+- manejo de correcciones/borrados de `Entry` con impacto en recursos;
+- alineación con `#8`, `#12`, `#37`, `#40` y glosario.
+
+No incluye:
+
+- técnica Firestore exacta (transacción, batch, precondiciones técnicas);
+- diseño UI de controles `+/-` o edición manual de recursos;
+- política de timestamps/desempates (`#18`);
+- código de app.
+
+## Entradas y prerrequisitos
+
+- `docs/domain-glossary.md`
+- `docs/conflict-policy.md` (Issue `#8`)
+- `docs/firestore-operation-contract.md` (Issue `#12`)
+- `docs/editability-policy.md` (Issue `#37`)
+- `docs/resource-delta-model.md` (Issue `#40`)
+- `docs/timestamp-order-policy.md` (Issue `#18`)
+- `docs/mvp-implementation-checklist.md`
+- `docs/mvp-implementation-blocks.md`
+
+## Operaciones de recursos cubiertas (MVP)
+
+### Tabla 1 — Inventario de operaciones de recursos (`I15-S1`)
+
+| `operation_id` | `trigger_funcional` | `agregados_afectados` | `resource_key_scope` | `efecto_sobre_totales` | `notas` |
+| --- | --- | --- | --- | --- | --- |
+| `Entry.adjust_resource_delta` | tap `+/-` o ajuste incremental en una `Entry` | `entry`, `campaign` | una `resource_key` | recalcula/ajusta `campaign.resource_totals` para la clave afectada | permitido en weeks `open|closed` |
+| `Entry.set_resource_delta` | edición manual directa del delta neto de un recurso en una `Entry` | `entry`, `campaign` | una `resource_key` | recalcula/ajusta `campaign.resource_totals` para la clave afectada | si valor final `0`, normaliza a `clear` |
+| `Entry.clear_resource_delta` | limpieza explícita del delta neto de un recurso en una `Entry` | `entry`, `campaign` | una `resource_key` | recalcula/ajusta `campaign.resource_totals` para la clave afectada | idempotente si la clave ya no existe |
+| `Entry.delete` (impacto recursos) | borrado de `Entry` (manual) | `entry`, `campaign` (+ `session` por cascada) | todas las claves de `entry.resource_deltas` | elimina la contribución de la `Entry` a `campaign.resource_totals` | `#15` cubre solo la parte de recursos; cascada/auto-stop siguen en `#12` |
+
+## Convenciones y notación de cálculo
+
+1. `resource_key`:
+   - debe pertenecer al catálogo MVP (`docs/domain-glossary.md`);
+   - se trata como clave de mapa.
+1. `entry.resource_deltas[resource_key]`:
+   - ausencia de clave == delta `0`;
+   - no se persisten claves con valor `0`.
+1. `campaign.resource_totals[resource_key]`:
+   - ausencia de clave == total `0`;
+   - en MVP se recomienda normalizar y no persistir claves con total `0`.
+1. Para una operación sobre una clave `k`:
+   - `entry_before = delta neto previo de k en la Entry` (ausencia => `0`)
+   - `entry_after = delta neto resultante de k en la Entry`
+   - `entry_delta_change = entry_after - entry_before`
+   - `campaign_before = total previo de k en campaign.resource_totals` (ausencia => `0`)
+   - `campaign_after = campaign_before + entry_delta_change`
+
+## Reglas de validación por operación
+
+### Tabla 2 — Validaciones y rechazos (`I15-S2`)
+
+| `operation_id` | `payload_requerido` | `validaciones_payload` | `validaciones_dominio` | `rechazos_esperados` | `categoria_rechazo` | `respuesta_cliente_recomendada` | `notas` |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `Entry.adjust_resource_delta` | `entry_id`, `resource_key`, `adjustment_delta` | `resource_key` válida; `adjustment_delta` entero firmado | `campaign_after >= 0`; si `entry_after = 0` se elimina la clave; weeks `open|closed` permitidas | `resource_key` inválida; payload inválido; total final negativo; base obsoleta | `validacion` / `conflicto` | error local si validación; `refrescar + reintentar` si conflicto | `adjustment_delta = 0` se admite como no-op idempotente |
+| `Entry.set_resource_delta` | `entry_id`, `resource_key`, `target_delta` | `resource_key` válida; `target_delta` entero firmado | `campaign_after >= 0`; si `target_delta = 0` normaliza a `clear`; weeks `open|closed` permitidas | `resource_key` inválida; payload inválido; total final negativo; base obsoleta | `validacion` / `conflicto` | error local si validación; `refrescar + reintentar` si conflicto | fijar el mismo valor se admite como no-op idempotente |
+| `Entry.clear_resource_delta` | `entry_id`, `resource_key` | `resource_key` válida | quitar contribución de la `Entry`; `campaign_after >= 0`; weeks `open|closed` permitidas | `resource_key` inválida; total final negativo (si detecta drift); base obsoleta | `validacion` / `conflicto` | error local si validación; `refrescar + reintentar` si conflicto | limpiar clave inexistente es idempotente (sin error) |
+| `Entry.delete` (impacto recursos) | `entry_id` | `entry_id` válida | sustrae todas las contribuciones de la `Entry`; no debe dejar totales negativos; coherencia con borrado/cascada | entry ya borrada; base obsoleta; inconsistencia de totales detectada | `transicion_invalida` / `conflicto` / `validacion` | error local si transición/validación; `refrescar + reintentar` si conflicto | clasificación de cascada/auto-stop se hereda de `#12`; aquí se centra la parte de totales |
+
+### Reglas adicionales de validación
+
+1. No se aceptan `resource_key` fuera del catálogo MVP.
+1. No se aceptan deltas no enteros (float, string, `null`, etc.).
+1. El criterio de validez es el **estado final** de totales:
+   - se permiten deltas negativos en una `Entry`;
+   - se rechaza únicamente si el total global resultante de un recurso queda
+     negativo.
+1. La editabilidad de recursos es válida en weeks `open|closed` (por `#37`);
+   `Week.status=closed` no es rechazo por sí mismo.
+1. La ausencia de clave en `entry.resource_deltas` o `campaign.resource_totals`
+   equivale a valor `0` para cálculo y validación.
+
+## Estrategia de recálculo y consistencia de totales (`I15-S3`)
+
+### Invariante de consistencia (fuente de verdad documental)
+
+Para cada `resource_key` del catálogo MVP:
+
+- `campaign.resource_totals[k] == Σ entry.resource_deltas[k]` sobre todas las
+  `Entry` persistidas de la campaña (tomando ausencia de clave como `0`).
+
+Además:
+
+- ningún total final puede ser negativo;
+- no se persisten claves con total `0` en `campaign.resource_totals` (ausencia =
+  `0`);
+- no se persisten claves fuera del catálogo MVP.
+
+### Estrategia de recálculo (nivel de comportamiento, no técnico)
+
+1. El resultado observable de cualquier operación de recursos debe ser
+   **equivalente** a recalcular `campaign.resource_totals` desde el estado final
+   de `Entry.resource_deltas`.
+1. Para operaciones sobre una sola `resource_key` (`adjust`, `set`, `clear`),
+   el comportamiento esperado puede calcularse con actualización por diferencia
+   de esa clave:
+   - `campaign_after = campaign_before + (entry_after - entry_before)`
+1. Para `Entry.delete`, el comportamiento esperado es sustraer la contribución
+   de **todas** las claves presentes en `entry.resource_deltas` antes del
+   borrado (equivalente a recalcular desde el conjunto de entries restante).
+1. Si el resultado de una clave queda `0`, se elimina la clave del mapa
+   `campaign.resource_totals`.
+1. `#15` no fija si la implementación materializa esto como:
+   - recálculo completo;
+   - actualización incremental por diferencia;
+   - o combinación con checks de consistencia.
+   Solo fija el resultado observable y las validaciones.
+
+### Coherencia con atomicidad de `#12`
+
+1. `#12` ya exige atomicidad de comportamiento para:
+   - `Entry.adjust_resource_delta`
+   - `Entry.set_resource_delta`
+   - `Entry.clear_resource_delta`
+   - `Entry.delete` (incluyendo impacto en recursos por borrar la `Entry`)
+1. `#15` precisa **qué** debe considerarse consistente dentro de ese resultado:
+   - `Entry.resource_deltas` normalizado;
+   - `campaign.resource_totals` consistente;
+   - no negatividad preservada.
+
+## Reglas de rechazo y recuperación (alineación con `#8` y `#12`)
+
+### Tabla 3 — Matriz de rechazos de recursos (`I15-S4`)
+
+| `error_case_id` | `operacion` | `trigger` | `categoria` | `feedback_esperado` | `accion_usuario_recomendada` | `requiere_refresh` | `notas` |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `resource_invalid_key` | `adjust/set/clear` | `resource_key` fuera de catálogo MVP | `validacion` | error local | corregir recurso/entrada | No | payload inválido |
+| `resource_invalid_delta_payload` | `adjust/set` | delta no entero o payload inválido | `validacion` | error local | corregir valor | No | `#15` no define UX concreta |
+| `resource_negative_total_result` | `adjust/set/clear` | el total final del recurso quedaría `< 0` | `validacion` | error local de validación | corregir delta o revisar base | No (por defecto) | si la UI sospecha base obsoleta puede ofrecer refresh manual |
+| `resource_conflict_obsolete_base` | `adjust/set/clear` | base de `Entry`/totales cambió concurrentemente | `conflicto` | error de conflicto | `refrescar + reintentar` | Sí | política estricta de `#8` |
+| `resource_clear_missing_key` | `clear` | la clave ya no existe en la `Entry` | *sin error* | no-op silencioso o feedback neutro | ninguna | No | idempotente por decisión de `#15` |
+| `resource_delete_entry_conflict` | `Entry.delete` (impacto recursos) | entry/totales obsoletos durante borrado | `conflicto` | error de conflicto | `refrescar + reintentar` | Sí | cascada/auto-stop heredados de `#12` |
+| `resource_delete_entry_not_found` | `Entry.delete` (impacto recursos) | entry ya no existe | `transicion_invalida` | error local | refrescar si necesita confirmar estado | No (por defecto) | coherente con `#12` |
+| `resource_inconsistent_totals_detected` | cualquiera | el cálculo detecta drift/imposible preestado | `conflicto` (recomendado) | error de conflicto / estado desincronizado | `refrescar` y reintentar | Sí | si persiste tras refresh, escalar como incidencia de integridad |
+
+### Regla de clasificación
+
+1. `validacion`:
+   - payload inválido o resultado final inválido (totales negativos).
+1. `conflicto`:
+   - base obsoleta o inconsistencia detectada que invalida la confianza en el
+     estado local.
+1. `transicion_invalida`:
+   - solo aplica aquí por efecto heredado de `Entry.delete` cuando la `Entry` ya
+     no existe.
+
+## Manejo de correcciones y borrados (aceptación de la issue)
+
+### Correcciones (`adjust`, `set`, `clear`)
+
+1. Las correcciones de recursos operan sobre `Entry.resource_deltas` (no existe
+   log incremental `ResourceChange` en MVP).
+1. Se permite corregir recursos en weeks `open|closed`.
+1. `set` a `0` y `adjust` que resulta en `0` normalizan a eliminación de clave.
+1. `clear` de clave inexistente es idempotente (sin error).
+
+### Borrado de `Entry`
+
+1. El borrado de `Entry` elimina implícitamente los `resource_deltas` al borrar
+   la `Entry` (modelo embebido de `#40`).
+1. `#15` exige que `campaign.resource_totals` deje de incluir la contribución de
+   esa `Entry` tras el borrado exitoso.
+1. `#15` no redefine la cascada de `sessions` ni el `auto-stop` (quedan en
+   `#12` y `#14`).
+
+## Alineación con documentos oficiales
+
+### `docs/firestore-operation-contract.md` (`#12`)
+
+1. `#12` define operaciones y atomicidad de comportamiento.
+1. `#15` define el detalle de validación y consistencia/re-cálculo esperado de
+   recursos para esas operaciones.
+
+### `docs/resource-delta-model.md` (`#40`)
+
+1. `#40` define el modelo (`Entry.resource_deltas`, delta neto, clave `0`
+   eliminada).
+1. `#15` define cómo validar y recalcular totales globales a partir de ese
+   modelo.
+
+### `docs/conflict-policy.md` (`#8`)
+
+1. `#8` mantiene política estricta de rechazo por conflicto.
+1. `#15` especifica cómo clasificar errores funcionales de recursos vs
+   conflictos e inconsistencias de base.
+
+### `docs/editability-policy.md` (`#37`)
+
+1. `#15` respeta que recursos son editables en weeks `open|closed`.
+1. `#15` no reabre la política de editabilidad; solo la usa como precondición.
+
+## Casos de aceptación / verificación documental
+
+1. `Entry.adjust_resource_delta` con taps repetidos sobre la misma clave calcula
+   un delta neto único y actualiza totales globales de forma consistente.
+1. `Entry.set_resource_delta` con `target_delta = 0` elimina la clave en
+   `entry.resource_deltas` y normaliza `campaign.resource_totals`.
+1. `Entry.clear_resource_delta` sobre clave inexistente es idempotente (sin
+   error).
+1. Se rechaza cualquier operación que deje un total global final negativo.
+1. La validación se hace sobre el estado final, no sobre el signo del delta en
+   sí mismo.
+1. Borrar una `Entry` elimina su contribución de recursos del total global.
+1. Weeks `closed` no bloquean las operaciones de recursos por sí mismas.
+1. Los conflictos de recursos se resuelven con `refrescar + reintentar`.
+1. La documentación deja trazable la diferencia entre:
+   - `validacion` (resultado final inválido);
+   - `conflicto` (base obsoleta/inconsistente);
+   - `transicion_invalida` (solo heredada por `Entry.delete` no encontrada).
+
+## Riesgos, límites y decisiones diferidas
+
+- La técnica exacta para materializar el recálculo (incremental vs recompute
+  completo) queda para implementación; `#15` fija equivalencia de resultado.
+- El comportamiento visual exacto de errores (toast/inline/modal) queda fuera de
+  alcance.
+- El tratamiento de una inconsistencia persistente tras `refresh` (incidencia de
+  integridad) se documenta aquí como escalación conceptual, pero no define
+  tooling operativo.
+
+## Supuestos explícitos (registro)
+
+1. `campaign.resource_totals` usa la misma normalización lógica que
+   `entry.resource_deltas`:
+   - ausencia de clave == `0`;
+   - no persistir claves con valor `0`.
+1. `adjustment_delta = 0` y `set` al mismo valor se aceptan como no-op
+   idempotente para simplificar clientes.
+1. Una inconsistencia detectada de totales/base se clasifica como `conflicto`
+   (no como `validacion`) para forzar `refresh` y evitar operar sobre una base
+   no confiable.
+
+## Referencias
+
+- `AGENTS.md`
+- `docs/domain-glossary.md`
+- `docs/conflict-policy.md`
+- `docs/firestore-operation-contract.md`
+- `docs/resource-delta-model.md`
+- `docs/editability-policy.md`
+- `docs/timestamp-order-policy.md`
+- `docs/decision-log.md`
+- `docs/mvp-implementation-checklist.md`
+- `docs/mvp-implementation-blocks.md`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/15`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/8`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/40`

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -37,6 +37,8 @@ Este documento permite que una persona o agente nuevo entienda rápidamente:
   - Contrato de operaciones de escritura por agregado del MVP.
 - `docs/resource-delta-model.md`
   - Modelo de recursos del MVP por `Entry` (`resource_deltas`, delta neto).
+- `docs/resource-validation-recalculation.md`
+  - Reglas de validación y recálculo de `resource_deltas`/totales globales.
 - `docs/timestamp-order-policy.md`
   - Política de timestamps de auditoría y orden estable entre dispositivos.
 - `docs/active-session-flow.md`
@@ -99,6 +101,7 @@ Este documento permite que una persona o agente nuevo entienda rápidamente:
 - Conflictos concurrentes MVP -> `docs/conflict-policy.md`
 - Contrato Firestore por agregado -> `docs/firestore-operation-contract.md`
 - Modelo de recursos por `Entry` -> `docs/resource-delta-model.md`
+- Validación y recálculo de recursos -> `docs/resource-validation-recalculation.md`
 - Timestamps y orden estable -> `docs/timestamp-order-policy.md`
 - Flujo de sesión activa y `auto-stop` -> `docs/active-session-flow.md`
 - Controles temporales de campaña -> `docs/campaign-temporal-controls.md`


### PR DESCRIPTION
## Resumen
- cierra reglas de validaci?n y rec?lculo para `Entry.resource_deltas` y `campaign.resource_totals`
- documenta operaciones `adjust/set/clear` y el impacto de `Entry.delete`
- alinea rechazos (`validacion/conflicto/transicion_invalida`) con `#8` y `#12`
- actualiza trazabilidad y tracking para dejar `#16` como siguiente

## Validaci?n
- `git diff --cached --check`

Closes #15
