### PR TITLE
docs(reads): consultas mínimas de pantalla principal (Issue #16)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,7 @@ Cada interacción termina con un menú numerado fijo de 3 a 5 siguientes pasos.
 - Reglas de validación y recálculo de recursos (MVP): `docs/resource-validation-recalculation.md`
 - Política de timestamps y orden estable (MVP): `docs/timestamp-order-policy.md`
 - Flujo de sesión activa y `auto-stop` (MVP): `docs/active-session-flow.md`
+- Consultas mínimas para pantalla principal (MVP): `docs/minimal-read-queries.md`
 - Controles temporales de campaña: `docs/campaign-temporal-controls.md`
 - Inicialización temporal de campaña (técnica): `docs/campaign-temporal-initialization.md`
 - Política de editabilidad manual MVP: `docs/editability-policy.md`

--- a/docs/active-session-flow.md
+++ b/docs/active-session-flow.md
@@ -46,6 +46,7 @@ No incluye:
 - `docs/firestore-operation-contract.md` (Issue `#12`)
 - `docs/editability-policy.md` (Issue `#37`)
 - `docs/timestamp-order-policy.md` (Issue `#18`)
+- `docs/minimal-read-queries.md` (Issue `#16`)
 - `docs/mvp-implementation-checklist.md`
 - `docs/mvp-implementation-blocks.md`
 
@@ -222,6 +223,17 @@ No incluye:
 1. Cuando el flujo requiere refrescar listas/estado de sesiones tras acciones o
    conflictos, el orden visible se rige por `docs/timestamp-order-policy.md`.
 
+### `#16` — Consultas mínimas de pantalla principal
+
+1. `#14` define el comportamiento observable del flujo (`start/stop/auto-stop`,
+   separación foco/activo y recuperación de errores).
+1. `#16` define las lecturas mínimas que soportan ese flujo en pantalla:
+   - `Q6 active_session_global`;
+   - `Q7 active_entry_doc_if_needed` (condicional);
+   - `Q8 sessions_selected_entry_combined`.
+1. El arranque sin selección (`selected_week`/`selected_entry` vacíos) y la
+   carga diferida de sesiones hasta seleccionar `Entry` se documentan en `#16`.
+
 ## Casos de aceptación / verificación documental
 
 1. `Start` sobre `selected_entry` sin sesión activa global crea sesión activa y
@@ -261,6 +273,7 @@ No incluye:
 - `docs/firestore-operation-contract.md`
 - `docs/editability-policy.md`
 - `docs/timestamp-order-policy.md`
+- `docs/minimal-read-queries.md`
 - `docs/decision-log.md`
 - `docs/mvp-implementation-checklist.md`
 - `docs/mvp-implementation-blocks.md`

--- a/docs/campaign-temporal-controls.md
+++ b/docs/campaign-temporal-controls.md
@@ -96,6 +96,9 @@ No incluye:
 1. El marcador visual de `current week` (derivado de `week_cursor`) y la
    selección `Week`/`Entry` usada por el flujo de sesión se tratan como
    conceptos separados (ver `docs/active-session-flow.md`, Issue `#14`).
+1. Default de arranque de pantalla principal (`#16`): la barra superior se
+   sitúa en el año de `current week`, pero la selección inicial de `Week` y
+   `Entry` es vacía (`none`).
 
 ## Click en semana y selector de entry (patrón + intención)
 
@@ -116,6 +119,9 @@ No incluye:
 - **Issue #14** (o equivalente): detalle del popover de entries y flujo de
   selección/creación de entry desde semana, incluyendo flujo de sesión activa y
   separación entre `current week`, foco y activo (`docs/active-session-flow.md`).
+- **Issue #16**: inventario mínimo de lecturas/consultas de pantalla principal
+  (arranque sin selección, cargas por selección de week/entry y triggers de
+  refresh on-demand).
 - **Issue #12**: contrato de operaciones Firestore por agregado (implementación
   técnica de operaciones como provisión/extensión/cambio de cursor).
 - **Issue #37**: política de editabilidad manual del MVP y semántica derivada de
@@ -129,9 +135,11 @@ No incluye:
 - `docs/decision-log.md`
 - `docs/editability-policy.md`
 - `docs/active-session-flow.md`
