### PR TITLE
docs: corrige defaults de recursos de #15 (totales con clave 0)

### DIFF
--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -568,3 +568,37 @@
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/40`
+
+### DEC-0028
+
+- `date`: 2026-02-24
+- `status`: accepted
+- `problem`: tras cerrar `#15` se detectó que se habían documentado defaults de
+  representación de `campaign.resource_totals` sin revisión explícita de Kiko,
+  dejando una normalización de claves `0` que no coincidía con la intención
+  final del dominio.
+- `decision`: corregir parcialmente `DEC-0027` (sin reabrir `#15`) para que
+  `campaign.resource_totals` conserve claves materializadas con valor `0` cuando
+  una operación las deja en `0`, permitiendo a la vez ausencia de clave para
+  recursos nunca usados; confirmar como contrato oficial que
+  `Entry.adjust_resource_delta(adjustment_delta=0)`, `Entry.set_resource_delta`
+  al mismo valor y `Entry.clear_resource_delta` sobre clave inexistente son
+  no-ops idempotentes; y mantener la clasificación de drift/inconsistencia de
+  base/totales como `conflicto` con `refrescar + reintentar`.
+- `rationale`: preserva la trazabilidad del cierre de `#15` sin reescribir su
+  historial, alinea la representación de totales con la revisión posterior de
+  Kiko y mantiene consistencia con `#8`, `#12` y `#40`.
+- `impact`: actualiza `docs/resource-validation-recalculation.md` y
+  `docs/domain-glossary.md` para reflejar la nueva regla de claves `0` en
+  `campaign.resource_totals`; deja `Entry.resource_deltas` sin cambios
+  (claves `0` no persistidas); y documenta explícitamente la supersesión parcial
+  de `DEC-0027` en este punto.
+- `references`: `docs/resource-validation-recalculation.md`,
+  `docs/domain-glossary.md`, `docs/decision-log.md`,
+  `docs/firestore-operation-contract.md`, `docs/conflict-policy.md`,
+  `docs/resource-delta-model.md`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/45`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/15`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/8`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/40`

--- a/docs/domain-glossary.md
+++ b/docs/domain-glossary.md
@@ -25,7 +25,10 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
     y se recalcula tras operaciones que cambian el estado de `Week`.
 - `resource_totals`: mapa `resource_key -> int` derivado de la suma de
   `Entry.resource_deltas` en la campaña.
-  - Ausencia de clave = total `0` (normalización de claves `0` fuera del mapa).
+  - Ausencia de clave = total `0` para cálculo (las claves nunca usadas pueden
+    permanecer ausentes).
+  - Si una clave materializada queda en `0` tras una operación, se conserva
+    explícitamente con valor `0`.
 - `created_at_utc`, `updated_at_utc`: auditoría mínima (server-only).
 
 ### Year

--- a/docs/resource-validation-recalculation.md
+++ b/docs/resource-validation-recalculation.md
@@ -65,8 +65,10 @@ No incluye:
    - ausencia de clave == delta `0`;
    - no se persisten claves con valor `0`.
 1. `campaign.resource_totals[resource_key]`:
-   - ausencia de clave == total `0`;
-   - en MVP se recomienda normalizar y no persistir claves con total `0`.
+   - ausencia de clave == total `0` para cálculo/validación;
+   - si una clave materializada queda en `0` tras una operación, se conserva
+     explícitamente con valor `0`;
+   - claves nunca usadas pueden permanecer ausentes.
 1. Para una operación sobre una clave `k`:
    - `entry_before = delta neto previo de k en la Entry` (ausencia => `0`)
    - `entry_after = delta neto resultante de k en la Entry`
@@ -110,8 +112,9 @@ Para cada `resource_key` del catálogo MVP:
 Además:
 
 - ningún total final puede ser negativo;
-- no se persisten claves con total `0` en `campaign.resource_totals` (ausencia =
-  `0`);
+- `campaign.resource_totals` puede omitir claves nunca usadas;
+- si una clave materializada queda en `0`, se conserva explícitamente con valor
+  `0`;
 - no se persisten claves fuera del catálogo MVP.
 
 ### Estrategia de recálculo (nivel de comportamiento, no técnico)
@@ -126,8 +129,9 @@ Además:
 1. Para `Entry.delete`, el comportamiento esperado es sustraer la contribución
    de **todas** las claves presentes en `entry.resource_deltas` antes del
    borrado (equivalente a recalcular desde el conjunto de entries restante).
-1. Si el resultado de una clave queda `0`, se elimina la clave del mapa
-   `campaign.resource_totals`.
+1. Si el resultado de una clave queda `0`, se conserva la clave con valor `0`
+   en `campaign.resource_totals` cuando la clave ya estaba materializada; las
+   claves nunca usadas pueden permanecer ausentes.
 1. `#15` no fija si la implementación materializa esto como:
    - recálculo completo;
    - actualización incremental por diferencia;
@@ -222,7 +226,10 @@ Además:
 1. `Entry.adjust_resource_delta` con taps repetidos sobre la misma clave calcula
    un delta neto único y actualiza totales globales de forma consistente.
 1. `Entry.set_resource_delta` con `target_delta = 0` elimina la clave en
-   `entry.resource_deltas` y normaliza `campaign.resource_totals`.
+   `entry.resource_deltas` y aplica la regla de representación de
+   `campaign.resource_totals`:
+   - clave `0` explícita si la clave estaba materializada;
+   - ausencia de clave si no tenía uso previo.
 1. `Entry.clear_resource_delta` sobre clave inexistente es idempotente (sin
    error).
 1. Se rechaza cualquier operación que deje un total global final negativo.
@@ -248,10 +255,12 @@ Además:
 
 ## Supuestos explícitos (registro)
 
-1. `campaign.resource_totals` usa la misma normalización lógica que
-   `entry.resource_deltas`:
-   - ausencia de clave == `0`;
-   - no persistir claves con valor `0`.
+1. `campaign.resource_totals` **no** usa la misma normalización de persistencia
+   que `entry.resource_deltas`:
+   - ausencia de clave == `0` para cálculo/validación;
+   - conservar clave explícita con valor `0` cuando una clave materializada
+     queda en `0`;
+   - las claves nunca usadas pueden permanecer ausentes.
 1. `adjustment_delta = 0` y `set` al mismo valor se aceptan como no-op
    idempotente para simplificar clientes.
 1. Una inconsistencia detectada de totales/base se clasifica como `conflicto`


### PR DESCRIPTION
## Resumen
- corrige la representaci?n de `campaign.resource_totals` para conservar claves `0` materializadas
- mantiene no-ops idempotentes (`adjust=0`, `set` igual, `clear` inexistente)
- a?ade trazabilidad correctiva en `DEC-0028` sin reabrir `#15`

## Contexto
Parche documental posterior a `#15` tras revisi?n expl?cita con Kiko de defaults de dominio que se hab?an cerrado sin consulta.

Closes #45
