### PR TITLE
feat(ui): estado local con visor sticky y activo mock (#53)

### DIFF
--- a/docs/active-session-flow.md
+++ b/docs/active-session-flow.md
@@ -60,6 +60,9 @@ No incluye:
 1. `selected_entry`:
    - única `Entry` visible/activa en el panel de edición para acciones de
      sesión en el flujo normal del MVP.
+   - una implementación puede materializar esto como **entry visible en visor**
+     separada de la navegación (`selected_week`) mientras preserve el contrato
+     de acciones sobre la entry visible.
 1. `active_entry`:
    - `Entry` que posee la sesión activa global (si existe), derivado de una
      `Session` con `ended_at_utc = null`.
@@ -67,6 +70,9 @@ No incluye:
    `selected_entry` (junto a total jugado y lista de sesiones desplegable).
 1. Cambiar `selected_week` o `selected_entry` no implica por sí mismo cambiar
    `current week` ni cerrar la sesión activa global.
+1. Una implementación puede mantener un **visor sticky** (última entry visible)
+   al navegar por weeks/años; esto no altera la separación de responsabilidades
+   entre navegación, visor y estado activo global.
 
 ## Modelo de estado del flujo de sesión (cliente)
 
@@ -152,6 +158,11 @@ No incluye:
    - `current week` (marcador derivado de `week_cursor`);
    - `selected_week` / `selected_entry` (contexto de edición);
    - `active_entry` (estado activo global).
+1. La implementación puede distinguir internamente entre:
+   - navegación (`selected_week`);
+   - entry visible en visor (sticky);
+   - `active_entry`;
+   siempre que las acciones de sesión sigan actuando sobre la entry visible.
 1. Cambiar de `selected_entry` no implica trasladar automáticamente el estado
    activo ni ejecutar `stop`.
 1. El usuario puede editar otra `Entry`/`Week` mientras existe una sesión activa

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -727,3 +727,33 @@
   `docs/system-map.md`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/20`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/19`
+
+### DEC-0033
+
+- `date`: 2026-02-25
+- `status`: accepted
+- `problem`: al implementar el wiring local de la pantalla principal (`#53`)
+  se decidió mantener un visor sticky (última entry visible) al navegar por
+  years/weeks, lo que desalineaba parcialmente la semántica de selección usada
+  en `docs/minimal-read-queries.md` (`#16`) y podía introducir ambigüedad con
+  la separación foco/activo descrita en `docs/active-session-flow.md` (`#14`).
+- `decision`: aceptar en la implementación del shell/local state (`#53`) una
+  separación explícita entre navegación (`selected_year`, `selected_week`),
+  entry visible en visor (sticky) y `active_entry` (sesión activa global). La
+  navegación por year/week puede cambiar sin limpiar la entry visible en visor.
+  En el shell mock de `#53` las weeks cerradas se muestran atenuadas y la week
+  seleccionada se marca visualmente, sin añadir marcador explícito de "current
+  week" (que sigue siendo un concepto derivado de `week_cursor` real).
+- `rationale`: mejora la continuidad visual del panel central al navegar,
+  demuestra mejor la separación foco/activo antes de integrar datos reales
+  (`#54`) y mantiene el contrato de acciones sobre la entry visible sin reabrir
+  las reglas de backend/operaciones.
+- `impact`: ajusta semántica de UI/lecturas en `#16` y aclaraciones de flujo en
+  `#14`; guía la implementación de `#53` y deja preparada la integración
+  read-only de `#54` con distinción navegación/visor/activo.
+- `references`: `docs/minimal-read-queries.md`, `docs/active-session-flow.md`,
+  `docs/mvp-implementation-checklist.md`, `docs/mvp-implementation-blocks.md`,
+  `src/frosthaven_campaign_journal/ui/app_root.py`,
+  `src/frosthaven_campaign_journal/ui/views/main_shell_view.py`,
+  `src/frosthaven_campaign_journal/state/placeholders.py`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/53`

--- a/docs/minimal-read-queries.md
+++ b/docs/minimal-read-queries.md
@@ -241,6 +241,14 @@ Estados de pantalla del MVP (canon para lecturas):
 - `selected_week` inicial = `none`
 - `selected_entry` inicial = `none`
 
+Notas de implementación posteriores (`#53+`):
+
+- La UI puede separar **navegación** (`selected_year` / `selected_week`) de la
+  **entry visible en visor** (sticky).
+- En este documento, `selected_entry` se usa como shorthand de la entry cuyo
+  detalle/sesiones se muestran en visor cuando existe; cambiar de year/week de
+  navegación no obliga a limpiar ese visor.
+
 ### Consecuencia de lecturas iniciales
 
 - **Cargar al abrir pantalla**: Q1 + Q2 + Q3 + Q4 + Q6
@@ -252,14 +260,14 @@ Estados de pantalla del MVP (canon para lecturas):
 | --- | --- | --- | --- | --- |
 | `open_main_screen` | Q1, Q2, Q3, Q4, Q6 | Estado inicial mínimo visible | No | Año inicial derivado de `week_cursor` |
 | `ui.manual_refresh` | Q1, Q2, Q3, Q4, Q6 + (Q5/Q7/Q8 si hay selección/activa aplicable) | `on-demand refresh` global del contexto visible | Sí (trigger del usuario) | Sin listeners realtime (`#7`) |
-| `ui.select_year` | Q3, Q4 (+ limpiar selección local de `Week`/`Entry`) | Cambia el conjunto de weeks visibles | No | Q5/Q8 no cargan hasta nueva selección |
-| `ui.select_week` | Q5 | Cargar entries de la week seleccionada | No | No cambia `week_cursor` |
-| `ui.select_entry` | Q8 (+ Q7 solo si sigue activo global en otra entry y la UI lo necesita) | Cargar sesiones de la entry seleccionada | No | Q5 ya aporta datos base de la entry |
+| `ui.select_year` | Q3, Q4 (resetea navegación de `Week`) | Cambia el conjunto de weeks visibles | No | Puede mantenerse una entry en visor sticky; Q5/Q8 no cargan hasta nueva selección de entry |
+| `ui.select_week` | Q5 | Cargar entries de la week seleccionada | No | No cambia `week_cursor` ni obliga a limpiar la entry en visor sticky |
+| `ui.select_entry` | Q8 (+ Q7 solo si sigue activo global en otra entry y la UI lo necesita) | Cargar sesiones de la entry seleccionada para el visor | No | Q5 ya aporta datos base de la entry |
 | `Week.close/reopen/reclose/update_notes` | Q1 (si cambia `week_cursor`), Q3/Q4 (año visible), Q6 (si hubo `auto-stop`) | Reflejar estado de week, cursor y sesión activa | No (post-escritura local) | Si la week afectada no está en año visible, Q3/Q4 puede diferirse a refresh manual |
 | `Campaign.extend_years_plus_one` | Q1, Q2, Q3/Q4 si el año visible queda afectado | Reflejar nuevo año / estado de campaña | No (post-escritura local) | `+` vive en selector de año (`#9`) |
-| `Entry.create/update/delete/reorder` sobre `selected_week` | Q5 (+ Q8 si afecta `selected_entry`) | Actualizar tabs/lista y panel de entry | No (post-escritura local) | `Entry.delete` puede requerir también Q6 si había activa |
-| `Entry.adjust/set/clear_resource_delta` sobre `selected_entry` | Q1, Q5 | Totales globales + `resource_deltas` de entry | No (post-escritura local) | Reglas de recursos en `#15` |
-| `Session.start/stop/auto-stop/manual_*` | Q6, Q8 (si afecta `selected_entry`), Q7 (si aplica) | Reflejar activo global y sesiones de la entry | No (post-escritura local) | Recuperación por conflicto sigue `#14/#8` |
+| `Entry.create/update/delete/reorder` sobre `selected_week` | Q5 (+ Q8 si afecta la entry en visor) | Actualizar tabs/lista y panel de entry | No (post-escritura local) | `Entry.delete` puede requerir también Q6 si había activa |
+| `Entry.adjust/set/clear_resource_delta` sobre la entry en visor | Q1, Q5 | Totales globales + `resource_deltas` de entry | No (post-escritura local) | Reglas de recursos en `#15` |
+| `Session.start/stop/auto-stop/manual_*` | Q6, Q8 (si afecta la entry en visor), Q7 (si aplica) | Reflejar activo global y sesiones de la entry | No (post-escritura local) | Recuperación por conflicto sigue `#14/#8` |
 
 ### Regla de refresh post-escritura (MVP)
 
@@ -333,9 +341,12 @@ se tratará como ampliación posterior (no bloquea `#16`).
    - no hay `Week` ni `Entry` seleccionada;
    - se cargan Q1 + Q2 + Q3 + Q4 + Q6, pero no Q5/Q7/Q8.
 1. Seleccionar una week carga Q5 (`entries_selected_week`) y no dispara Q8
-   hasta seleccionar `Entry`.
+   hasta seleccionar una nueva `Entry` para el visor.
 1. Seleccionar una entry carga Q8 (`sessions_selected_entry_combined`) para
    total jugado y desplegable de sesiones.
+1. La navegación (`selected_year` / `selected_week`) puede cambiar sin limpiar
+   la entry visible en visor (sticky), y eso no cambia qué evento dispara Q8:
+   solo la selección de una nueva `Entry`.
 1. La UI puede distinguir foco vs activo con Q6 (+ Q7 si aplica), alineado con
    `#14`.
 1. Cambiar de año recarga weeks del año seleccionado completo (Q3+Q4), sin

--- a/docs/mvp-implementation-blocks.md
+++ b/docs/mvp-implementation-blocks.md
@@ -557,9 +557,16 @@ No incluye:
 - [x] `#19` Plan de pruebas de invariantes (`draftable`)
 - [x] `#20` Gate de listo para codificar (`final_gate`)
 
+### Seguimiento de implementación (post-`#20`)
+
+- [x] `#51` Bootstrap de app Flet y estructura base
+- [x] `#52` Shell de pantalla principal (layout base Figma)
+- [x] `#53` Estado local de navegación/visor sticky/activo mock
+- [ ] `#54` Integración read-only inicial (`Q1/Q2/Q3/Q4/Q6/Q7`)
+
 ### Próxima secuencia técnica esperada (según orden actual)
 
-1. Inicio de implementación (slice recomendado por `#20`: infraestructura/base app)
+1. `#54` Integrar lecturas mínimas read-only para arranque y navegación base
 
 ## Referencias
 

--- a/docs/mvp-implementation-checklist.md
+++ b/docs/mvp-implementation-checklist.md
@@ -231,6 +231,13 @@ Usar esta plantilla mínima en cada issue/bloque del checklist:
 - [x] Plan de pruebas para invariantes (Issue #19)
 - [x] Gate de listo para codificar (Issue #20)
 
+## Seguimiento de implementación (post-#20)
+
+- [x] Bootstrap de app Flet y estructura base del proyecto (Issue #51)
+- [x] Shell de pantalla principal con layout base según Figma (Issue #52)
+- [x] Estado local de selección/navegación + visor sticky + activo mock (Issue #53)
+- [ ] Integrar lecturas mínimas read-only para arranque y navegación base (Issue #54)
+
 ## Referencias
 
 - `AGENTS.md`

--- a/src/frosthaven_campaign_journal/state/placeholders.py
+++ b/src/frosthaven_campaign_journal/state/placeholders.py
@@ -1,12 +1,160 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import NamedTuple
+
+
+@dataclass(frozen=True)
+class EntryRef:
+    year_number: int
+    week_number: int
+    entry_id: str
+
+
+@dataclass(frozen=True)
+class MockEntry:
+    ref: EntryRef
+    label: str
+    entry_type: str
+    scenario_ref: str | None = None
+
+
+@dataclass(frozen=True)
+class MockWeek:
+    year_number: int
+    week_number: int
+    is_closed: bool
+    status_label: str
+    notes_preview: str
 
 
 @dataclass
-class BootstrapSelectionState:
-    selected_year: int | None = None
-    selected_week: int | None = None
-    selected_entry: str | None = None
-    current_week_marker: int | None = None
-    active_entry_id: str | None = None
+class MainScreenLocalState:
+    selected_year: int
+    selected_week: int | None
+    viewer_entry_ref: EntryRef | None
+    active_entry_ref_mock: EntryRef | None
+
+
+class MockMainScreenDataset(NamedTuple):
+    years: list[int]
+    weeks_by_year: dict[int, list[MockWeek]]
+    entries_by_week: dict[tuple[int, int], list[MockEntry]]
+    active_entry_ref_mock: EntryRef | None
+
+
+def build_mock_years() -> list[int]:
+    return [1, 2, 3]
+
+
+def build_mock_weeks_by_year() -> dict[int, list[MockWeek]]:
+    years = build_mock_years()
+    weeks_by_year: dict[int, list[MockWeek]] = {}
+
+    for year_number in years:
+        start_week = ((year_number - 1) * 20) + 1
+        weeks: list[MockWeek] = []
+        for offset in range(20):
+            week_number = start_week + offset
+            if year_number == 1:
+                is_closed = True
+            elif year_number == 2:
+                is_closed = week_number <= 34
+            else:
+                is_closed = False
+
+            weeks.append(
+                MockWeek(
+                    year_number=year_number,
+                    week_number=week_number,
+                    is_closed=is_closed,
+                    status_label="closed" if is_closed else "open",
+                    notes_preview=(
+                        f"Notas mock de la week {week_number} (Año {year_number})."
+                    ),
+                )
+            )
+        weeks_by_year[year_number] = weeks
+
+    return weeks_by_year
+
+
+def build_mock_entries_by_week() -> dict[tuple[int, int], list[MockEntry]]:
+    entries: dict[tuple[int, int], list[MockEntry]] = {}
+
+    week35_entries = [
+        MockEntry(
+            ref=EntryRef(year_number=2, week_number=35, entry_id="w35-e1"),
+            label="Escenario 51",
+            entry_type="scenario",
+            scenario_ref="scenario_51",
+        ),
+        MockEntry(
+            ref=EntryRef(year_number=2, week_number=35, entry_id="w35-e2"),
+            label="Escenario 42",
+            entry_type="scenario",
+            scenario_ref="scenario_42",
+        ),
+        MockEntry(
+            ref=EntryRef(year_number=2, week_number=35, entry_id="w35-e3"),
+            label="Puesto fronterizo",
+            entry_type="outpost",
+            scenario_ref=None,
+        ),
+    ]
+    entries[(2, 35)] = week35_entries
+
+    week36_entries = [
+        MockEntry(
+            ref=EntryRef(year_number=2, week_number=36, entry_id="w36-e1"),
+            label="Escenario 51",
+            entry_type="scenario",
+            scenario_ref="scenario_51",
+        ),
+        MockEntry(
+            ref=EntryRef(year_number=2, week_number=36, entry_id="w36-e2"),
+            label="Escenario 42",
+            entry_type="scenario",
+            scenario_ref="scenario_42",
+        ),
+        MockEntry(
+            ref=EntryRef(year_number=2, week_number=36, entry_id="w36-e3"),
+            label="Puesto fronterizo",
+            entry_type="outpost",
+            scenario_ref=None,
+        ),
+    ]
+    entries[(2, 36)] = week36_entries
+
+    entries[(2, 34)] = [
+        MockEntry(
+            ref=EntryRef(year_number=2, week_number=34, entry_id="w34-e1"),
+            label="Escenario 17",
+            entry_type="scenario",
+            scenario_ref="scenario_17",
+        )
+    ]
+
+    return entries
+
+
+def build_mock_main_screen_dataset() -> MockMainScreenDataset:
+    years = build_mock_years()
+    weeks_by_year = build_mock_weeks_by_year()
+    entries_by_week = build_mock_entries_by_week()
+    active_entry_ref_mock = entries_by_week[(2, 36)][0].ref
+    return MockMainScreenDataset(
+        years=years,
+        weeks_by_year=weeks_by_year,
+        entries_by_week=entries_by_week,
+        active_entry_ref_mock=active_entry_ref_mock,
+    )
+
+
+def build_initial_main_screen_state(active_entry_ref_mock: EntryRef | None) -> MainScreenLocalState:
+    return MainScreenLocalState(
+        selected_year=2,
+        selected_week=None,
+        viewer_entry_ref=None,
+        active_entry_ref_mock=active_entry_ref_mock,
+    )

--- a/src/frosthaven_campaign_journal/ui/app_root.py
+++ b/src/frosthaven_campaign_journal/ui/app_root.py
@@ -3,18 +3,102 @@ from __future__ import annotations
 import flet as ft
 
 from frosthaven_campaign_journal.config import load_settings
+from frosthaven_campaign_journal.state.placeholders import (
+    EntryRef,
+    MockEntry,
+    build_initial_main_screen_state,
+    build_mock_main_screen_dataset,
+)
 from frosthaven_campaign_journal.ui.views import (
-    DEFAULT_SHELL_PREVIEW_STATE,
     build_main_shell_view,
 )
 
 
-def build_app_root() -> ft.Control:
+def build_app_root(page: ft.Page) -> ft.Control:
     settings = load_settings()
-    return ft.SafeArea(
-        content=build_main_shell_view(
-            preview_state=DEFAULT_SHELL_PREVIEW_STATE,
+    dataset = build_mock_main_screen_dataset()
+    state = build_initial_main_screen_state(dataset.active_entry_ref_mock)
+
+    entry_index = _build_entry_index(dataset.entries_by_week)
+    root = ft.SafeArea(content=ft.Container(), expand=True)
+
+    def weeks_for_selected_year() -> list:
+        return dataset.weeks_by_year.get(state.selected_year, [])
+
+    def entries_for_selected_week() -> list[MockEntry]:
+        if state.selected_week is None:
+            return []
+        return dataset.entries_by_week.get((state.selected_year, state.selected_week), [])
+
+    def resolve_entry(entry_ref: EntryRef | None) -> MockEntry | None:
+        if entry_ref is None:
+            return None
+        return entry_index.get((entry_ref.year_number, entry_ref.week_number, entry_ref.entry_id))
+
+    def rerender() -> None:
+        root.content = build_main_shell_view(
+            state=state,
+            years=dataset.years,
+            weeks_for_selected_year=weeks_for_selected_year(),
+            entries_for_selected_week=entries_for_selected_week(),
+            viewer_entry=resolve_entry(state.viewer_entry_ref),
+            active_entry_mock=resolve_entry(state.active_entry_ref_mock),
             env_name=settings.env,
-        ),
-        expand=True,
-    )
+            on_prev_year=handle_prev_year,
+            on_next_year=handle_next_year,
+            on_select_week=handle_select_week,
+            on_select_entry=handle_select_entry,
+        )
+
+    def commit_ui_state() -> None:
+        rerender()
+        page.update()
+
+    def handle_prev_year() -> None:
+        current_index = dataset.years.index(state.selected_year)
+        if current_index == 0:
+            return
+        state.selected_year = dataset.years[current_index - 1]
+        state.selected_week = None
+        commit_ui_state()
+
+    def handle_next_year() -> None:
+        current_index = dataset.years.index(state.selected_year)
+        if current_index >= len(dataset.years) - 1:
+            return
+        state.selected_year = dataset.years[current_index + 1]
+        state.selected_week = None
+        commit_ui_state()
+
+    def handle_select_week(week_number: int) -> None:
+        if not any(week.week_number == week_number for week in weeks_for_selected_year()):
+            return
+        state.selected_week = week_number
+        commit_ui_state()
+
+    def handle_select_entry(entry_ref: EntryRef) -> None:
+        if state.selected_week is None:
+            return
+        week_entries = entries_for_selected_week()
+        if not any(entry.ref == entry_ref for entry in week_entries):
+            return
+        state.viewer_entry_ref = entry_ref
+        commit_ui_state()
+
+    rerender()
+    return root
+
+
+def _build_entry_index(
+    entries_by_week: dict[tuple[int, int], list[MockEntry]],
+) -> dict[tuple[int, int, str], MockEntry]:
+    index: dict[tuple[int, int, str], MockEntry] = {}
+    for entries in entries_by_week.values():
+        for entry in entries:
+            key = (
+                entry.ref.year_number,
+                entry.ref.week_number,
+                entry.ref.entry_id,
+            )
+            index[key] = entry
+    return index

--- a/src/frosthaven_campaign_journal/ui/views/__init__.py
+++ b/src/frosthaven_campaign_journal/ui/views/__init__.py
@@ -1,13 +1,7 @@
 """UI views used by the app."""
 
-from .main_shell_view import (
-    DEFAULT_SHELL_PREVIEW_STATE,
-    ShellPreviewState,
-    build_main_shell_view,
-)
+from .main_shell_view import build_main_shell_view
 
 __all__ = [
-    "DEFAULT_SHELL_PREVIEW_STATE",
-    "ShellPreviewState",
     "build_main_shell_view",
 ]

--- a/src/frosthaven_campaign_journal/ui/views/main_shell_view.py
+++ b/src/frosthaven_campaign_journal/ui/views/main_shell_view.py
@@ -1,8 +1,15 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
-from enum import Enum
+from typing import Callable
 
 import flet as ft
+
+from frosthaven_campaign_journal.state.placeholders import (
+    EntryRef,
+    MainScreenLocalState,
+    MockEntry,
+    MockWeek,
+)
 
 
 TOP_BAR_HEIGHT = 64
@@ -13,8 +20,9 @@ CENTER_PANEL_PADDING = 16
 
 COLOR_TOP_BAR_BG = "#F39A9A"
 COLOR_TOP_NAV_BUTTON_BG = "#5F58C8"
+COLOR_TOP_NAV_BUTTON_DISABLED_BG = "#8E88D8"
 COLOR_WEEK_TILE_BG = "#F4A0A0"
-COLOR_WEEK_TILE_CURRENT_BG = "#BFD7D0"
+COLOR_WEEK_TILE_CLOSED_BG = "#E6B7B7"
 COLOR_WEEK_TILE_SELECTED_BORDER = "#4F46A5"
 COLOR_ENTRY_TABS_BG = "#EFEFEF"
 COLOR_ENTRY_TAB_SELECTED_UNDERLINE = "#6D5BD6"
@@ -22,24 +30,24 @@ COLOR_CENTER_BG = "#E6E6E6"
 COLOR_BOTTOM_BAR_BG = "#36B7E6"
 COLOR_TEXT_PRIMARY = "#111111"
 COLOR_TEXT_MUTED = "#555555"
+COLOR_TEXT_DIMMED = "#7A6E6E"
 COLOR_WHITE = "#FFFFFF"
 
 
-class ShellPreviewState(str, Enum):
-    NO_SELECTION = "no_selection"
-    WEEK_SELECTED = "week_selected"
-    ENTRY_SELECTED = "entry_selected"
-
-
-DEFAULT_SHELL_PREVIEW_STATE = ShellPreviewState.NO_SELECTION
-
-_MOCK_WEEK_NUMBERS = list(range(21, 41))
-_CURRENT_WEEK_NUMBER = 35
-_WEEK_SELECTED_NUMBER = 35
-_ENTRY_SELECTED_WEEK_NUMBER = 36
-
-
-def build_main_shell_view(preview_state: ShellPreviewState, env_name: str) -> ft.Control:
+def build_main_shell_view(
+    *,
+    state: MainScreenLocalState,
+    years: list[int],
+    weeks_for_selected_year: list[MockWeek],
+    entries_for_selected_week: list[MockEntry],
+    viewer_entry: MockEntry | None,
+    active_entry_mock: MockEntry | None,
+    env_name: str,
+    on_prev_year: Callable[[], None],
+    on_next_year: Callable[[], None],
+    on_select_week: Callable[[int], None],
+    on_select_entry: Callable[[EntryRef], None],
+) -> ft.Control:
     return ft.Container(
         expand=True,
         padding=OUTER_PADDING,
@@ -47,17 +55,47 @@ def build_main_shell_view(preview_state: ShellPreviewState, env_name: str) -> ft
             expand=True,
             spacing=0,
             controls=[
-                _build_top_temporal_bar(preview_state),
-                _build_entry_tabs_bar(preview_state),
-                _build_center_focus_panel(preview_state),
-                _build_bottom_status_bar(env_name),
+                _build_top_temporal_bar(
+                    state=state,
+                    years=years,
+                    weeks_for_selected_year=weeks_for_selected_year,
+                    on_prev_year=on_prev_year,
+                    on_next_year=on_next_year,
+                    on_select_week=on_select_week,
+                ),
+                _build_entry_tabs_bar(
+                    state=state,
+                    entries_for_selected_week=entries_for_selected_week,
+                    viewer_entry=viewer_entry,
+                    on_select_entry=on_select_entry,
+                ),
+                _build_center_focus_panel(
+                    state=state,
+                    weeks_for_selected_year=weeks_for_selected_year,
+                    viewer_entry=viewer_entry,
+                    active_entry_mock=active_entry_mock,
+                ),
+                _build_bottom_status_bar(
+                    env_name=env_name,
+                    viewer_entry=viewer_entry,
+                    active_entry_mock=active_entry_mock,
+                ),
             ],
         ),
     )
 
 
-def _build_top_temporal_bar(preview_state: ShellPreviewState) -> ft.Control:
-    selected_week_number = _selected_week_number(preview_state)
+def _build_top_temporal_bar(
+    *,
+    state: MainScreenLocalState,
+    years: list[int],
+    weeks_for_selected_year: list[MockWeek],
+    on_prev_year: Callable[[], None],
+    on_next_year: Callable[[], None],
+    on_select_week: Callable[[int], None],
+) -> ft.Control:
+    has_prev_year = years.index(state.selected_year) > 0
+    has_next_year = years.index(state.selected_year) < len(years) - 1
 
     return ft.Container(
         height=TOP_BAR_HEIGHT,
@@ -72,14 +110,14 @@ def _build_top_temporal_bar(preview_state: ShellPreviewState) -> ft.Control:
                     spacing=12,
                     vertical_alignment=ft.CrossAxisAlignment.CENTER,
                     controls=[
-                        _build_year_nav_button("←"),
+                        _build_year_nav_button("←", on_prev_year if has_prev_year else None),
                         ft.Text(
-                            "Año 2",
+                            f"Año {state.selected_year}",
                             size=32,
                             weight=ft.FontWeight.BOLD,
                             color=COLOR_TEXT_PRIMARY,
                         ),
-                        _build_year_nav_button("→"),
+                        _build_year_nav_button("→", on_next_year if has_next_year else None),
                     ],
                 ),
                 ft.Container(
@@ -90,11 +128,11 @@ def _build_top_temporal_bar(preview_state: ShellPreviewState) -> ft.Control:
                         scroll=ft.ScrollMode.AUTO,
                         controls=[
                             _build_week_tile(
-                                week_number=week_number,
-                                is_current=(week_number == _CURRENT_WEEK_NUMBER),
-                                is_selected=(week_number == selected_week_number),
+                                week=week,
+                                is_selected=(week.week_number == state.selected_week),
+                                on_select_week=on_select_week,
                             )
-                            for week_number in _MOCK_WEEK_NUMBERS
+                            for week in weeks_for_selected_year
                         ],
                     ),
                 ),
@@ -103,25 +141,34 @@ def _build_top_temporal_bar(preview_state: ShellPreviewState) -> ft.Control:
     )
 
 
-def _build_year_nav_button(label: str) -> ft.Control:
+def _build_year_nav_button(label: str, on_click: Callable[[], None] | None) -> ft.Control:
+    enabled = on_click is not None
     return ft.Container(
         width=42,
         height=42,
-        bgcolor=COLOR_TOP_NAV_BUTTON_BG,
+        bgcolor=COLOR_TOP_NAV_BUTTON_BG if enabled else COLOR_TOP_NAV_BUTTON_DISABLED_BG,
         border_radius=999,
         alignment=ft.Alignment.CENTER,
+        on_click=(lambda _e: on_click()) if on_click else None,
         content=ft.Text(
             label,
             size=20,
             weight=ft.FontWeight.BOLD,
-            color=COLOR_WHITE,
+            color=COLOR_WHITE if enabled else "#ECEBFF",
         ),
     )
 
 
-def _build_week_tile(week_number: int, is_current: bool, is_selected: bool) -> ft.Control:
-    border = ft.border.all(2, COLOR_WEEK_TILE_SELECTED_BORDER) if is_selected else None
-    bgcolor = COLOR_WEEK_TILE_CURRENT_BG if is_current else COLOR_WEEK_TILE_BG
+def _build_week_tile(
+    *,
+    week: MockWeek,
+    is_selected: bool,
+    on_select_week: Callable[[int], None],
+) -> ft.Control:
+    border = ft.Border.all(2, COLOR_WEEK_TILE_SELECTED_BORDER) if is_selected else None
+    bgcolor = COLOR_WEEK_TILE_CLOSED_BG if week.is_closed else COLOR_WEEK_TILE_BG
+    text_color = COLOR_TEXT_DIMMED if week.is_closed else COLOR_TEXT_PRIMARY
+
     return ft.Container(
         width=46,
         height=42,
@@ -129,56 +176,98 @@ def _build_week_tile(week_number: int, is_current: bool, is_selected: bool) -> f
         border=border,
         border_radius=2,
         alignment=ft.Alignment.CENTER,
+        on_click=lambda _e, week_number=week.week_number: on_select_week(week_number),
         content=ft.Text(
-            str(week_number),
+            str(week.week_number),
             size=13,
             weight=ft.FontWeight.W_600,
-            color=COLOR_TEXT_PRIMARY,
+            color=text_color,
         ),
     )
 
 
-def _build_entry_tabs_bar(preview_state: ShellPreviewState) -> ft.Control:
-    has_selected_week = preview_state in (
-        ShellPreviewState.WEEK_SELECTED,
-        ShellPreviewState.ENTRY_SELECTED,
-    )
-    has_selected_entry = preview_state == ShellPreviewState.ENTRY_SELECTED
-    tabs = ["Escenario 51", "Escenario 42", "Puesto fronterizo"]
-
-    return ft.Container(
-        height=ENTRY_TABS_BAR_HEIGHT,
-        bgcolor=COLOR_ENTRY_TABS_BG,
-        padding=ft.Padding(left=16, top=4, right=16, bottom=4),
-        content=ft.Row(
+def _build_entry_tabs_bar(
+    *,
+    state: MainScreenLocalState,
+    entries_for_selected_week: list[MockEntry],
+    viewer_entry: MockEntry | None,
+    on_select_entry: Callable[[EntryRef], None],
+) -> ft.Control:
+    if state.selected_week is None:
+        content: ft.Control = ft.Row(
+            alignment=ft.MainAxisAlignment.CENTER,
+            vertical_alignment=ft.CrossAxisAlignment.CENTER,
+            controls=[
+                ft.Text(
+                    "Selecciona una week para ver entries",
+                    size=13,
+                    color=COLOR_TEXT_MUTED,
+                    italic=True,
+                )
+            ],
+        )
+    elif not entries_for_selected_week:
+        content = ft.Row(
+            alignment=ft.MainAxisAlignment.CENTER,
+            vertical_alignment=ft.CrossAxisAlignment.CENTER,
+            controls=[
+                ft.Text(
+                    f"Week {state.selected_week} sin entries (mock)",
+                    size=13,
+                    color=COLOR_TEXT_MUTED,
+                    italic=True,
+                )
+            ],
+        )
+    else:
+        tab_selected_ref = (
+            viewer_entry.ref if _viewer_matches_selected_week(state, viewer_entry) else None
+        )
+        content = ft.Row(
             alignment=ft.MainAxisAlignment.CENTER,
             vertical_alignment=ft.CrossAxisAlignment.END,
             spacing=8,
             controls=[
                 _build_entry_tab(
-                    label=label,
-                    is_selected=has_selected_entry and index == 0,
-                    is_dimmed=not has_selected_week,
+                    entry=entry,
+                    is_selected=(tab_selected_ref == entry.ref),
+                    on_select_entry=on_select_entry,
                 )
-                for index, label in enumerate(tabs)
+                for entry in entries_for_selected_week
             ],
-        ),
+        )
+
+    return ft.Container(
+        height=ENTRY_TABS_BAR_HEIGHT,
+        bgcolor=COLOR_ENTRY_TABS_BG,
+        padding=ft.Padding(left=16, top=4, right=16, bottom=4),
+        content=content,
     )
 
 
-def _build_entry_tab(label: str, is_selected: bool, is_dimmed: bool) -> ft.Control:
+def _build_entry_tab(
+    *,
+    entry: MockEntry,
+    is_selected: bool,
+    on_select_entry: Callable[[EntryRef], None],
+) -> ft.Control:
     underline_color = COLOR_ENTRY_TAB_SELECTED_UNDERLINE if is_selected else "transparent"
-    text_color = COLOR_TEXT_MUTED if is_dimmed else COLOR_TEXT_PRIMARY
     text_weight = ft.FontWeight.W_600 if is_selected else ft.FontWeight.NORMAL
-    underline_width = max(36, min(110, len(label) * 7))
+    underline_width = max(36, min(120, len(entry.label) * 7))
 
     return ft.Container(
         padding=ft.Padding(left=12, top=6, right=12, bottom=2),
+        on_click=lambda _e, ref=entry.ref: on_select_entry(ref),
         content=ft.Column(
             spacing=4,
             horizontal_alignment=ft.CrossAxisAlignment.CENTER,
             controls=[
-                ft.Text(label, size=13, color=text_color, weight=text_weight),
+                ft.Text(
+                    entry.label,
+                    size=13,
+                    color=COLOR_TEXT_PRIMARY,
+                    weight=text_weight,
+                ),
                 ft.Container(
                     width=underline_width,
                     height=2,
@@ -190,69 +279,69 @@ def _build_entry_tab(label: str, is_selected: bool, is_dimmed: bool) -> ft.Contr
     )
 
 
-def _build_center_focus_panel(preview_state: ShellPreviewState) -> ft.Control:
+def _build_center_focus_panel(
+    *,
+    state: MainScreenLocalState,
+    weeks_for_selected_year: list[MockWeek],
+    viewer_entry: MockEntry | None,
+    active_entry_mock: MockEntry | None,
+) -> ft.Control:
+    selected_week = _find_selected_week(state, weeks_for_selected_year)
+
+    if viewer_entry is not None:
+        content = _build_focus_entry_mode(
+            state=state,
+            viewer_entry=viewer_entry,
+            active_entry_mock=active_entry_mock,
+        )
+    elif selected_week is not None:
+        content = _build_focus_week_mode(selected_week)
+    else:
+        content = _build_focus_empty_mode(state)
+
     return ft.Container(
         expand=True,
         bgcolor=COLOR_CENTER_BG,
         padding=ft.Padding.all(CENTER_PANEL_PADDING),
-        content=_build_focus_placeholder(preview_state),
+        content=content,
     )
 
 
-def _build_focus_placeholder(preview_state: ShellPreviewState) -> ft.Control:
-    if preview_state == ShellPreviewState.NO_SELECTION:
-        return ft.Column(
-            spacing=8,
-            controls=[
-                ft.Text(
-                    "Sin week seleccionada",
-                    size=24,
-                    weight=ft.FontWeight.BOLD,
-                    color=COLOR_TEXT_PRIMARY,
+def _build_focus_empty_mode(state: MainScreenLocalState) -> ft.Control:
+    return ft.Column(
+        spacing=10,
+        controls=[
+            ft.Text(
+                "Sin week seleccionada",
+                size=24,
+                weight=ft.FontWeight.BOLD,
+                color=COLOR_TEXT_PRIMARY,
+            ),
+            ft.Text(
+                "Navega por las weeks del año visible y selecciona una entry para mostrarla en el visor.",
+                size=14,
+                color=COLOR_TEXT_MUTED,
+            ),
+            _build_placeholder_card(
+                title="Visor (sticky) vacío",
+                body=(
+                    "En #53 el visor se mantiene separado de la navegación. "
+                    "Cuando selecciones una entry, seguirá visible aunque cambies de year/week."
                 ),
-                ft.Text(
-                    "El panel central mostrará el foco de week o entry en los siguientes slices.",
-                    size=14,
-                    color=COLOR_TEXT_MUTED,
-                ),
-            ],
-        )
+                min_height=108,
+            ),
+            _build_placeholder_card(
+                title=f"Navegación actual (mock): Año {state.selected_year}",
+                body="No hay week seleccionada todavía.",
+                min_height=74,
+            ),
+        ],
+    )
 
-    if preview_state == ShellPreviewState.WEEK_SELECTED:
-        return ft.Column(
-            spacing=12,
-            controls=[
-                ft.Row(
-                    spacing=10,
-                    vertical_alignment=ft.CrossAxisAlignment.CENTER,
-                    controls=[
-                        ft.Text(
-                            f"Week {_WEEK_SELECTED_NUMBER}",
-                            size=22,
-                            weight=ft.FontWeight.BOLD,
-                            color=COLOR_TEXT_PRIMARY,
-                        ),
-                        _build_badge("open", "#D9F2D9", "#237A3B"),
-                    ],
-                ),
-                _build_placeholder_card(
-                    title="Notas de la week (placeholder)",
-                    body=(
-                        "Aquí se mostrarán status y notes de la week seleccionada "
-                        "cuando se conecten estado real y lecturas."
-                    ),
-                    min_height=120,
-                ),
-                _build_placeholder_card(
-                    title="Sin entry seleccionada",
-                    body=(
-                        "Los tabs de entry están visibles, pero el detalle de entry "
-                        "se activará cuando se seleccione una entry (#53/#54)."
-                    ),
-                    min_height=100,
-                ),
-            ],
-        )
+
+def _build_focus_week_mode(week: MockWeek) -> ft.Control:
+    badge_bg = "#EDEDED" if week.is_closed else "#D9F2D9"
+    badge_fg = "#6A6A6A" if week.is_closed else "#237A3B"
 
     return ft.Column(
         spacing=12,
@@ -262,34 +351,112 @@ def _build_focus_placeholder(preview_state: ShellPreviewState) -> ft.Control:
                 vertical_alignment=ft.CrossAxisAlignment.CENTER,
                 controls=[
                     ft.Text(
-                        "Week 36 · Escenario 51",
+                        f"Week {week.week_number}",
                         size=22,
                         weight=ft.FontWeight.BOLD,
                         color=COLOR_TEXT_PRIMARY,
                     ),
-                    _build_badge("entry", "#E7E0FF", "#4F46A5"),
+                    _build_badge(week.status_label, badge_bg, badge_fg),
                 ],
             ),
             _build_placeholder_card(
-                title="Detalle de entry (placeholder)",
-                body=(
-                    "Tipo, referencia de escenario y datos de entry se conectarán "
-                    "en los siguientes slices read-only."
-                ),
+                title="Notas de la week (mock)",
+                body=week.notes_preview,
                 min_height=110,
             ),
             _build_placeholder_card(
-                title="Sesión activa / historial (placeholder)",
+                title="Sin entry en visor",
                 body=(
-                    "El bloque de sesión irá aquí (start/stop real fuera de #52, "
-                    "datos reales en #54+)."
+                    "La week está seleccionada para navegación, pero el visor solo cambia al seleccionar una entry."
                 ),
                 min_height=90,
             ),
+        ],
+    )
+
+
+def _build_focus_entry_mode(
+    *,
+    state: MainScreenLocalState,
+    viewer_entry: MockEntry,
+    active_entry_mock: MockEntry | None,
+) -> ft.Control:
+    viewer_matches_selected_week = _entry_ref_matches_selected_week(state, viewer_entry.ref)
+    active_here = active_entry_mock is not None and active_entry_mock.ref == viewer_entry.ref
+
+    context_lines = [
+        f"Viendo: {viewer_entry.label} · Week {viewer_entry.ref.week_number} · Año {viewer_entry.ref.year_number}",
+        (
+            f"Navegación actual: Año {state.selected_year}"
+            + (
+                f" · Week {state.selected_week}"
+                if state.selected_week is not None
+                else " · sin week seleccionada"
+            )
+        ),
+    ]
+    if not viewer_matches_selected_week:
+        context_lines.append(
+            "Visor sticky: la entry visible no coincide con la week navegada actualmente."
+        )
+
+    session_mock_text = (
+        "Con sesión activa (mock) en esta entry."
+        if active_here
+        else "Sin sesión activa (mock) en esta entry."
+    )
+
+    return ft.Column(
+        spacing=12,
+        controls=[
+            ft.Row(
+                spacing=10,
+                vertical_alignment=ft.CrossAxisAlignment.CENTER,
+                controls=[
+                    ft.Text(
+                        f"Week {viewer_entry.ref.week_number} · {viewer_entry.label}",
+                        size=22,
+                        weight=ft.FontWeight.BOLD,
+                        color=COLOR_TEXT_PRIMARY,
+                    ),
+                    _build_badge(viewer_entry.entry_type, "#E7E0FF", "#4F46A5"),
+                    _build_badge(
+                        "activo aquí (mock)" if active_here else "visor (mock)",
+                        "#DFF4FF" if active_here else "#F0F0F0",
+                        "#0E5E78" if active_here else "#666666",
+                    ),
+                ],
+            ),
             _build_placeholder_card(
-                title="Recursos de la entry (placeholder)",
-                body="Resumen y edición de recursos se conectan en la ola de recursos.",
-                min_height=80,
+                title="Contexto de visor / navegación",
+                body="\n".join(context_lines),
+                min_height=110,
+            ),
+            _build_placeholder_card(
+                title="Detalle de entry (mock)",
+                body=(
+                    f"Tipo: {viewer_entry.entry_type}\n"
+                    + (
+                        f"Scenario ref: {viewer_entry.scenario_ref}\n"
+                        if viewer_entry.scenario_ref
+                        else ""
+                    )
+                    + "Datos reales y sincronización llegarán en #54+."
+                ),
+                min_height=96,
+            ),
+            _build_placeholder_card(
+                title="Bloque de sesión (mock)",
+                body=(
+                    f"{session_mock_text}\n"
+                    "Start/Stop reales y sesiones persistidas quedan fuera de #53."
+                ),
+                min_height=84,
+            ),
+            _build_placeholder_card(
+                title="Recursos de la entry (mock)",
+                body="Placeholder visual de recursos. Sin datos reales ni mutaciones.",
+                min_height=72,
             ),
         ],
     )
@@ -314,7 +481,7 @@ def _build_placeholder_card(title: str, body: str, min_height: int) -> ft.Contro
         padding=ft.Padding.all(12),
         bgcolor="#F6F6F6",
         border_radius=8,
-        border=ft.border.all(1, "#D6D6D6"),
+        border=ft.Border.all(1, "#D6D6D6"),
         content=ft.Column(
             spacing=6,
             controls=[
@@ -336,7 +503,19 @@ def _build_placeholder_card(title: str, body: str, min_height: int) -> ft.Contro
     )
 
 
-def _build_bottom_status_bar(env_name: str) -> ft.Control:
+def _build_bottom_status_bar(
+    *,
+    env_name: str,
+    viewer_entry: MockEntry | None,
+    active_entry_mock: MockEntry | None,
+) -> ft.Control:
+    active_text = _active_mock_status_text(active_entry_mock, viewer_entry)
+    viewer_text = (
+        f"Viendo: {_entry_short_label(viewer_entry)}"
+        if viewer_entry is not None
+        else "Sin entry en visor"
+    )
+
     return ft.Container(
         height=BOTTOM_BAR_HEIGHT,
         bgcolor=COLOR_BOTTOM_BAR_BG,
@@ -356,7 +535,7 @@ def _build_bottom_status_bar(env_name: str) -> ft.Control:
                             color=COLOR_WHITE,
                         ),
                         ft.Text(
-                            "Los totales reales se conectarán con lecturas read-only.",
+                            "Se conectarán con Q1 y reglas de recursos en #54+.",
                             size=12,
                             color="#EAF9FF",
                         ),
@@ -367,15 +546,23 @@ def _build_bottom_status_bar(env_name: str) -> ft.Control:
                     horizontal_alignment=ft.CrossAxisAlignment.END,
                     controls=[
                         ft.Text(
-                            "Activo global (placeholder)",
-                            size=14,
+                            active_text,
+                            size=13,
                             weight=ft.FontWeight.BOLD,
                             color=COLOR_WHITE,
+                            text_align=ft.TextAlign.RIGHT,
                         ),
                         ft.Text(
-                            f"Sin sesión activa · env={env_name}",
+                            viewer_text,
                             size=12,
                             color="#EAF9FF",
+                            text_align=ft.TextAlign.RIGHT,
+                        ),
+                        ft.Text(
+                            f"env={env_name}",
+                            size=11,
+                            color="#DDF5FF",
+                            text_align=ft.TextAlign.RIGHT,
                         ),
                     ],
                 ),
@@ -384,9 +571,50 @@ def _build_bottom_status_bar(env_name: str) -> ft.Control:
     )
 
 
-def _selected_week_number(preview_state: ShellPreviewState) -> int | None:
-    if preview_state == ShellPreviewState.WEEK_SELECTED:
-        return _WEEK_SELECTED_NUMBER
-    if preview_state == ShellPreviewState.ENTRY_SELECTED:
-        return _ENTRY_SELECTED_WEEK_NUMBER
+def _active_mock_status_text(
+    active_entry_mock: MockEntry | None,
+    viewer_entry: MockEntry | None,
+) -> str:
+    if active_entry_mock is None:
+        return "Sin sesión activa (mock)"
+
+    base = f"Con sesión activa (mock): {_entry_short_label(active_entry_mock)}"
+    if viewer_entry is not None and viewer_entry.ref == active_entry_mock.ref:
+        return f"{base} · aquí"
+    return f"{base} · en otra entry"
+
+
+def _entry_short_label(entry: MockEntry) -> str:
+    return f"{entry.label} (W{entry.ref.week_number})"
+
+
+def _find_selected_week(
+    state: MainScreenLocalState,
+    weeks_for_selected_year: list[MockWeek],
+) -> MockWeek | None:
+    if state.selected_week is None:
+        return None
+    for week in weeks_for_selected_year:
+        if week.week_number == state.selected_week:
+            return week
     return None
+
+
+def _viewer_matches_selected_week(
+    state: MainScreenLocalState,
+    viewer_entry: MockEntry | None,
+) -> bool:
+    if viewer_entry is None:
+        return False
+    return _entry_ref_matches_selected_week(state, viewer_entry.ref)
+
+
+def _entry_ref_matches_selected_week(
+    state: MainScreenLocalState,
+    entry_ref: EntryRef,
+) -> bool:
+    return (
+        state.selected_week is not None
+        and entry_ref.year_number == state.selected_year
+        and entry_ref.week_number == state.selected_week
+    )

--- a/src/main.py
+++ b/src/main.py
@@ -13,7 +13,7 @@ def main(page: ft.Page) -> None:
     page.padding = 0
     page.horizontal_alignment = ft.CrossAxisAlignment.STRETCH
     page.vertical_alignment = ft.MainAxisAlignment.START
-    page.add(build_app_root())
+    page.add(build_app_root(page))
 
 
 def run() -> None:


### PR DESCRIPTION
﻿## Resumen

Implementa `#53` con estado local de pantalla principal (sin Firestore), separando navegación, visor sticky y activo mock.

## Cambios principales

- Refactor de `app_root` como owner del estado local (`selected_year`, `selected_week`, `viewer_entry_ref`, `active_entry_ref_mock`).
- Shell `main_shell_view` pasa de preview estático a builder presentacional state-driven con callbacks.
- Dataset mock en `state/placeholders.py` (años/weeks/entries) para demostrar navegación y casos de visor/activo.
- Weeks cerradas atenuadas y selección visual.
- Visor sticky: la entry visible persiste al navegar por otras weeks/años.
- Activo mock diferenciado visualmente (`aquí` / `en otra entry`).
- Parche documental por semántica de visor sticky (`#16`, `#14`) + `DEC-0033`.
- Tracking actualizado: `#53` cerrada, `#54` como siguiente.

## Validación

- `pipenv run python -m compileall src`
- `rg` sin APIs Flet deprecadas usadas en el código (`ft.app`, `ft.padding.all`, `ft.border.all`, `ft.alignment.center`)
- Smoke runtime Flet web (puertos auxiliares `8552/8553`) con Playwright:
  - carga OK (`Flutter app loaded`)
  - sin errores/warnings en consola web
  - navegación local, selección, visor sticky y activo mock validados vía árbol semántico (accesibilidad Flutter)
- Verificación de warnings Python/Flet en log de arranque limpio (`8553`): sin warnings

## Notas

- `#53` mantiene todo mock/local: sin Firestore y sin mutaciones de dominio.
- Se incluye hotfix de compatibilidad runtime detectado durante validación (`SafeArea` requiere `content` en Flet 0.80).

Closes #53