+- `docs/minimal-read-queries.md`
 - `tdd.md` (legado temporal, alineado con referencia oficial)
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/9`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/16`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/13`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/14`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -602,3 +602,32 @@
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/8`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/40`
+
+### DEC-0029
+
+- `date`: 2026-02-24
+- `status`: accepted
+- `problem`: faltaba una especificación oficial y trazable de consultas mínimas
+  para la pantalla principal del MVP, y `#16` seguía descrita en términos de
+  "timeline/panel de foco" sin cerrar el inventario de lecturas por superficie,
+  triggers de carga y compatibilidad con `#18`.
+- `decision`: aceptar `docs/minimal-read-queries.md` como contrato oficial de
+  lecturas mínimas de pantalla principal para el MVP (`#16`), fijando:
+  Figma compartido por Kiko como canon de layout/superficies para esta issue;
+  arranque sin `Week`/`Entry` seleccionada (barra en el año de `current week`);
+  inventario de consultas Q1..Q8; carga diferida de sesiones hasta selección de
+  `Entry`; y ausencia de paginación en MVP.
+- `rationale`: reduce ambigüedad entre layout heredado (`tdd.md`) y diseño
+  actual, alinea lecturas con `#9`, `#14`, `#15`, `#18` y `#12`, y deja una
+  base ejecutable para implementación sin listeners realtime ni sobrecargar el
+  modelo con lecturas innecesarias.
+- `impact`: cierra `#16`; actualiza tracking y trazabilidad (`AGENTS.md`,
+  `docs/system-map.md`, checklist y blocks); y añade referencias cruzadas en
+  docs temporales/flujo/orden para que `#17` y `#19` usen el mismo contrato de
+  lectura.
+- `references`: `docs/minimal-read-queries.md`, `docs/timestamp-order-policy.md`,
+  `docs/campaign-temporal-controls.md`, `docs/active-session-flow.md`,
+  `docs/firestore-operation-contract.md`, `docs/decision-log.md`,
+  `docs/mvp-implementation-checklist.md`, `docs/mvp-implementation-blocks.md`,
+  `AGENTS.md`, `docs/system-map.md`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/16`

--- a/docs/minimal-read-queries.md
+++ b/docs/minimal-read-queries.md
@@ -1,0 +1,384 @@
+# Consultas Mínimas para Pantalla Principal (MVP)
+
+## Metadatos
+
+- `doc_id`: DOC-MINIMAL-READ-QUERIES
+- `purpose`: Definir el inventario mínimo de lecturas/consultas para la pantalla principal del MVP (superficies visibles, triggers, orden y límites de carga).
+- `status`: active
+- `source_of_truth`: official
+- `last_updated`: 2026-02-24
+- `next_review`: 2026-03-10
+
+## Objetivo
+
+Cerrar un contrato documental de lecturas mínimas para la pantalla principal
+del MVP que permita implementar la UI con consultas suficientes, orden estable
+y límites explícitos de coste/latencia, sin adelantar código ni detalles
+técnicos de Firestore que no pertenecen a esta issue.
+
+## Alcance y no alcance
+
+Incluye:
+
+- inventario de superficies de pantalla y estados relevantes para lecturas;
+- consultas mínimas necesarias por superficie/estado;
+- campos mínimos lógicos por consulta;
+- triggers de carga y refresh (`on-demand`);
+- orden/prefijos compatibles con `docs/timestamp-order-policy.md` (Issue `#18`);
+- decisión explícita de no paginación en el MVP;
+- riesgos de coste/latencia y límites aceptados.
+
+No incluye:
+
+- implementación de queries en código;
+- índices Firestore físicos definitivos;
+- listeners realtime (excluidos por `docs/sync-strategy.md`, Issue `#7`);
+- paginación avanzada;
+- rediseño visual detallado de Figma;
+- cambios de modelo de dominio o de operaciones de escritura.
+
+## Entradas y prerrequisitos
+
+- `docs/sync-strategy.md` (Issue `#7`)
+- `docs/campaign-temporal-controls.md` (Issue `#9`)
+- `docs/campaign-temporal-initialization.md` (Issue `#13`)
+- `docs/firestore-operation-contract.md` (Issue `#12`)
+- `docs/editability-policy.md` (Issue `#37`)
+- `docs/active-session-flow.md` (Issue `#14`)
+- `docs/resource-delta-model.md` (Issue `#40`)
+- `docs/resource-validation-recalculation.md` (Issue `#15`)
+- `docs/timestamp-order-policy.md` (Issue `#18`)
+- `docs/domain-glossary.md`
+- `docs/mvp-implementation-checklist.md`
+- `docs/mvp-implementation-blocks.md`
+- Figma compartido por Kiko (captura de distribución de frames usada como canon
+  de layout para `#16`; referencia visual fuera del repo).
+
+## Canon de layout/superficies para `#16` (Figma + contratos oficiales)
+
+### Regla de precedencia para esta issue
+
+1. **Layout/superficies visibles**:
+   - manda el diseño de Figma compartido por Kiko para la distribución de
+     frames de la pantalla principal (referencia visual de esta sesión).
+1. **Reglas de dominio/flujo/orden**:
+   - mandan los documentos oficiales ya cerrados (`#9`, `#12`, `#14`, `#15`,
+     `#18`, `#37`, `#40`).
+1. `tdd.md`:
+   - se trata como legado y referencia histórica;
+   - **no** es canon de layout para `#16`.
+
+### Decisiones de layout/lecturas cerradas en `#16`
+
+1. El flujo de lectura se modela para la **pantalla principal** (no solo
+   “timeline y panel de foco” en sentido legacy).
+1. El timeline del MVP se basa en **weeks** (no se activa un timeline plano de
+   entries multi-week en esta issue).
+1. La carga temporal visible se resuelve sobre el **año seleccionado completo**
+   (sin ventana de weeks).
+1. Las sesiones de una `Entry` se cargan al **seleccionar la `Entry`**.
+1. No hay paginación en el MVP para years/weeks/entries/sesiones.
+1. Estado inicial de pantalla:
+   - barra superior en el año de `current week` (`week_cursor` derivado);
+   - sin `Week` seleccionada;
+   - sin `Entry` seleccionada;
+   - sin bloque de `Entry` visible.
+
+## Superficies de lectura y estados de pantalla
+
+### Tabla 1 — Superficies/estados de pantalla (`I16-S1`)
+
+| `surface_id` | `descripcion` | `visible_en_estado` | `datos_necesarios` | `notas` |
+| --- | --- | --- | --- | --- |
+| `top_year_selector` | Barra superior con año actual seleccionado, navegación prev/next y `+` de extensión | Todos | años provisionados, año seleccionado, condición de último año | `+` depende del último año provisionado (`#9`) |
+| `top_week_selector` | Tira de semanas del año seleccionado (navegación/foco temporal) | Todos | weeks del año seleccionado (`week_number`, `status`), marcador `current week` | Seleccionar week no cambia `week_cursor` (`#9`) |
+| `top_entry_selector_tabs` | Selector de `Entry` de la week seleccionada (tabs) | `week_selected_no_entry`, `entry_selected_*` | entries de la week seleccionada ordenadas | Puede mostrar estado vacío/acción de creación si no hay entries |
+| `focus_panel_week_state` | Panel central en modo `Week` (semana seleccionada, notas, estado) | `week_selected_no_entry` | `Week` seleccionada (`status`, `notes`) | Consume datos ya presentes en lecturas de weeks |
+| `focus_panel_entry_state` | Panel central en modo `Entry` (datos de entry, recursos, bloque sesión) | `entry_selected_*` | `Entry` seleccionada + sesiones de esa entry | `total jugado` y desplegable de sesiones dependen de lectura de `sessions` |
+| `bottom_totals_bar` | Barra inferior con totales globales y resumen de activo | Todos | `campaign.resource_totals`, resumen de sesión activa, label del activo si aplica | El detalle visual no cambia las lecturas mínimas |
+| `active_session_indicator_summary` | Indicadores de foco vs activo / estado de sesión global | Todos (condicional si hay activa) | sesión activa global + owner (`Entry`) si no coincide con la seleccionada | Alineado con separación foco/activo de `#14` |
+
+Estados de pantalla del MVP (canon para lecturas):
+
+- `screen_open_no_selection`
+- `week_selected_no_entry`
+- `entry_selected_no_active_session`
+- `entry_selected_active_session_here`
+- `entry_selected_active_session_other_entry`
+
+## Inventario de consultas mínimas
+
+### Tabla 2 — Inventario de consultas mínimas (`I16-S2`)
+
+| `query_id` | `superficies_que_alimenta` | `path_o_scope` | `filtros` | `query_order_prefix` | `client_canonical_order` (ref `#18`) | `trigger_de_carga` | `trigger_de_refresh` | `paginacion_mvp` | `notas` |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `Q1 campaign_main_doc` | `top_week_selector`, `bottom_totals_bar`, `active_session_indicator_summary` | `campaigns/01` (doc) | N/A | N/A | N/A | abrir pantalla | refresh manual; post-escrituras que cambian `campaign` | No aplica | Fuente de `week_cursor` y `resource_totals` |
+| `Q2 years_list` | `top_year_selector` | `campaigns/01/years` | N/A | `year_number ASC` | `(year_number ASC)` | abrir pantalla | refresh manual; extensión `+1` año | No | Volumen bajo |
+| `Q3 weeks_selected_year_summer` | `top_week_selector`, `focus_panel_week_state` | `.../years/{selected_year}/seasons/summer/weeks` | N/A | `week_number ASC` | `(week_number ASC)` | abrir pantalla (año inicial); cambio de año | refresh manual; cambios de `Week` del año visible; provisión/extensión que afecte año visible | No | 10 weeks por estación |
+| `Q4 weeks_selected_year_winter` | `top_week_selector`, `focus_panel_week_state` | `.../years/{selected_year}/seasons/winter/weeks` | N/A | `week_number ASC` | `(week_number ASC)` | abrir pantalla (año inicial); cambio de año | refresh manual; cambios de `Week` del año visible; provisión/extensión que afecte año visible | No | Se fusiona en cliente con Q3 por `week_number` |
+| `Q5 entries_selected_week` | `top_entry_selector_tabs`, `focus_panel_entry_state`, `focus_panel_week_state` | `.../weeks/{selected_week}/entries` | N/A | `order_index ASC` | `(order_index ASC, created_at_utc ASC, entry_id ASC)` | selección de `Week` | refresh manual (si hay week seleccionada); post `Entry.*`; cambios de recursos que afecten render de `Entry` | No | También sirve para estado vacío de week |
+| `Q6 active_session_global` | `active_session_indicator_summary`, `bottom_totals_bar` | `collection group sessions` | `ended_at_utc == null`, `limit 1` | (según capacidad de query; no crítico para `limit 1`) | N/A (single result) | abrir pantalla | refresh manual; post `Session.*`; `Week.close/reclose`; `Entry.delete` con posible `auto-stop` | No aplica | Invariante `0..1` activa global |
+| `Q7 active_entry_doc_if_needed` | `active_session_indicator_summary`, `bottom_totals_bar` | doc `Entry` owner de Q6 (derivado por ruta) | condicional | N/A | N/A | tras Q6 si aplica | refresh manual (si aplica) | No aplica | Solo si activa != `selected_entry` o se necesita label del activo |
+| `Q8 sessions_selected_entry_combined` | `focus_panel_entry_state`, `active_session_indicator_summary` | `.../entries/{selected_entry}/sessions` | N/A | `started_at_utc DESC` | `(is_active DESC, started_at_utc DESC, updated_at_utc DESC, session_id ASC)` | selección de `Entry` | refresh manual (si hay `selected_entry`); post `Session.*` que afecten esa entry | No | Alimenta total jugado + lista desplegable |
+
+### Definición operativa de cada consulta (resumen normativo)
+
+#### Q1 — `campaign_main_doc`
+
+- **Campos lógicos mínimos**:
+  - `week_cursor`
+  - `resource_totals`
+  - `updated_at_utc` (y `created_at_utc` opcional técnico)
+- **Uso**:
+  - marcador `current week` (vía `week_cursor`)
+  - barra de totales
+  - estado general persistido de campaña
+
+#### Q2 — `years_list`
+
+- **Campos lógicos mínimos**:
+  - `year_number`
+  - `created_at_utc`, `updated_at_utc` (opcionales técnicos)
+- **Uso**:
+  - selector de año y validación de límites prev/next
+  - disponibilidad de `+` cuando el año seleccionado es el último provisionado
+
+#### Q3/Q4 — `weeks_selected_year_{summer|winter}`
+
+- **Campos lógicos mínimos**:
+  - `week_number`
+  - `status`
+  - `notes`
+  - `updated_at_utc` (opcional técnico)
+- **Uso**:
+  - tira de weeks del año seleccionado
+  - datos de panel `Week` sin query extra cuando se selecciona una week
+
+#### Q5 — `entries_selected_week`
+
+- **Campos lógicos mínimos**:
+  - `entry_id` (doc id)
+  - `type`
+  - `scenario_ref` (si aplica)
+  - `order_index`
+  - `resource_deltas`
+  - `created_at_utc`, `updated_at_utc`
+- **Uso**:
+  - tabs/selector de entries de la week
+  - panel de foco en modo `Entry`
+  - estado vacío si la week no tiene entries
+
+#### Q6 — `active_session_global`
+
+- **Campos lógicos mínimos**:
+  - `session_id` (doc id)
+  - `started_at_utc`
+  - `ended_at_utc`
+  - `created_at_utc`, `updated_at_utc`
+  - ruta del documento (para derivar owner `Entry`/`Week`)
+- **Uso**:
+  - resumen de activo global
+  - barra inferior (tiempo/activo)
+  - separación foco vs activo (`#14`)
+
+#### Q7 — `active_entry_doc_if_needed` (condicional)
+
+- **Campos lógicos mínimos**:
+  - `type`
+  - `scenario_ref`
+  - `updated_at_utc` (opcional técnico)
+- **Uso**:
+  - label/identificador del activo cuando la sesión activa pertenece a otra
+    `Entry` distinta de la seleccionada
+
+#### Q8 — `sessions_selected_entry_combined`
+
+- **Campos lógicos mínimos**:
+  - `started_at_utc`
+  - `ended_at_utc`
+  - `created_at_utc`
+  - `updated_at_utc`
+- **Uso**:
+  - total jugado (calculado en cliente)
+  - lista de sesiones desplegable de la `Entry` seleccionada
+  - estado activo/histórico de esa `Entry`
+
+## Campos mínimos lógicos por consulta
+
+### Tabla 3 — Campos mínimos lógicos por consulta (`I16-S2`)
+
+| `query_id` | `entity` | `campos_minimos_logicos` | `campos_para_orden` | `campos_para_render` | `campos_para_estado` | `notas` |
+| --- | --- | --- | --- | --- | --- | --- |
+| `Q1 campaign_main_doc` | `campaign` | `week_cursor`, `resource_totals`, `updated_at_utc` | N/A | `resource_totals`, `week_cursor` | `week_cursor`, `updated_at_utc` | `created_at_utc` opcional técnico |
+| `Q2 years_list` | `year` | `year_number` | `year_number` | `year_number` | `updated_at_utc` opcional | Auditoría no es primaria de UI |
+| `Q3 weeks_selected_year_summer` | `week` | `week_number`, `status`, `notes` | `week_number` | `week_number`, `status`, `notes` | `status`, `updated_at_utc` | Parte `summer` del año |
+| `Q4 weeks_selected_year_winter` | `week` | `week_number`, `status`, `notes` | `week_number` | `week_number`, `status`, `notes` | `status`, `updated_at_utc` | Parte `winter` del año |
+| `Q5 entries_selected_week` | `entry` | `type`, `scenario_ref`, `order_index`, `resource_deltas`, `created_at_utc`, `updated_at_utc` | `order_index`, `created_at_utc`, `entry_id` | `type`, `scenario_ref`, `resource_deltas` | `updated_at_utc`, `order_index` | `entry_id` viene del doc id |
+| `Q6 active_session_global` | `session` | `started_at_utc`, `ended_at_utc`, `created_at_utc`, `updated_at_utc` + ruta | `N/A (single)` | `started_at_utc`, `ended_at_utc` | `ended_at_utc`, `updated_at_utc` | `limit 1` por invariante |
+| `Q7 active_entry_doc_if_needed` | `entry` | `type`, `scenario_ref` | N/A | `type`, `scenario_ref` | `updated_at_utc` opcional | Solo si activa != seleccionada |
+| `Q8 sessions_selected_entry_combined` | `session` | `started_at_utc`, `ended_at_utc`, `created_at_utc`, `updated_at_utc` | `started_at_utc`, `updated_at_utc`, `session_id` | `started_at_utc`, `ended_at_utc` | `ended_at_utc`, `updated_at_utc` | Orden canónico final en cliente según `#18` |
+
+## Orden estable y compatibilidad con `#18`
+
+1. `#16` **no redefine** la política de desempate ni timestamps:
+   reutiliza `docs/timestamp-order-policy.md`.
+1. Aplicación directa de `#18` en `#16`:
+   - `year_selector_list` -> Q2
+   - `week_selector_list` / `timeline_week_groups` -> Q3 + Q4 (merge cliente)
+   - `week_entries_list` -> Q5
+   - `entry_sessions_combined_list` -> Q8
+1. `timeline_entries_flat`:
+   - permanece documentado en `#18` como opción condicional;
+   - **no se activa** en el MVP actual de `#16`.
+1. Timestamps pendientes (`serverTimestamp`) mantienen orden provisional hasta
+   `refresh`, según `#18`.
+
+## Triggers de carga y refresh (`on-demand`)
+
+### Estado inicial de pantalla (decisión cerrada)
+
+- `selected_year` inicial = año de `current week` (`week_cursor` derivado)
+- `selected_week` inicial = `none`
+- `selected_entry` inicial = `none`
+
+### Consecuencia de lecturas iniciales
+
+- **Cargar al abrir pantalla**: Q1 + Q2 + Q3 + Q4 + Q6
+- **No cargar hasta selección**: Q5 + Q7 + Q8
+
+### Tabla 4 — Refresco por tipo de evento (`I16-S3`)
+
+| `evento_ui_o_operacion` | `queries_a_refrescar` | `motivo` | `requiere_refresh_manual` | `notas` |
+| --- | --- | --- | --- | --- |
+| `open_main_screen` | Q1, Q2, Q3, Q4, Q6 | Estado inicial mínimo visible | No | Año inicial derivado de `week_cursor` |
+| `ui.manual_refresh` | Q1, Q2, Q3, Q4, Q6 + (Q5/Q7/Q8 si hay selección/activa aplicable) | `on-demand refresh` global del contexto visible | Sí (trigger del usuario) | Sin listeners realtime (`#7`) |
+| `ui.select_year` | Q3, Q4 (+ limpiar selección local de `Week`/`Entry`) | Cambia el conjunto de weeks visibles | No | Q5/Q8 no cargan hasta nueva selección |
+| `ui.select_week` | Q5 | Cargar entries de la week seleccionada | No | No cambia `week_cursor` |
+| `ui.select_entry` | Q8 (+ Q7 solo si sigue activo global en otra entry y la UI lo necesita) | Cargar sesiones de la entry seleccionada | No | Q5 ya aporta datos base de la entry |
+| `Week.close/reopen/reclose/update_notes` | Q1 (si cambia `week_cursor`), Q3/Q4 (año visible), Q6 (si hubo `auto-stop`) | Reflejar estado de week, cursor y sesión activa | No (post-escritura local) | Si la week afectada no está en año visible, Q3/Q4 puede diferirse a refresh manual |
+| `Campaign.extend_years_plus_one` | Q1, Q2, Q3/Q4 si el año visible queda afectado | Reflejar nuevo año / estado de campaña | No (post-escritura local) | `+` vive en selector de año (`#9`) |
+| `Entry.create/update/delete/reorder` sobre `selected_week` | Q5 (+ Q8 si afecta `selected_entry`) | Actualizar tabs/lista y panel de entry | No (post-escritura local) | `Entry.delete` puede requerir también Q6 si había activa |
+| `Entry.adjust/set/clear_resource_delta` sobre `selected_entry` | Q1, Q5 | Totales globales + `resource_deltas` de entry | No (post-escritura local) | Reglas de recursos en `#15` |
+| `Session.start/stop/auto-stop/manual_*` | Q6, Q8 (si afecta `selected_entry`), Q7 (si aplica) | Reflejar activo global y sesiones de la entry | No (post-escritura local) | Recuperación por conflicto sigue `#14/#8` |
+
+### Regla de refresh post-escritura (MVP)
+
+1. Tras una escritura local confirmada, el cliente refresca **solo las queries
+   del ámbito afectado** (no recarga global indiscriminada por defecto).
+1. Ante `conflicto`, la recuperación sigue el patrón `refresh` manual +
+   reintento (`#8`, `#14`, `#15`, `#12`).
+
+## Paginación y límites del MVP
+
+### Decisión cerrada
+
+- **No hay paginación en el MVP** para:
+  - years
+  - weeks del año seleccionado
+  - entries de la week seleccionada
+  - sesiones de la entry seleccionada
+
+### Justificación documental
+
+1. `years_list` y `weeks_selected_year_*` tienen volumen pequeño y acotado.
+1. `entries_selected_week` solo se carga tras seleccionar week.
+1. `sessions_selected_entry_combined` solo se carga tras seleccionar entry y el
+   volumen esperado es bajo (normalmente ~1 sesión por entry).
+1. La UI puede plegar sesiones sin exigir paginación.
+
+### Límite explícito aceptado
+
+Si el histórico de sesiones de una `Entry` crece de forma anómala o el número
+de entries por week se vuelve alto para el dispositivo objetivo, la paginación
+se tratará como ampliación posterior (no bloquea `#16`).
+
+## Riesgos de coste/latencia y mitigaciones
+
+### Riesgos principales
+
+1. **Sobrecarga por recargar de más tras escrituras**
+   - Riesgo: degradar UX si se recarga toda la pantalla tras cada operación.
+   - Mitigación: refresco por ámbito (tabla 4) y refresh manual para conflictos.
+
+1. **Q3+Q4 incluyen `notes`**
+   - Riesgo: cargar campos de week que no siempre se muestran.
+   - Mitigación: aceptar el coste por simplicidad del MVP; evita query extra
+     para panel `Week`.
+
+1. **Dependencia de `collection group` para Q6**
+   - Riesgo: índice/consulta no disponible si se implementa sin soporte.
+   - Mitigación: documentar la dependencia en `#16`; si la implementación no la
+     usa, deberá ofrecer una alternativa equivalente sin cambiar el contrato
+     observable.
+
+1. **Figma incompleto (bloque central / barra inferior)**
+   - Riesgo: lecturas faltantes si luego aparecen nuevos datos requeridos.
+   - Mitigación: cerrar `#16` con supuestos explícitos y limitar el contrato a
+     datos ya cerrados por dominio/flujo.
+
+### Supuestos de lectura por superficies incompletas (obligatorios)
+
+1. **Bloque central**
+   - modo `Week`: consume `status` + `notes` desde Q3/Q4 (sin query extra)
+   - modo `Entry`: consume `Entry` desde Q5 y sesiones desde Q8
+1. **Barra inferior**
+   - requiere Q1 (`resource_totals`) + Q6 (activo global) + Q7 (label del
+     activo si activa != seleccionada)
+   - el detalle visual no introduce nuevas entidades/queries en `#16`
+
+## Casos de aceptación / verificación documental
+
+1. Al abrir pantalla:
+   - la barra superior se sitúa en el año de `current week`;
+   - no hay `Week` ni `Entry` seleccionada;
+   - se cargan Q1 + Q2 + Q3 + Q4 + Q6, pero no Q5/Q7/Q8.
+1. Seleccionar una week carga Q5 (`entries_selected_week`) y no dispara Q8
+   hasta seleccionar `Entry`.
+1. Seleccionar una entry carga Q8 (`sessions_selected_entry_combined`) para
+   total jugado y desplegable de sesiones.
+1. La UI puede distinguir foco vs activo con Q6 (+ Q7 si aplica), alineado con
+   `#14`.
+1. Cambiar de año recarga weeks del año seleccionado completo (Q3+Q4), sin
+   paginación por ventana.
+1. `#16` reutiliza las tuplas canónicas de `#18` y no redefine desempates.
+1. `timeline_entries_flat` queda explícitamente no activado en el MVP actual.
+1. La ausencia de paginación queda documentada como decisión explícita con
+   límites aceptados.
+
+## Riesgos, límites y decisiones diferidas
+
+- La implementación concreta de queries/índices Firestore queda fuera de esta
+  issue.
+- La paginación real (si se necesitara por volumen) se difiere a una ampliación
+  posterior.
+- El Figma usado como canon de layout para `#16` no está archivado aún en el
+  repo; se recomienda incorporar referencia persistente en una issue/doco de UI
+  futura.
+
+## Referencias
+
+- `AGENTS.md`
+- `docs/system-map.md`
+- `docs/decision-log.md`
+- `docs/domain-glossary.md`
+- `docs/sync-strategy.md`
+- `docs/campaign-temporal-controls.md`
+- `docs/campaign-temporal-initialization.md`
+- `docs/firestore-operation-contract.md`
+- `docs/editability-policy.md`
+- `docs/active-session-flow.md`
+- `docs/resource-delta-model.md`
+- `docs/resource-validation-recalculation.md`
+- `docs/timestamp-order-policy.md`
+- `docs/mvp-implementation-checklist.md`
+- `docs/mvp-implementation-blocks.md`
+- `tdd.md` (legado, no canónico para layout de `#16`)
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/16`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/7`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/9`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/14`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/15`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/18`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`
+- `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/40`

--- a/docs/mvp-implementation-blocks.md
+++ b/docs/mvp-implementation-blocks.md
@@ -300,28 +300,30 @@ No incluye:
 - `tipo`: `task`
 - `estado_inicial`: `draftable`
 - `responsable_de_coordinación`: `Codex+Kiko`
-- `dependencias_de_cierre`: alineación con `#9`; orden estable recomendado con
-  `#18`
+- `dependencias_de_cierre`: alineación con `#9`, `#14`, `#15`; compatibilidad
+  con `#18`; canon de layout/superficies fijado por Figma para esta issue
 - `impacta_a`: `#19`, `#20`
 
 #### Subbloques ejecutables
 
 | subbloque_id | objetivo | responsable | depende_de | entregable | criterio_de_finalización | estado_inicial |
 | --- | --- | --- | --- | --- | --- | --- |
-| `I16-S1` | Inventariar vistas/zonas de UI y sus necesidades mínimas de lectura | `Codex` | `#9`, `tdd.md` (referencia de producto) | Inventario de vistas y lecturas | Cada zona de UI tiene necesidades mínimas identificadas | `draftable` |
+| `I16-S1` | Inventariar superficies/estados de pantalla y sus necesidades mínimas de lectura | `Codex` | `#9`, `#14`, Figma (canon de layout para `#16`) | Inventario de superficies y lecturas | Cada superficie/estado visible tiene necesidades mínimas identificadas | `draftable` |
 | `I16-S2` | Definir consultas mínimas y campos requeridos por consulta | `Codex` | `I16-S1` | Lista de consultas + campos | Inventario de consultas mínimo y suficiente | `draftable` |
 | `I16-S3` | Definir orden, paginación y estabilidad visual (compatibilidad con `#18`) | `Codex+Kiko` | `I16-S2`, `#18` | Reglas de orden/paginación | Orden estable y criterios de paginación documentados | `draftable` |
 | `I16-S4` | Documentar riesgos de coste/latencia y límites aceptables del MVP | `Codex` | `I16-S2`, `I16-S3` | Sección de riesgos/rendimiento | Riesgos y límites quedan explícitos y trazables | `draftable` |
 
 #### Riesgos y bloqueos
 
+- Riesgo de usar `tdd.md` como canon de layout en lugar del Figma acordado.
 - Riesgo de cerrar consultas antes de fijar orden estable (`#18`).
 - Riesgo de sobrecarga de lecturas por no recortar campos mínimos.
 
 #### Criterio de cierre de la issue
 
-- Conjunto mínimo de lecturas y reglas de orden/paginación documentado, con
-  límites de rendimiento y coherencia con `#9`.
+- Conjunto mínimo de lecturas de pantalla principal documentado (superficies,
+  triggers, orden y no paginación), con límites de rendimiento y coherencia con
+  `#9`, `#14`, `#15` y `#18`.
 
 #### Notas de secuencia / paralelización
 
@@ -548,14 +550,13 @@ No incluye:
 - [x] `#18` Timestamps y orden estable (`draftable`)
 - [x] `#14` Flujo de sesión activa y `auto-stop` (`draftable`)
 - [x] `#15` Validación y recálculo de recursos (`draftable`)
-- [ ] `#16` Consultas mínimas para timeline/foco (`draftable`)
+- [x] `#16` Consultas mínimas para timeline/foco (`draftable`)
 - [ ] `#17` Matriz de edge cases (`draftable`)
 - [ ] `#19` Plan de pruebas de invariantes (`draftable`)
 - [ ] `#20` Gate de listo para codificar (`final_gate`)
 
 ### Próxima secuencia técnica esperada (según orden actual)
 
-1. `#16`
 1. `#17`
 1. `#19`
 1. `#20`

--- a/docs/mvp-implementation-checklist.md
+++ b/docs/mvp-implementation-checklist.md
@@ -71,6 +71,10 @@ este checklist:
   `docs/resource-validation-recalculation.md`
   - reglas por operación (`adjust/set/clear`), recálculo de `campaign.resource_totals`
     y clasificación de rechazos de recursos.
+- **Consultas mínimas para pantalla principal** (Issue #16):
+  `docs/minimal-read-queries.md`
+  - inventario mínimo de lecturas por superficie/estado, triggers de carga y
+    refresh, orden compatible con `#18` y sin paginación en MVP.
 
 ## Corte de responsabilidades entre `#10`, `#11` y `#20`
 
@@ -222,7 +226,7 @@ Usar esta plantilla mínima en cada issue/bloque del checklist:
 - [x] Política de timestamps y orden estable (Issue #18)
 - [x] Flujo de sesión activa y `auto-stop` (Issue #14)
 - [x] Reglas de validación y recálculo de recursos (Issue #15)
-- [ ] Consultas mínimas para timeline/foco (Issue #16)
+- [x] Consultas mínimas para timeline/foco (Issue #16)
 - [ ] Matriz de edge cases de concurrencia y sincronización (Issue #17)
 - [ ] Plan de pruebas para invariantes (Issue #19)
 - [ ] Gate de listo para codificar (Issue #20)

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -43,6 +43,9 @@ Este documento permite que una persona o agente nuevo entienda rápidamente:
   - Política de timestamps de auditoría y orden estable entre dispositivos.
 - `docs/active-session-flow.md`
   - Flujo de sesión activa (`start/stop/auto-stop`) y separación foco/activo.
+- `docs/minimal-read-queries.md`
+  - Consultas mínimas para pantalla principal (superficies, triggers, orden y
+    límites de carga) del MVP.
 - `docs/campaign-temporal-controls.md`
   - Controles temporales de campaña y provisión/extensión de años del MVP.
 - `docs/campaign-temporal-initialization.md`
@@ -104,6 +107,7 @@ Este documento permite que una persona o agente nuevo entienda rápidamente:
 - Validación y recálculo de recursos -> `docs/resource-validation-recalculation.md`
 - Timestamps y orden estable -> `docs/timestamp-order-policy.md`
 - Flujo de sesión activa y `auto-stop` -> `docs/active-session-flow.md`
+- Consultas mínimas de pantalla principal -> `docs/minimal-read-queries.md`
 - Controles temporales de campaña -> `docs/campaign-temporal-controls.md`
 - Inicialización temporal técnica -> `docs/campaign-temporal-initialization.md`
 - Editabilidad manual MVP -> `docs/editability-policy.md`

--- a/docs/timestamp-order-policy.md
+++ b/docs/timestamp-order-policy.md
@@ -142,7 +142,7 @@ desempate estable, no como reemplazo del orden funcional del dominio.
 | `week_selector_list` | Selector temporal de semana (UI) | `week_number ASC` | `(week_number ASC)` | `N/A` | `N/A` | `N/A` | Lista de dominio |
 | `timeline_week_groups` | Grupos/secciones de week en timeline | `week_number ASC` | `(week_number ASC)` | `N/A` | `N/A` | `N/A` | Compatible con `#16` |
 | `week_entries_list` | Lista de entries de una `Week` (panel foco / selector de entry) | `order_index ASC` | `(order_index ASC, created_at_utc ASC, entry_id ASC)` | Fallback/desempate | `N/A` | `created_at_utc` pendiente puede dar orden provisional hasta `refresh` | `updated_at_utc` no se usa para evitar drift visual por ediciones no relacionadas con orden |
-| `timeline_entries_flat` | Timeline aplanado multi-week (si `#16` lo define) | Prefijo máximo posible según query de `#16` | `(week_number ASC, order_index ASC, created_at_utc ASC, entry_id ASC)` | Fallback/desempate | `N/A` | `created_at_utc` pendiente => orden provisional | Lista condicional según diseño de `#16` |
+| `timeline_entries_flat` | Timeline aplanado multi-week (si `#16` lo define) | Prefijo máximo posible según query de `#16` | `(week_number ASC, order_index ASC, created_at_utc ASC, entry_id ASC)` | Fallback/desempate | `N/A` | `created_at_utc` pendiente => orden provisional | Lista condicional; `#16` cerrada no la activa en el MVP actual |
 | `entry_sessions_combined_list` | Sesiones de una `Entry` (activa + histórico) | `started_at_utc DESC` | `(is_active DESC, started_at_utc DESC, updated_at_utc DESC, session_id ASC)` | Principal + desempate | `ended_at_utc = null` => `is_active=1` | timestamps pendientes => orden provisional hasta `refresh` | Activa primero por regla de dominio |
 | `entry_sessions_history_list` | Histórico de sesiones (sin activa o filtrando activas) | `started_at_utc DESC` | `(started_at_utc DESC, updated_at_utc DESC, session_id ASC)` | Principal + desempate | `N/A` | timestamps pendientes => orden provisional hasta `refresh` | Histórico descendente |
 
@@ -160,6 +160,8 @@ desempate estable, no como reemplazo del orden funcional del dominio.
 - `#16` queda desbloqueada con una matriz de orden explícita por lista.
 - `#16` puede centrarse en inventario de consultas, paginación y coste,
   reutilizando las tuplas canónicas definidas aquí.
+- `#16` adopta `timeline_week_groups` (weeks) y deja `timeline_entries_flat`
+  fuera del MVP actual.
 
 ### `#40` (modelo de recursos por `Entry`)
 


### PR DESCRIPTION
﻿## Resumen

Cierra la Issue #16 definiendo el contrato documental de lecturas mínimas para la pantalla principal del MVP.

## Cambios

- añade docs/minimal-read-queries.md con superficies, consultas Q1..Q8, campos mínimos, triggers de refresh y límites de MVP
- toma Figma (captura compartida) como canon de layout/superficies para #16
- fija arranque sin Week/Entry seleccionada y sin paginación en MVP
- actualiza trazabilidad en AGENTS.md, docs/system-map.md y docs/decision-log.md (DEC-0029)
- actualiza tracking en checklist/bloques y deja #17 como siguiente secuencia
- añade referencias cruzadas en docs/timestamp-order-policy.md, docs/campaign-temporal-controls.md y docs/active-session-flow.md

## Verificación

- git diff --cached --check
- revisión de consistencia de referencias #16, 	imeline_entries_flat, selected_week, selected_entry, paginación

Closes #16
