### PR TITLE
feat(data): integra lecturas read-only iniciales de Firestore (#54)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dist/
 .env
 .env.*
 !.env.example
+.secrets/
 
 # Logs
 *.log

--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,8 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+google-cloud-firestore = "*"
+python-dotenv = "*"
 flet = "*"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "af86b0e77288b81d3def467f4f698a1e0484eedd2832e99b1a1136df01345d1d"
+            "sha256": "61dacd5c79aa270f954d017fba5e7109ad53167cf8edadcefd519f3956f9794d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -27,20 +27,403 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c",
-                "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120"
+                "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa",
+                "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2026.1.4"
+            "version": "==2026.2.25"
+        },
+        "cffi": {
+            "hashes": [
+                "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb",
+                "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b",
+                "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f",
+                "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9",
+                "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44",
+                "sha256:0f6084a0ea23d05d20c3edcda20c3d006f9b6f3fefeac38f59262e10cef47ee2",
+                "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c",
+                "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75",
+                "sha256:1cd13c99ce269b3ed80b417dcd591415d3372bcac067009b6e0f59c7d4015e65",
+                "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e",
+                "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a",
+                "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e",
+                "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25",
+                "sha256:2081580ebb843f759b9f617314a24ed5738c51d2aee65d31e02f6f7a2b97707a",
+                "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe",
+                "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b",
+                "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91",
+                "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592",
+                "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187",
+                "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c",
+                "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1",
+                "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94",
+                "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba",
+                "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb",
+                "sha256:3f4d46d8b35698056ec29bca21546e1551a205058ae1a181d871e278b0b28165",
+                "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529",
+                "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca",
+                "sha256:4647afc2f90d1ddd33441e5b0e85b16b12ddec4fca55f0d9671fef036ecca27c",
+                "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6",
+                "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c",
+                "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0",
+                "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743",
+                "sha256:61d028e90346df14fedc3d1e5441df818d095f3b87d286825dfcbd6459b7ef63",
+                "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5",
+                "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5",
+                "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4",
+                "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d",
+                "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b",
+                "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93",
+                "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205",
+                "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27",
+                "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512",
+                "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d",
+                "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c",
+                "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037",
+                "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26",
+                "sha256:89472c9762729b5ae1ad974b777416bfda4ac5642423fa93bd57a09204712322",
+                "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb",
+                "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c",
+                "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8",
+                "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4",
+                "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414",
+                "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9",
+                "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664",
+                "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9",
+                "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775",
+                "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739",
+                "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc",
+                "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062",
+                "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe",
+                "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9",
+                "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92",
+                "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5",
+                "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13",
+                "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d",
+                "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26",
+                "sha256:cb527a79772e5ef98fb1d700678fe031e353e765d1ca2d409c92263c6d43e09f",
+                "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495",
+                "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b",
+                "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6",
+                "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c",
+                "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef",
+                "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5",
+                "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18",
+                "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad",
+                "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3",
+                "sha256:de8dad4425a6ca6e4e5e297b27b5c824ecc7581910bf9aee86cb6835e6812aa7",
+                "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5",
+                "sha256:e6e73b9e02893c764e7e8d5bb5ce277f1a009cd5243f8228f75f842bf937c534",
+                "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49",
+                "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2",
+                "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5",
+                "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453",
+                "sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.0.0"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:027f6de494925c0ab2a55eab46ae5129951638a49a34d87f4c3eda90f696b4ad",
+                "sha256:077fbb858e903c73f6c9db43374fd213b0b6a778106bc7032446a8e8b5b38b93",
+                "sha256:0a98e6759f854bd25a58a73fa88833fba3b7c491169f86ce1180c948ab3fd394",
+                "sha256:0d3d8f15c07f86e9ff82319b3d9ef6f4bf907608f53fe9d92b28ea9ae3d1fd89",
+                "sha256:0f04b14ffe5fdc8c4933862d8306109a2c51e0704acfa35d51598eb45a1e89fc",
+                "sha256:11d694519d7f29d6cd09f6ac70028dba10f92f6cdd059096db198c283794ac86",
+                "sha256:194f08cbb32dc406d6e1aea671a68be0823673db2832b38405deba2fb0d88f63",
+                "sha256:1bee1e43c28aa63cb16e5c14e582580546b08e535299b8b6158a7c9c768a1f3d",
+                "sha256:21d142cc6c0ec30d2efee5068ca36c128a30b0f2c53c1c07bd78cb6bc1d3be5f",
+                "sha256:2437418e20515acec67d86e12bf70056a33abdacb5cb1655042f6538d6b085a8",
+                "sha256:244bfb999c71b35de57821b8ea746b24e863398194a4014e4c76adc2bbdfeff0",
+                "sha256:2677acec1a2f8ef614c6888b5b4ae4060cc184174a938ed4e8ef690e15d3e505",
+                "sha256:277e970e750505ed74c832b4bf75dac7476262ee2a013f5574dd49075879e161",
+                "sha256:2aaba3b0819274cc41757a1da876f810a3e4d7b6eb25699253a4effef9e8e4af",
+                "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152",
+                "sha256:2c9d3c380143a1fedbff95a312aa798578371eb29da42106a29019368a475318",
+                "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72",
+                "sha256:31fd66405eaf47bb62e8cd575dc621c56c668f27d46a61d975a249930dd5e2a4",
+                "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e",
+                "sha256:376bec83a63b8021bb5c8ea75e21c4ccb86e7e45ca4eb81146091b56599b80c3",
+                "sha256:44c2a8734b333e0578090c4cd6b16f275e07aa6614ca8715e6c038e865e70576",
+                "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c",
+                "sha256:4902828217069c3c5c71094537a8e623f5d097858ac6ca8252f7b4d10b7560f1",
+                "sha256:4bd5d4137d500351a30687c2d3971758aac9a19208fc110ccb9d7188fbe709e8",
+                "sha256:4fe7859a4e3e8457458e2ff592f15ccb02f3da787fcd31e0183879c3ad4692a1",
+                "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2",
+                "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44",
+                "sha256:5833d2c39d8896e4e19b689ffc198f08ea58116bee26dea51e362ecc7cd3ed26",
+                "sha256:5947809c8a2417be3267efc979c47d76a079758166f7d43ef5ae8e9f92751f88",
+                "sha256:5ae497466c7901d54b639cf42d5b8c1b6a4fead55215500d2f486d34db48d016",
+                "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede",
+                "sha256:5bfbb1b9acf3334612667b61bd3002196fe2a1eb4dd74d247e0f2a4d50ec9bbf",
+                "sha256:5cb4d72eea50c8868f5288b7f7f33ed276118325c1dfd3957089f6b519e1382a",
+                "sha256:5dbe56a36425d26d6cfb40ce79c314a2e4dd6211d51d6d2191c00bed34f354cc",
+                "sha256:5f819d5fe9234f9f82d75bdfa9aef3a3d72c4d24a6e57aeaebba32a704553aa0",
+                "sha256:64b55f9dce520635f018f907ff1b0df1fdc31f2795a922fb49dd14fbcdf48c84",
+                "sha256:6515f3182dbe4ea06ced2d9e8666d97b46ef4c75e326b79bb624110f122551db",
+                "sha256:65e2befcd84bc6f37095f5961e68a6f077bf44946771354a28ad434c2cce0ae1",
+                "sha256:6aee717dcfead04c6eb1ce3bd29ac1e22663cdea57f943c87d1eab9a025438d7",
+                "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed",
+                "sha256:6e1fcf0720908f200cd21aa4e6750a48ff6ce4afe7ff5a79a90d5ed8a08296f8",
+                "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133",
+                "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e",
+                "sha256:74bb723680f9f7a6234dcf67aea57e708ec1fbdf5699fb91dfd6f511b0a320ef",
+                "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14",
+                "sha256:778d2e08eda00f4256d7f672ca9fef386071c9202f5e4607920b86d7803387f2",
+                "sha256:780236ac706e66881f3b7f2f32dfe90507a09e67d1d454c762cf642e6e1586e0",
+                "sha256:798d75d81754988d2565bff1b97ba5a44411867c0cf32b77a7e8f8d84796b10d",
+                "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828",
+                "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f",
+                "sha256:7c308f7e26e4363d79df40ca5b2be1c6ba9f02bdbccfed5abddb7859a6ce72cf",
+                "sha256:7fa17817dc5625de8a027cb8b26d9fefa3ea28c8253929b8d6649e705d2835b6",
+                "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328",
+                "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090",
+                "sha256:837c2ce8c5a65a2035be9b3569c684358dfbf109fd3b6969630a87535495ceaa",
+                "sha256:840c25fb618a231545cbab0564a799f101b63b9901f2569faecd6b222ac72381",
+                "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c",
+                "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb",
+                "sha256:8ef3c867360f88ac904fd3f5e1f902f13307af9052646963ee08ff4f131adafc",
+                "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a",
+                "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec",
+                "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc",
+                "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac",
+                "sha256:9cd98cdc06614a2f768d2b7286d66805f94c48cde050acdbbb7db2600ab3197e",
+                "sha256:9d1bb833febdff5c8927f922386db610b49db6e0d4f4ee29601d71e7c2694313",
+                "sha256:9f7fcd74d410a36883701fafa2482a6af2ff5ba96b9a620e9e0721e28ead5569",
+                "sha256:a59cb51917aa591b1c4e6a43c132f0cdc3c76dbad6155df4e28ee626cc77a0a3",
+                "sha256:a61900df84c667873b292c3de315a786dd8dac506704dea57bc957bd31e22c7d",
+                "sha256:a79cfe37875f822425b89a82333404539ae63dbdddf97f84dcbc3d339aae9525",
+                "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894",
+                "sha256:a8bf8d0f749c5757af2142fe7903a9df1d2e8aa3841559b2bad34b08d0e2bcf3",
+                "sha256:a9768c477b9d7bd54bc0c86dbaebdec6f03306675526c9927c0e8a04e8f94af9",
+                "sha256:ac1c4a689edcc530fc9d9aa11f5774b9e2f33f9a0c6a57864e90908f5208d30a",
+                "sha256:af2d8c67d8e573d6de5bc30cdb27e9b95e49115cd9baad5ddbd1a6207aaa82a9",
+                "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14",
+                "sha256:b5b290ccc2a263e8d185130284f8501e3e36c5e02750fc6b6bdeb2e9e96f1e25",
+                "sha256:b5d84d37db046c5ca74ee7bb47dd6cbc13f80665fdde3e8040bdd3fb015ecb50",
+                "sha256:b7cf1017d601aa35e6bb650b6ad28652c9cd78ee6caff19f3c28d03e1c80acbf",
+                "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1",
+                "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3",
+                "sha256:c4ef880e27901b6cc782f1b95f82da9313c0eb95c3af699103088fa0ac3ce9ac",
+                "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e",
+                "sha256:ca5862d5b3928c4940729dacc329aa9102900382fea192fc5e52eb69d6093815",
+                "sha256:cb01158d8b88ee68f15949894ccc6712278243d95f344770fa7593fa2d94410c",
+                "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6",
+                "sha256:cc00f04ed596e9dc0da42ed17ac5e596c6ccba999ba6bd92b0e0aef2f170f2d6",
+                "sha256:cd09d08005f958f370f539f186d10aec3377d55b9eeb0d796025d4886119d76e",
+                "sha256:cd4b7ca9984e5e7985c12bc60a6f173f3c958eae74f3ef6624bb6b26e2abbae4",
+                "sha256:ce8a0633f41a967713a59c4139d29110c07e826d131a316b50ce11b1d79b4f84",
+                "sha256:cead0978fc57397645f12578bfd2d5ea9138ea0fac82b2f63f7f7c6877986a69",
+                "sha256:d055ec1e26e441f6187acf818b73564e6e6282709e9bcb5b63f5b23068356a15",
+                "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191",
+                "sha256:d9c7f57c3d666a53421049053eaacdd14bbd0a528e2186fcb2e672effd053bb0",
+                "sha256:d9e45d7faa48ee908174d8fe84854479ef838fc6a705c9315372eacbc2f02897",
+                "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd",
+                "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2",
+                "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794",
+                "sha256:e824f1492727fa856dd6eda4f7cee25f8518a12f3c4a56a74e8095695089cf6d",
+                "sha256:e912091979546adf63357d7e2ccff9b44f026c075aeaf25a52d0e95ad2281074",
+                "sha256:eaabd426fe94daf8fd157c32e571c85cb12e66692f15516a83a03264b08d06c3",
+                "sha256:ebf3e58c7ec8a8bed6d66a75d7fb37b55e5015b03ceae72a8e7c74495551e224",
+                "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838",
+                "sha256:eecbc200c7fd5ddb9a7f16c7decb07b566c29fa2161a16cf67b8d068bd21690a",
+                "sha256:f155a433c2ec037d4e8df17d18922c3a0d9b3232a396690f17175d2946f0218d",
+                "sha256:f1e34719c6ed0b92f418c7c780480b26b5d9c50349e9a9af7d76bf757530350d",
+                "sha256:f34be2938726fc13801220747472850852fe6b1ea75869a048d6f896838c896f",
+                "sha256:f820802628d2694cb7e56db99213f930856014862f3fd943d290ea8438d07ca8",
+                "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490",
+                "sha256:f8e160feb2aed042cd657a72acc0b481212ed28b1b9a95c0cee1621b524e1966",
+                "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9",
+                "sha256:fa09f53c465e532f4d3db095e0c55b615f010ad81803d383195b6b5ca6cbf5f3",
+                "sha256:faa3a41b2b66b6e50f84ae4a68c64fcd0c44355741c6374813a800cd6695db9e",
+                "sha256:fd44c878ea55ba351104cb93cc85e74916eb8fa440ca7903e57575e97394f608"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.4.4"
+        },
+        "cryptography": {
+            "hashes": [
+                "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72",
+                "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235",
+                "sha256:1abfdb89b41c3be0365328a410baa9df3ff8a9110fb75e7b52e66803ddabc9a9",
+                "sha256:2ae6971afd6246710480e3f15824ed3029a60fc16991db250034efd0b9fb4356",
+                "sha256:2b7a67c9cd56372f3249b39699f2ad479f6991e62ea15800973b956f4b73e257",
+                "sha256:351695ada9ea9618b3500b490ad54c739860883df6c1f555e088eaf25b1bbaad",
+                "sha256:38946c54b16c885c72c4f59846be9743d699eee2b69b6988e0a00a01f46a61a4",
+                "sha256:3b4995dc971c9fb83c25aa44cf45f02ba86f71ee600d81091c2f0cbae116b06c",
+                "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614",
+                "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed",
+                "sha256:4108d4c09fbbf2789d0c926eb4152ae1760d5a2d97612b92d508d96c861e4d31",
+                "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229",
+                "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0",
+                "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731",
+                "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b",
+                "sha256:4d8ae8659ab18c65ced284993c2265910f6c9e650189d4e3f68445ef82a810e4",
+                "sha256:4e817a8920bfbcff8940ecfd60f23d01836408242b30f1a708d93198393a80b4",
+                "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263",
+                "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595",
+                "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1",
+                "sha256:5be7bf2fb40769e05739dd0046e7b26f9d4670badc7b032d6ce4db64dddc0678",
+                "sha256:60ee7e19e95104d4c03871d7d7dfb3d22ef8a9b9c6778c94e1c8fcc8365afd48",
+                "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76",
+                "sha256:68f68d13f2e1cb95163fa3b4db4bf9a159a418f5f6e7242564fc75fcae667fd0",
+                "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18",
+                "sha256:7d731d4b107030987fd61a7f8ab512b25b53cef8f233a97379ede116f30eb67d",
+                "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d",
+                "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1",
+                "sha256:8293f3dea7fc929ef7240796ba231413afa7b68ce38fd21da2995549f5961981",
+                "sha256:8456928655f856c6e1533ff59d5be76578a7157224dbd9ce6872f25055ab9ab7",
+                "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82",
+                "sha256:94a76daa32eb78d61339aff7952ea819b1734b46f73646a07decb40e5b3448e2",
+                "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4",
+                "sha256:a3d1fae9863299076f05cb8a778c467578262fae09f9dc0ee9b12eb4268ce663",
+                "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c",
+                "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d",
+                "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a",
+                "sha256:bc84e875994c3b445871ea7181d424588171efec3e185dced958dad9e001950a",
+                "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d",
+                "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b",
+                "sha256:c3bcce8521d785d510b2aad26ae2c966092b7daa8f45dd8f44734a104dc0bc1a",
+                "sha256:c4143987a42a2397f2fc3b4d7e3a7d313fbe684f67ff443999e803dd75a76826",
+                "sha256:c69fd885df7d089548a42d5ec05be26050ebcd2283d89b3d30676eb32ff87dee",
+                "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9",
+                "sha256:d66e421495fdb797610a08f43b05269e0a5ea7f5e652a89bfd5a7d3c1dee3648",
+                "sha256:d861ee9e76ace6cf36a6a89b959ec08e7bc2493ee39d07ffe5acb23ef46d27da",
+                "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2",
+                "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2",
+                "sha256:fe346b143ff9685e40192a4960938545c699054ba11d4f9029f94751e3f71d87"
+            ],
+            "markers": "python_version >= '3.8' and python_full_version not in '3.9.0, 3.9.1'",
+            "version": "==46.0.5"
         },
         "flet": {
             "hashes": [
-                "sha256:8ce4cde04fa698515d273b8dcb6261a873e965c493740c590ca09b8e698cae16",
-                "sha256:9317dba543cf6a8773f991d08c570bee377cc916780ed57362114e4777c1ea5c"
+                "sha256:2bc22d9ddf65b30a836fff43455968a1531f0673a41c1c89eec494816ed68676",
+                "sha256:406466e378c8e863e6af1247f308837dfc90f4e1a40d476e47ac3881ff4b76e7"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==0.80.5"
+            "version": "==0.81.0"
+        },
+        "google-api-core": {
+            "extras": [
+                "grpc"
+            ],
+            "hashes": [
+                "sha256:02edfa9fab31e17fc0befb5f161b3bf93c9096d99aed584625f38065c511ad9b",
+                "sha256:80be49ee937ff9aba0fd79a6eddfde35fe658b9953ab9b79c57dd7061afa8df5"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.30.0"
+        },
+        "google-auth": {
+            "hashes": [
+                "sha256:2e2a537873d449434252a9632c28bfc268b0adb1e53f9fb62afc5333a975903f",
+                "sha256:4f7e706b0cd3208a3d940a19a822c37a476ddba5450156c3e6624a71f7c841ce"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.48.0"
+        },
+        "google-cloud-core": {
+            "hashes": [
+                "sha256:67d977b41ae6c7211ee830c7912e41003ea8194bff15ae7d72fd6f51e57acabc",
+                "sha256:7c1b7ef5c92311717bd05301aa1a91ffbc565673d3b0b4163a52d8413a186963"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.5.0"
+        },
+        "google-cloud-firestore": {
+            "hashes": [
+                "sha256:19f2326cb466b0d52aed9fabbd89758be431f6ce18c422966cfdb8326b424314",
+                "sha256:a9cffba7cdc6101111d6d54cde22d521c98f9e7d415e67486b137fa16f06aa03"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==2.23.0"
+        },
+        "googleapis-common-protos": {
+            "hashes": [
+                "sha256:4299c5a82d5ae1a9702ada957347726b167f9f8d1fc352477702a1e851ff4038",
+                "sha256:e55a601c1b32b52d7a3e65f43563e2aa61bcd737998ee672ac9b951cd49319f5"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.72.0"
+        },
+        "grpcio": {
+            "hashes": [
+                "sha256:02b82dcd2fa580f5e82b4cf62ecde1b3c7cc9ba27b946421200706a6e5acaf85",
+                "sha256:07eb016ea7444a22bef465cce045512756956433f54450aeaa0b443b8563b9ca",
+                "sha256:09fbd4bcaadb6d8604ed1504b0bdf7ac18e48467e83a9d930a70a7fefa27e862",
+                "sha256:0fa9943d4c7f4a14a9a876153a4e8ee2bb20a410b65c09f31510b2a42271f41b",
+                "sha256:13937b28986f45fee342806b07c6344db785ad74a549ebcb00c659142973556f",
+                "sha256:15f6e636d1152667ddb4022b37534c161c8477274edb26a0b65b215dd0a81e97",
+                "sha256:1a56bf3ee99af5cf32d469de91bf5de79bdac2e18082b495fc1063ea33f4f2d0",
+                "sha256:263307118791bc350f4642749a9c8c2d13fec496228ab11070973e568c256bfd",
+                "sha256:27b5cb669603efb7883a882275db88b6b5d6b6c9f0267d5846ba8699b7ace338",
+                "sha256:27c625532d33ace45d57e775edf1982e183ff8641c72e4e91ef7ba667a149d72",
+                "sha256:2b7ad2981550ce999e25ce3f10c8863f718a352a2fd655068d29ea3fd37b4907",
+                "sha256:2c473b54ef1618f4fb85e82ff4994de18143b74efc088b91b5a935a3a45042ba",
+                "sha256:34b6cb16f4b67eeb5206250dc5b4d5e8e3db939535e58efc330e4c61341554bd",
+                "sha256:36aeff5ba8aaf70ceb2cbf6cbba9ad6beef715ad744841f3e0cd977ec02e5966",
+                "sha256:389b77484959bdaad6a2b7dda44d7d1228381dd669a03f5660392aa0e9385b22",
+                "sha256:39d21fd30d38a5afb93f0e2e71e2ec2bd894605fb75d41d5a40060c2f98f8d11",
+                "sha256:39da1680d260c0c619c3b5fa2dc47480ca24d5704c7a548098bca7de7f5dd17f",
+                "sha256:3a8aa79bc6e004394c0abefd4b034c14affda7b66480085d87f5fbadf43b593b",
+                "sha256:409bfe22220889b9906739910a0ee4c197a967c21b8dd14b4b06dd477f8819ce",
+                "sha256:41e4605c923e0e9a84a2718e4948a53a530172bfaf1a6d1ded16ef9c5849fca2",
+                "sha256:4393bef64cf26dc07cd6f18eaa5170ae4eebaafd4418e7e3a59ca9526a6fa30b",
+                "sha256:43b930cf4f9c4a2262bb3e5d5bc40df426a72538b4f98e46f158b7eb112d2d70",
+                "sha256:4b8d7fda614cf2af0f73bbb042f3b7fee2ecd4aea69ec98dbd903590a1083529",
+                "sha256:4d50329b081c223d444751076bb5b389d4f06c2b32d51b31a1e98172e6cecfb9",
+                "sha256:5380268ab8513445740f1f77bd966d13043d07e2793487e61fd5b5d0935071eb",
+                "sha256:5572c5dd1e43dbb452b466be9794f77e3502bdb6aa6a1a7feca72c98c5085ca7",
+                "sha256:559f58b6823e1abc38f82e157800aff649146f8906f7998c356cd48ae274d512",
+                "sha256:5ce1855e8cfc217cdf6bcfe0cf046d7cf81ddcc3e6894d6cfd075f87a2d8f460",
+                "sha256:656a5bd142caeb8b1efe1fe0b4434ecc7781f44c97cfc7927f6608627cf178c0",
+                "sha256:716a544969660ed609164aff27b2effd3ff84e54ac81aa4ce77b1607ca917d22",
+                "sha256:75fa92c47d048d696f12b81a775316fca68385ffc6e6cb1ed1d76c8562579f74",
+                "sha256:7e836778c13ff70edada16567e8da0c431e8818eaae85b80d11c1ba5782eccbb",
+                "sha256:849cc62eb989bc3be5629d4f3acef79be0d0ff15622201ed251a86d17fef6494",
+                "sha256:86edb3966778fa05bfdb333688fde5dc9079f9e2a9aa6a5c42e9564b7656ba04",
+                "sha256:888ceb7821acd925b1c90f0cdceaed1386e69cfe25e496e0771f6c35a156132f",
+                "sha256:8942bdfc143b467c264b048862090c4ba9a0223c52ae28c9ae97754361372e42",
+                "sha256:8991c2add0d8505178ff6c3ae54bd9386279e712be82fa3733c54067aae9eda1",
+                "sha256:8e1fcb419da5811deb47b7749b8049f7c62b993ba17822e3c7231e3e0ba65b79",
+                "sha256:8f27683ca68359bd3f0eb4925824d71e538f84338b3ae337ead2ae43977d7541",
+                "sha256:917047c19cd120b40aab9a4b8a22e9ce3562f4a1343c0d62b3cd2d5199da3d67",
+                "sha256:99550e344482e3c21950c034f74668fccf8a546d50c1ecb4f717543bbdc071ba",
+                "sha256:9a00992d6fafe19d648b9ccb4952200c50d8e36d0cce8cf026c56ed3fdc28465",
+                "sha256:9dee66d142f4a8cca36b5b98a38f006419138c3c89e72071747f8fca415a6d8f",
+                "sha256:a40515b69ac50792f9b8ead260f194ba2bb3285375b6c40c7ff938f14c3df17d",
+                "sha256:a6afd191551fd72e632367dfb083e33cd185bf9ead565f2476bba8ab864ae496",
+                "sha256:b071dccac245c32cd6b1dd96b722283b855881ca0bf1c685cf843185f5d5d51e",
+                "sha256:b2acd83186305c0802dbc4d81ed0ec2f3e8658d7fde97cfba2f78d7372f05b89",
+                "sha256:b5d5881d72a09b8336a8f874784a8eeffacde44a7bc1a148bce5a0243a265ef0",
+                "sha256:ca6aebae928383e971d5eace4f1a217fd7aadaf18d5ddd3163d80354105e9068",
+                "sha256:cd26048d066b51f39fe9206e2bcc2cea869a5e5b2d13c8d523f4179193047ebd",
+                "sha256:d101fe49b1e0fb4a7aa36ed0c3821a0f67a5956ef572745452d2cd790d723a3f",
+                "sha256:d6fb962947e4fe321eeef3be1ba5ba49d32dea9233c825fcbade8e858c14aaf4",
+                "sha256:db681513a1bdd879c0b24a5a6a70398da5eaaba0e077a306410dc6008426847a",
+                "sha256:e2a6b33d1050dce2c6f563c5caf7f7cbeebf7fba8cde37ffe3803d50526900d1",
+                "sha256:e49e720cd6b092504ec7bb2f60eb459aaaf4ce0e5fe20521c201b179e93b5d5d",
+                "sha256:e840405a3f1249509892be2399f668c59b9d492068a2cf326d661a8c79e5e747",
+                "sha256:ebeec1383aed86530a5f39646984e92d6596c050629982ac54eeb4e2f6ead668",
+                "sha256:f81816faa426da461e9a597a178832a351d6f1078102590a4b32c77d251b71eb",
+                "sha256:f8759a1347f3b4f03d9a9d4ce8f9f31ad5e5d0144ba06ccfb1ffaeb0ba4c1e20",
+                "sha256:ff7de398bb3528d44d17e6913a7cfe639e3b15c65595a71155322df16978c5e1",
+                "sha256:ffbb760df1cd49e0989f9826b2fd48930700db6846ac171eaff404f3cfbe5c28"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.78.1"
+        },
+        "grpcio-status": {
+            "hashes": [
+                "sha256:47e7fa903549c5881344f1cba23c814b5f69d09233541036eb25642d32497c8e",
+                "sha256:5f6660b99063f918b7f84d99cab68084aeb0dd09949e1224a6073026cea6820c"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.78.1"
         },
         "h11": {
             "hashes": [
@@ -150,12 +533,85 @@
             "markers": "python_version >= '3.8'",
             "version": "==3.3.1"
         },
+        "proto-plus": {
+            "hashes": [
+                "sha256:912a7460446625b792f6448bade9e55cd4e41e6ac10e27009ef71a7f317fa147",
+                "sha256:e4643061f3a4d0de092d62aa4ad09fa4756b2cbb89d4627f3985018216f9fefc"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.27.1"
+        },
+        "protobuf": {
+            "hashes": [
+                "sha256:3093804752167bcab3998bec9f1048baae6e29505adaf1afd14a37bddede533c",
+                "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02",
+                "sha256:6ddcac2a081f8b7b9642c09406bc6a4290128fce5f471cddd165960bb9119e5c",
+                "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd",
+                "sha256:8f04fa32763dcdb4973d537d6b54e615cc61108c7cb38fe59310c3192d29510a",
+                "sha256:9b71e0281f36f179d00cbcb119cb19dec4d14a81393e5ea220f64b286173e190",
+                "sha256:a3157e62729aafb8df6da2c03aa5c0937c7266c626ce11a278b6eb7963c4e37c",
+                "sha256:a5cb85982d95d906df1e2210e58f8e4f1e3cdc088e52c921a041f9c9a0386de5",
+                "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0",
+                "sha256:d71b040839446bac0f4d162e758bea99c8251161dae9d0983a3b88dee345153b"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==6.33.5"
+        },
+        "pyasn1": {
+            "hashes": [
+                "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf",
+                "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.6.2"
+        },
+        "pyasn1-modules": {
+            "hashes": [
+                "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a",
+                "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.4.2"
+        },
+        "pycparser": {
+            "hashes": [
+                "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29",
+                "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==3.0"
+        },
+        "python-dotenv": {
+            "hashes": [
+                "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6",
+                "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==1.2.1"
+        },
         "repath": {
             "hashes": [
                 "sha256:8292139bac6a0e43fd9d70605d4e8daeb25d46672e484ed31a24c7ce0aef0fb7",
                 "sha256:ee079d6c91faeb843274d22d8f786094ee01316ecfe293a1eb6546312bb6a318"
             ],
             "version": "==0.9.0"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6",
+                "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.32.5"
+        },
+        "rsa": {
+            "hashes": [
+                "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762",
+                "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75"
+            ],
+            "markers": "python_version >= '3.6' and python_version < '4'",
+            "version": "==4.9.1"
         },
         "six": {
             "hashes": [
@@ -172,6 +628,14 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==4.15.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed",
+                "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.6.3"
         }
     },
     "develop": {}

--- a/src/frosthaven_campaign_journal/config/settings.py
+++ b/src/frosthaven_campaign_journal/config/settings.py
@@ -2,6 +2,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
 
 @dataclass(frozen=True)
@@ -12,9 +18,16 @@ class Settings:
 
 
 def load_settings() -> Settings:
+    load_dotenv(PROJECT_ROOT / ".env", override=False)
+
+    credentials_path = os.getenv("GOOGLE_APPLICATION_CREDENTIALS") or None
+    if credentials_path:
+        path_obj = Path(credentials_path)
+        if not path_obj.is_absolute():
+            credentials_path = str((PROJECT_ROOT / path_obj).resolve())
+
     return Settings(
         env=os.getenv("FHCJ_ENV", "dev"),
         firestore_project_id=os.getenv("FIRESTORE_PROJECT_ID") or None,
-        google_application_credentials=os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
-        or None,
+        google_application_credentials=credentials_path,
     )

--- a/src/frosthaven_campaign_journal/data/__init__.py
+++ b/src/frosthaven_campaign_journal/data/__init__.py
@@ -1,1 +1,31 @@
-"""Data access placeholders for future Firestore integration."""
+"""Data access helpers for Firestore and read-only app slices."""
+
+from .firestore_client import (
+    FirestoreConfigError,
+    FirestoreReadError,
+    build_firestore_client,
+)
+from .firestore_placeholder import describe_firestore_status
+from .main_screen_reads import (
+    ActiveEntryRead,
+    ActiveSessionRead,
+    CampaignMainRead,
+    MainScreenSnapshot,
+    WeekRead,
+    derive_year_from_week_cursor,
+    load_main_screen_snapshot,
+)
+
+__all__ = [
+    "ActiveEntryRead",
+    "ActiveSessionRead",
+    "CampaignMainRead",
+    "FirestoreConfigError",
+    "FirestoreReadError",
+    "MainScreenSnapshot",
+    "WeekRead",
+    "build_firestore_client",
+    "derive_year_from_week_cursor",
+    "describe_firestore_status",
+    "load_main_screen_snapshot",
+]

--- a/src/frosthaven_campaign_journal/data/firestore_client.py
+++ b/src/frosthaven_campaign_journal/data/firestore_client.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from google.auth.exceptions import DefaultCredentialsError
+from google.cloud import firestore
+
+from frosthaven_campaign_journal.config import Settings
+
+
+class FirestoreConfigError(Exception):
+    """Raised when local Firestore configuration is missing or invalid."""
+
+
+class FirestoreReadError(Exception):
+    """Raised when Firestore client initialization or reads fail."""
+
+
+def validate_firestore_settings(settings: Settings) -> None:
+    if not settings.firestore_project_id:
+        raise FirestoreConfigError(
+            "Falta FIRESTORE_PROJECT_ID. Configura la variable en .env o en el entorno."
+        )
+
+    credentials_path = settings.google_application_credentials
+    if not credentials_path:
+        raise FirestoreConfigError(
+            "Falta GOOGLE_APPLICATION_CREDENTIALS. Configura la ruta del JSON de credenciales."
+        )
+
+    path_obj = Path(credentials_path)
+    if not path_obj.exists():
+        raise FirestoreConfigError(
+            f"No existe el archivo de credenciales: {path_obj}"
+        )
+
+
+def build_firestore_client(settings: Settings) -> firestore.Client:
+    validate_firestore_settings(settings)
+    assert settings.google_application_credentials is not None  # narrow typing
+    assert settings.firestore_project_id is not None
+
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = settings.google_application_credentials
+
+    try:
+        return firestore.Client(project=settings.firestore_project_id)
+    except DefaultCredentialsError as exc:
+        raise FirestoreReadError(
+            "No se pudieron cargar las credenciales de Google para Firestore."
+        ) from exc
+    except Exception as exc:  # pragma: no cover - protective branch
+        raise FirestoreReadError(
+            f"Error al inicializar el cliente de Firestore: {exc}"
+        ) from exc

--- a/src/frosthaven_campaign_journal/data/main_screen_reads.py
+++ b/src/frosthaven_campaign_journal/data/main_screen_reads.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from google.cloud import firestore
+from google.cloud.firestore_v1.base_query import FieldFilter
+
+from frosthaven_campaign_journal.data.firestore_client import FirestoreReadError
+from frosthaven_campaign_journal.state.placeholders import EntryRef
+
+
+CAMPAIGN_ID = "01"
+WEEKS_PER_YEAR = 20
+
+
+@dataclass(frozen=True)
+class CampaignMainRead:
+    week_cursor: int
+    resource_totals: dict[str, int]
+    updated_at_utc: Any | None
+
+
+@dataclass(frozen=True)
+class WeekRead:
+    year_number: int
+    week_number: int
+    status: str
+    notes: str | None
+
+
+@dataclass(frozen=True)
+class ActiveSessionRead:
+    session_ref: Any
+    session_id: str
+    started_at_utc: Any | None
+    ended_at_utc: Any | None
+
+
+@dataclass(frozen=True)
+class ActiveEntryRead:
+    entry_ref: EntryRef
+    label: str
+    entry_type: str
+    scenario_ref: int | None
+
+
+@dataclass(frozen=True)
+class MainScreenSnapshot:
+    campaign_main: CampaignMainRead
+    years: list[int]
+    effective_year: int
+    weeks_for_selected_year: list[WeekRead]
+    active_session: ActiveSessionRead | None
+    active_entry: ActiveEntryRead | None
+    active_status_error_message: str | None
+
+
+def read_q1_campaign_main(client: firestore.Client) -> CampaignMainRead:
+    try:
+        snapshot = client.collection("campaigns").document(CAMPAIGN_ID).get()
+    except Exception as exc:
+        raise FirestoreReadError(f"Error leyendo Q1 (`campaigns/{CAMPAIGN_ID}`): {exc}") from exc
+
+    if not snapshot.exists:
+        raise FirestoreReadError(f"No existe el documento de campaña `campaigns/{CAMPAIGN_ID}`.")
+
+    data = snapshot.to_dict() or {}
+    week_cursor_raw = data.get("week_cursor")
+    if not isinstance(week_cursor_raw, int) or week_cursor_raw <= 0:
+        raise FirestoreReadError("Q1 inválido: `week_cursor` debe ser un entero positivo.")
+
+    resource_totals_raw = data.get("resource_totals") or {}
+    if not isinstance(resource_totals_raw, dict):
+        raise FirestoreReadError("Q1 inválido: `resource_totals` debe ser un mapa.")
+
+    resource_totals: dict[str, int] = {}
+    for key, value in resource_totals_raw.items():
+        if not isinstance(key, str):
+            raise FirestoreReadError("Q1 inválido: `resource_totals` contiene una clave no string.")
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise FirestoreReadError(
+                f"Q1 inválido: `resource_totals[{key}]` debe ser entero, recibido {type(value).__name__}."
+            )
+        resource_totals[key] = value
+
+    return CampaignMainRead(
+        week_cursor=week_cursor_raw,
+        resource_totals=resource_totals,
+        updated_at_utc=data.get("updated_at_utc"),
+    )
+
+
+def read_q2_years_list(client: firestore.Client) -> list[int]:
+    years: list[int] = []
+    try:
+        query = (
+            client.collection("campaigns")
+            .document(CAMPAIGN_ID)
+            .collection("years")
+            .order_by("year_number")
+        )
+        for snapshot in query.stream():
+            data = snapshot.to_dict() or {}
+            year_number = data.get("year_number")
+            if year_number is None:
+                try:
+                    year_number = int(snapshot.id)
+                except ValueError as exc:
+                    raise FirestoreReadError(
+                        f"Q2 inválido: year `{snapshot.id}` sin `year_number` parseable."
+                    ) from exc
+            if not isinstance(year_number, int) or year_number <= 0:
+                raise FirestoreReadError(
+                    f"Q2 inválido: `year_number` no válido en doc `{snapshot.id}`."
+                )
+            years.append(year_number)
+    except FirestoreReadError:
+        raise
+    except Exception as exc:
+        raise FirestoreReadError(f"Error leyendo Q2 (`years_list`): {exc}") from exc
+
+    return years
+
+
+def read_q3_q4_weeks_for_year(client: firestore.Client, year_number: int) -> list[WeekRead]:
+    weeks = [
+        *list(_read_weeks_for_season(client, year_number, "summer")),
+        *list(_read_weeks_for_season(client, year_number, "winter")),
+    ]
+    return sorted(weeks, key=lambda week: week.week_number)
+
+
+def _read_weeks_for_season(
+    client: firestore.Client,
+    year_number: int,
+    season_type: str,
+) -> list[WeekRead]:
+    weeks: list[WeekRead] = []
+    try:
+        query = (
+            client.collection("campaigns")
+            .document(CAMPAIGN_ID)
+            .collection("years")
+            .document(str(year_number))
+            .collection("seasons")
+            .document(season_type)
+            .collection("weeks")
+            .order_by("week_number")
+        )
+        for snapshot in query.stream():
+            data = snapshot.to_dict() or {}
+            week_number = data.get("week_number")
+            if not isinstance(week_number, int) or week_number <= 0:
+                try:
+                    week_number = int(snapshot.id)
+                except Exception as exc:
+                    raise FirestoreReadError(
+                        f"Q3/Q4 inválido: `week_number` no válido en `{snapshot.reference.path}`."
+                    ) from exc
+
+            status = data.get("status")
+            if status not in {"open", "closed"}:
+                raise FirestoreReadError(
+                    f"Q3/Q4 inválido: `status` no válido en `{snapshot.reference.path}`."
+                )
+
+            notes = data.get("notes")
+            if notes is not None and not isinstance(notes, str):
+                raise FirestoreReadError(
+                    f"Q3/Q4 inválido: `notes` debe ser string/null en `{snapshot.reference.path}`."
+                )
+
+            weeks.append(
+                WeekRead(
+                    year_number=year_number,
+                    week_number=week_number,
+                    status=status,
+                    notes=notes,
+                )
+            )
+    except FirestoreReadError:
+        raise
+    except Exception as exc:
+        raise FirestoreReadError(
+            f"Error leyendo weeks de `{season_type}` para año {year_number}: {exc}"
+        ) from exc
+
+    return weeks
+
+
+def read_q6_active_session_global(client: firestore.Client) -> ActiveSessionRead | None:
+    try:
+        query = (
+            client.collection_group("sessions")
+            .where(filter=FieldFilter("ended_at_utc", "==", None))
+            .limit(1)
+        )
+        snapshots = list(query.stream())
+    except Exception as exc:
+        raise FirestoreReadError(f"Error leyendo Q6 (`active_session_global`): {exc}") from exc
+
+    if not snapshots:
+        return None
+
+    snapshot = snapshots[0]
+    data = snapshot.to_dict() or {}
+    return ActiveSessionRead(
+        session_ref=snapshot.reference,
+        session_id=snapshot.id,
+        started_at_utc=data.get("started_at_utc"),
+        ended_at_utc=data.get("ended_at_utc"),
+    )
+
+
+def read_q7_active_entry_doc_if_needed(
+    client: firestore.Client,
+    active_session: ActiveSessionRead | None,
+    viewer_entry_ref: EntryRef | None,
+) -> ActiveEntryRead | None:
+    if active_session is None:
+        return None
+
+    entry_doc_ref = active_session.session_ref.parent.parent
+    if entry_doc_ref is None:
+        raise FirestoreReadError("Q7 inválido: no se pudo resolver la Entry owner desde la sesión activa.")
+
+    active_entry_ref = _entry_ref_from_entry_doc_ref(entry_doc_ref)
+
+    # Q7 es condicional; en #54 lo usamos siempre para label del activo.
+    # Mantenemos el parámetro para alineación con #16 y facilitar #54+.
+    _ = viewer_entry_ref
+
+    try:
+        entry_snapshot = entry_doc_ref.get()
+    except Exception as exc:
+        raise FirestoreReadError(f"Error leyendo Q7 (`active_entry_doc_if_needed`): {exc}") from exc
+
+    if not entry_snapshot.exists:
+        raise FirestoreReadError("Q7 inválido: la Entry owner de la sesión activa no existe.")
+
+    data = entry_snapshot.to_dict() or {}
+    entry_type_raw = data.get("type")
+    entry_type = str(entry_type_raw) if entry_type_raw is not None else ""
+
+    scenario_ref_raw = data.get("scenario_ref")
+    scenario_ref: int | None
+    if scenario_ref_raw is None:
+        scenario_ref = None
+    elif isinstance(scenario_ref_raw, bool) or not isinstance(scenario_ref_raw, int):
+        raise FirestoreReadError("Q7 inválido: `scenario_ref` debe ser entero o null.")
+    else:
+        scenario_ref = scenario_ref_raw
+
+    label = _build_entry_label(entry_type=entry_type, scenario_ref=scenario_ref, entry_id=entry_doc_ref.id)
+    return ActiveEntryRead(
+        entry_ref=active_entry_ref,
+        label=label,
+        entry_type=entry_type,
+        scenario_ref=scenario_ref,
+    )
+
+
+def load_main_screen_snapshot(
+    client: firestore.Client,
+    *,
+    selected_year: int | None,
+    viewer_entry_ref: EntryRef | None,
+) -> MainScreenSnapshot:
+    campaign_main = read_q1_campaign_main(client)
+    years = read_q2_years_list(client)
+    if not years:
+        raise FirestoreReadError("Q2 inválido: no hay años provisionados en la campaña.")
+
+    derived_year = derive_year_from_week_cursor(campaign_main.week_cursor)
+    if selected_year is not None and selected_year in years:
+        effective_year = selected_year
+    elif derived_year in years:
+        effective_year = derived_year
+    else:
+        effective_year = years[0]
+
+    weeks_for_selected_year = read_q3_q4_weeks_for_year(client, effective_year)
+
+    active_session: ActiveSessionRead | None = None
+    active_entry: ActiveEntryRead | None = None
+    active_status_error_message: str | None = None
+    try:
+        active_session = read_q6_active_session_global(client)
+        active_entry = read_q7_active_entry_doc_if_needed(
+            client,
+            active_session=active_session,
+            viewer_entry_ref=viewer_entry_ref,
+        )
+    except FirestoreReadError as exc:
+        active_status_error_message = str(exc)
+
+    return MainScreenSnapshot(
+        campaign_main=campaign_main,
+        years=years,
+        effective_year=effective_year,
+        weeks_for_selected_year=weeks_for_selected_year,
+        active_session=active_session,
+        active_entry=active_entry,
+        active_status_error_message=active_status_error_message,
+    )
+
+
+def derive_year_from_week_cursor(week_cursor: int) -> int:
+    return ((week_cursor - 1) // WEEKS_PER_YEAR) + 1
+
+
+def _entry_ref_from_entry_doc_ref(entry_doc_ref: Any) -> EntryRef:
+    try:
+        week_doc_ref = entry_doc_ref.parent.parent
+        season_doc_ref = week_doc_ref.parent.parent
+        year_doc_ref = season_doc_ref.parent.parent
+    except Exception as exc:
+        raise FirestoreReadError("Q7 inválido: no se pudo reconstruir la jerarquía de la Entry activa.") from exc
+
+    if week_doc_ref is None or year_doc_ref is None:
+        raise FirestoreReadError("Q7 inválido: jerarquía incompleta al resolver la Entry activa.")
+
+    try:
+        year_number = int(year_doc_ref.id)
+        week_number = int(week_doc_ref.id)
+    except ValueError as exc:
+        raise FirestoreReadError("Q7 inválido: IDs de year/week no parseables en la ruta de la Entry activa.") from exc
+
+    return EntryRef(
+        year_number=year_number,
+        week_number=week_number,
+        entry_id=entry_doc_ref.id,
+    )
+
+
+def _build_entry_label(*, entry_type: str, scenario_ref: int | None, entry_id: str) -> str:
+    if entry_type == "scenario" and scenario_ref is not None:
+        return f"Escenario {scenario_ref}"
+    if entry_type == "outpost":
+        return "Puesto fronterizo"
+    return f"Entry {entry_id}"

--- a/src/frosthaven_campaign_journal/state/placeholders.py
+++ b/src/frosthaven_campaign_journal/state/placeholders.py
@@ -30,17 +30,15 @@ class MockWeek:
 
 @dataclass
 class MainScreenLocalState:
-    selected_year: int
+    selected_year: int | None
     selected_week: int | None
     viewer_entry_ref: EntryRef | None
-    active_entry_ref_mock: EntryRef | None
 
 
 class MockMainScreenDataset(NamedTuple):
     years: list[int]
     weeks_by_year: dict[int, list[MockWeek]]
     entries_by_week: dict[tuple[int, int], list[MockEntry]]
-    active_entry_ref_mock: EntryRef | None
 
 
 def build_mock_years() -> list[int]:
@@ -142,19 +140,16 @@ def build_mock_main_screen_dataset() -> MockMainScreenDataset:
     years = build_mock_years()
     weeks_by_year = build_mock_weeks_by_year()
     entries_by_week = build_mock_entries_by_week()
-    active_entry_ref_mock = entries_by_week[(2, 36)][0].ref
     return MockMainScreenDataset(
         years=years,
         weeks_by_year=weeks_by_year,
         entries_by_week=entries_by_week,
-        active_entry_ref_mock=active_entry_ref_mock,
     )
 
 
-def build_initial_main_screen_state(active_entry_ref_mock: EntryRef | None) -> MainScreenLocalState:
+def build_initial_main_screen_state() -> MainScreenLocalState:
     return MainScreenLocalState(
-        selected_year=2,
+        selected_year=None,
         selected_week=None,
         viewer_entry_ref=None,
-        active_entry_ref_mock=active_entry_ref_mock,
     )

--- a/src/frosthaven_campaign_journal/ui/app_root.py
+++ b/src/frosthaven_campaign_journal/ui/app_root.py
@@ -1,104 +1,206 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+
 import flet as ft
 
 from frosthaven_campaign_journal.config import load_settings
+from frosthaven_campaign_journal.data import (
+    FirestoreConfigError,
+    FirestoreReadError,
+    WeekRead,
+    build_firestore_client,
+    derive_year_from_week_cursor,
+    load_main_screen_snapshot,
+)
 from frosthaven_campaign_journal.state.placeholders import (
     EntryRef,
+    MainScreenLocalState,
     MockEntry,
+    MockWeek,
     build_initial_main_screen_state,
     build_mock_main_screen_dataset,
 )
-from frosthaven_campaign_journal.ui.views import (
-    build_main_shell_view,
-)
+from frosthaven_campaign_journal.ui.views import build_main_shell_view
+
+
+@dataclass
+class MainScreenReadState:
+    status: str = "idle"
+    error_message: str | None = None
+    warning_message: str | None = None
+    years: list[int] = field(default_factory=list)
+    weeks_by_year: dict[int, list[MockWeek]] = field(default_factory=dict)
+    campaign_week_cursor: int | None = None
+    campaign_resource_totals: dict[str, int] | None = None
+    active_entry_ref: EntryRef | None = None
+    active_entry_label: str | None = None
+    active_status_error_message: str | None = None
 
 
 def build_app_root(page: ft.Page) -> ft.Control:
-    settings = load_settings()
-    dataset = build_mock_main_screen_dataset()
-    state = build_initial_main_screen_state(dataset.active_entry_ref_mock)
+    mock_dataset = build_mock_main_screen_dataset()
+    mock_entry_index = {
+        entry.ref: entry
+        for entries in mock_dataset.entries_by_week.values()
+        for entry in entries
+    }
+    local_state = build_initial_main_screen_state()
+    read_state = MainScreenReadState()
 
-    entry_index = _build_entry_index(dataset.entries_by_week)
-    root = ft.SafeArea(content=ft.Container(), expand=True)
+    shell_host = ft.Container(expand=True)
+    root = ft.SafeArea(content=shell_host)
 
-    def weeks_for_selected_year() -> list:
-        return dataset.weeks_by_year.get(state.selected_year, [])
-
-    def entries_for_selected_week() -> list[MockEntry]:
-        if state.selected_week is None:
+    def current_weeks_for_selected_year() -> list[MockWeek]:
+        if local_state.selected_year is None:
             return []
-        return dataset.entries_by_week.get((state.selected_year, state.selected_week), [])
+        return read_state.weeks_by_year.get(local_state.selected_year, [])
 
-    def resolve_entry(entry_ref: EntryRef | None) -> MockEntry | None:
-        if entry_ref is None:
+    def current_entries_for_selected_week() -> list[MockEntry]:
+        if local_state.selected_year is None or local_state.selected_week is None:
+            return []
+        return mock_dataset.entries_by_week.get(
+            (local_state.selected_year, local_state.selected_week),
+            [],
+        )
+
+    def current_viewer_entry() -> MockEntry | None:
+        if local_state.viewer_entry_ref is None:
             return None
-        return entry_index.get((entry_ref.year_number, entry_ref.week_number, entry_ref.entry_id))
+        return mock_entry_index.get(local_state.viewer_entry_ref)
 
-    def rerender() -> None:
-        root.content = build_main_shell_view(
-            state=state,
-            years=dataset.years,
-            weeks_for_selected_year=weeks_for_selected_year(),
-            entries_for_selected_week=entries_for_selected_week(),
-            viewer_entry=resolve_entry(state.viewer_entry_ref),
-            active_entry_mock=resolve_entry(state.active_entry_ref_mock),
-            env_name=settings.env,
+    def render_shell() -> None:
+        shell_host.content = build_main_shell_view(
+            state=local_state,
+            years=read_state.years,
+            weeks_for_selected_year=current_weeks_for_selected_year(),
+            entries_for_selected_week=current_entries_for_selected_week(),
+            viewer_entry=current_viewer_entry(),
+            active_entry_ref=read_state.active_entry_ref,
+            active_entry_label=read_state.active_entry_label,
+            active_status_error_message=read_state.active_status_error_message,
+            campaign_resource_totals=read_state.campaign_resource_totals,
+            read_status=read_state.status,
+            read_error_message=read_state.error_message,
+            read_warning_message=read_state.warning_message,
+            env_name=load_settings().env,
             on_prev_year=handle_prev_year,
             on_next_year=handle_next_year,
             on_select_week=handle_select_week,
             on_select_entry=handle_select_entry,
+            on_manual_refresh=handle_manual_refresh,
         )
 
-    def commit_ui_state() -> None:
-        rerender()
+    def load_readonly_snapshot(*, selected_year_override: int | None) -> bool:
+        try:
+            settings = load_settings()
+            client = build_firestore_client(settings)
+            snapshot = load_main_screen_snapshot(
+                client,
+                selected_year=selected_year_override,
+                viewer_entry_ref=local_state.viewer_entry_ref,
+            )
+        except (FirestoreConfigError, FirestoreReadError) as exc:
+            read_state.status = "error"
+            read_state.error_message = str(exc)
+            read_state.warning_message = None
+            return False
+
+        read_state.status = "ready"
+        read_state.error_message = None
+        read_state.years = snapshot.years
+        read_state.campaign_week_cursor = snapshot.campaign_main.week_cursor
+        read_state.campaign_resource_totals = snapshot.campaign_main.resource_totals
+        read_state.weeks_by_year[snapshot.effective_year] = [
+            _map_week_read_to_mock(week)
+            for week in snapshot.weeks_for_selected_year
+        ]
+
+        local_state.selected_year = snapshot.effective_year
+
+        visible_week_numbers = {
+            week.week_number for week in read_state.weeks_by_year[snapshot.effective_year]
+        }
+        if local_state.selected_week is not None and local_state.selected_week not in visible_week_numbers:
+            local_state.selected_week = None
+
+        derived_year = derive_year_from_week_cursor(snapshot.campaign_main.week_cursor)
+        if derived_year not in snapshot.years:
+            read_state.warning_message = (
+                "Advertencia: `week_cursor` apunta a un año no provisionado. "
+                f"Se usa Año {snapshot.effective_year} como fallback de navegación."
+            )
+        else:
+            read_state.warning_message = None
+
+        if snapshot.active_entry is None:
+            read_state.active_entry_ref = None
+            read_state.active_entry_label = None
+        else:
+            read_state.active_entry_ref = snapshot.active_entry.entry_ref
+            read_state.active_entry_label = snapshot.active_entry.label
+        read_state.active_status_error_message = snapshot.active_status_error_message
+
+        return True
+
+    def refresh_and_render(*, selected_year_override: int | None) -> None:
+        load_readonly_snapshot(selected_year_override=selected_year_override)
+        render_shell()
         page.update()
 
     def handle_prev_year() -> None:
-        current_index = dataset.years.index(state.selected_year)
-        if current_index == 0:
+        if local_state.selected_year is None or local_state.selected_year not in read_state.years:
             return
-        state.selected_year = dataset.years[current_index - 1]
-        state.selected_week = None
-        commit_ui_state()
+        current_index = read_state.years.index(local_state.selected_year)
+        if current_index <= 0:
+            return
+
+        local_state.selected_year = read_state.years[current_index - 1]
+        local_state.selected_week = None
+        refresh_and_render(selected_year_override=local_state.selected_year)
 
     def handle_next_year() -> None:
-        current_index = dataset.years.index(state.selected_year)
-        if current_index >= len(dataset.years) - 1:
+        if local_state.selected_year is None or local_state.selected_year not in read_state.years:
             return
-        state.selected_year = dataset.years[current_index + 1]
-        state.selected_week = None
-        commit_ui_state()
+        current_index = read_state.years.index(local_state.selected_year)
+        if current_index >= len(read_state.years) - 1:
+            return
+
+        local_state.selected_year = read_state.years[current_index + 1]
+        local_state.selected_week = None
+        refresh_and_render(selected_year_override=local_state.selected_year)
 
     def handle_select_week(week_number: int) -> None:
-        if not any(week.week_number == week_number for week in weeks_for_selected_year()):
+        if local_state.selected_year is None:
             return
-        state.selected_week = week_number
-        commit_ui_state()
+        visible_weeks = current_weeks_for_selected_year()
+        if not any(week.week_number == week_number for week in visible_weeks):
+            return
+        local_state.selected_week = week_number
+        render_shell()
+        page.update()
 
     def handle_select_entry(entry_ref: EntryRef) -> None:
-        if state.selected_week is None:
-            return
-        week_entries = entries_for_selected_week()
-        if not any(entry.ref == entry_ref for entry in week_entries):
-            return
-        state.viewer_entry_ref = entry_ref
-        commit_ui_state()
+        local_state.viewer_entry_ref = entry_ref
+        render_shell()
+        page.update()
 
-    rerender()
+    def handle_manual_refresh() -> None:
+        refresh_and_render(selected_year_override=local_state.selected_year)
+
+    # Carga inicial: si falla, el shell se renderiza con error visible.
+    load_readonly_snapshot(selected_year_override=local_state.selected_year)
+    render_shell()
     return root
 
 
-def _build_entry_index(
-    entries_by_week: dict[tuple[int, int], list[MockEntry]],
-) -> dict[tuple[int, int, str], MockEntry]:
-    index: dict[tuple[int, int, str], MockEntry] = {}
-    for entries in entries_by_week.values():
-        for entry in entries:
-            key = (
-                entry.ref.year_number,
-                entry.ref.week_number,
-                entry.ref.entry_id,
-            )
-            index[key] = entry
-    return index
+def _map_week_read_to_mock(week: WeekRead) -> MockWeek:
+    is_closed = week.status == "closed"
+    notes_preview = week.notes or f"Sin notas en la week {week.week_number}."
+    return MockWeek(
+        year_number=week.year_number,
+        week_number=week.week_number,
+        is_closed=is_closed,
+        status_label=week.status,
+        notes_preview=notes_preview,
+    )

--- a/src/frosthaven_campaign_journal/ui/views/main_shell_view.py
+++ b/src/frosthaven_campaign_journal/ui/views/main_shell_view.py
@@ -32,6 +32,12 @@ COLOR_TEXT_PRIMARY = "#111111"
 COLOR_TEXT_MUTED = "#555555"
 COLOR_TEXT_DIMMED = "#7A6E6E"
 COLOR_WHITE = "#FFFFFF"
+COLOR_ERROR_BG = "#FFE7E7"
+COLOR_ERROR_BORDER = "#D87A7A"
+COLOR_ERROR_TEXT = "#8A1F1F"
+COLOR_WARNING_BG = "#FFF4D8"
+COLOR_WARNING_BORDER = "#D0A55E"
+COLOR_WARNING_TEXT = "#7D5700"
 
 
 def build_main_shell_view(
@@ -41,12 +47,19 @@ def build_main_shell_view(
     weeks_for_selected_year: list[MockWeek],
     entries_for_selected_week: list[MockEntry],
     viewer_entry: MockEntry | None,
-    active_entry_mock: MockEntry | None,
+    active_entry_ref: EntryRef | None,
+    active_entry_label: str | None,
+    active_status_error_message: str | None,
+    campaign_resource_totals: dict[str, int] | None,
+    read_status: str,
+    read_error_message: str | None,
+    read_warning_message: str | None,
     env_name: str,
     on_prev_year: Callable[[], None],
     on_next_year: Callable[[], None],
     on_select_week: Callable[[int], None],
     on_select_entry: Callable[[EntryRef], None],
+    on_manual_refresh: Callable[[], None],
 ) -> ft.Control:
     return ft.Container(
         expand=True,
@@ -59,6 +72,8 @@ def build_main_shell_view(
                     state=state,
                     years=years,
                     weeks_for_selected_year=weeks_for_selected_year,
+                    read_status=read_status,
+                    read_error_message=read_error_message,
                     on_prev_year=on_prev_year,
                     on_next_year=on_next_year,
                     on_select_week=on_select_week,
@@ -73,12 +88,19 @@ def build_main_shell_view(
                     state=state,
                     weeks_for_selected_year=weeks_for_selected_year,
                     viewer_entry=viewer_entry,
-                    active_entry_mock=active_entry_mock,
+                    active_entry_ref=active_entry_ref,
+                    active_entry_label=active_entry_label,
+                    read_error_message=read_error_message,
+                    read_warning_message=read_warning_message,
                 ),
                 _build_bottom_status_bar(
                     env_name=env_name,
                     viewer_entry=viewer_entry,
-                    active_entry_mock=active_entry_mock,
+                    active_entry_ref=active_entry_ref,
+                    active_entry_label=active_entry_label,
+                    active_status_error_message=active_status_error_message,
+                    campaign_resource_totals=campaign_resource_totals,
+                    on_manual_refresh=on_manual_refresh,
                 ),
             ],
         ),
@@ -90,17 +112,72 @@ def _build_top_temporal_bar(
     state: MainScreenLocalState,
     years: list[int],
     weeks_for_selected_year: list[MockWeek],
+    read_status: str,
+    read_error_message: str | None,
     on_prev_year: Callable[[], None],
     on_next_year: Callable[[], None],
     on_select_week: Callable[[int], None],
 ) -> ft.Control:
-    has_prev_year = years.index(state.selected_year) > 0
-    has_next_year = years.index(state.selected_year) < len(years) - 1
+    selected_year = state.selected_year
+    has_valid_selected_year = selected_year is not None and selected_year in years
+    if has_valid_selected_year:
+        year_index = years.index(selected_year)
+        has_prev_year = year_index > 0
+        has_next_year = year_index < len(years) - 1
+        year_title = f"Año {selected_year}"
+    else:
+        has_prev_year = False
+        has_next_year = False
+        year_title = "Año —"
+
+    if read_status == "error" and not weeks_for_selected_year:
+        week_strip_content: ft.Control = ft.Row(
+            alignment=ft.MainAxisAlignment.START,
+            vertical_alignment=ft.CrossAxisAlignment.CENTER,
+            controls=[
+                ft.Text(
+                    "Weeks no disponibles (error de lectura)",
+                    size=13,
+                    color=COLOR_ERROR_TEXT,
+                    italic=True,
+                ),
+            ],
+        )
+    elif not weeks_for_selected_year:
+        week_strip_content = ft.Row(
+            alignment=ft.MainAxisAlignment.START,
+            vertical_alignment=ft.CrossAxisAlignment.CENTER,
+            controls=[
+                ft.Text(
+                    "Sin weeks para el año visible",
+                    size=13,
+                    color=COLOR_TEXT_MUTED,
+                    italic=True,
+                ),
+            ],
+        )
+    else:
+        week_strip_content = ft.Row(
+            spacing=6,
+            wrap=False,
+            scroll=ft.ScrollMode.AUTO,
+            controls=[
+                _build_week_tile(
+                    week=week,
+                    is_selected=(week.week_number == state.selected_week),
+                    on_select_week=on_select_week,
+                )
+                for week in weeks_for_selected_year
+            ],
+        )
+
+    tooltip = read_error_message if read_status == "error" else None
 
     return ft.Container(
         height=TOP_BAR_HEIGHT,
         bgcolor=COLOR_TOP_BAR_BG,
         padding=ft.Padding(left=12, top=10, right=12, bottom=10),
+        tooltip=tooltip,
         content=ft.Row(
             spacing=16,
             alignment=ft.MainAxisAlignment.START,
@@ -112,7 +189,7 @@ def _build_top_temporal_bar(
                     controls=[
                         _build_year_nav_button("←", on_prev_year if has_prev_year else None),
                         ft.Text(
-                            f"Año {state.selected_year}",
+                            year_title,
                             size=32,
                             weight=ft.FontWeight.BOLD,
                             color=COLOR_TEXT_PRIMARY,
@@ -120,22 +197,7 @@ def _build_top_temporal_bar(
                         _build_year_nav_button("→", on_next_year if has_next_year else None),
                     ],
                 ),
-                ft.Container(
-                    expand=True,
-                    content=ft.Row(
-                        spacing=6,
-                        wrap=False,
-                        scroll=ft.ScrollMode.AUTO,
-                        controls=[
-                            _build_week_tile(
-                                week=week,
-                                is_selected=(week.week_number == state.selected_week),
-                                on_select_week=on_select_week,
-                            )
-                            for week in weeks_for_selected_year
-                        ],
-                    ),
-                ),
+                ft.Container(expand=True, content=week_strip_content),
             ],
         ),
     )
@@ -284,26 +346,53 @@ def _build_center_focus_panel(
     state: MainScreenLocalState,
     weeks_for_selected_year: list[MockWeek],
     viewer_entry: MockEntry | None,
-    active_entry_mock: MockEntry | None,
+    active_entry_ref: EntryRef | None,
+    active_entry_label: str | None,
+    read_error_message: str | None,
+    read_warning_message: str | None,
 ) -> ft.Control:
     selected_week = _find_selected_week(state, weeks_for_selected_year)
 
     if viewer_entry is not None:
-        content = _build_focus_entry_mode(
+        primary_content = _build_focus_entry_mode(
             state=state,
             viewer_entry=viewer_entry,
-            active_entry_mock=active_entry_mock,
+            active_entry_ref=active_entry_ref,
+            active_entry_label=active_entry_label,
         )
     elif selected_week is not None:
-        content = _build_focus_week_mode(selected_week)
+        primary_content = _build_focus_week_mode(selected_week)
     else:
-        content = _build_focus_empty_mode(state)
+        primary_content = _build_focus_empty_mode(state)
+
+    stacked_controls: list[ft.Control] = []
+    if read_error_message:
+        stacked_controls.append(
+            _build_status_banner(
+                title="Error de lectura (Firestore)",
+                body=read_error_message,
+                background=COLOR_ERROR_BG,
+                border_color=COLOR_ERROR_BORDER,
+                foreground=COLOR_ERROR_TEXT,
+            )
+        )
+    if read_warning_message:
+        stacked_controls.append(
+            _build_status_banner(
+                title="Advertencia de consistencia",
+                body=read_warning_message,
+                background=COLOR_WARNING_BG,
+                border_color=COLOR_WARNING_BORDER,
+                foreground=COLOR_WARNING_TEXT,
+            )
+        )
+    stacked_controls.append(primary_content)
 
     return ft.Container(
         expand=True,
         bgcolor=COLOR_CENTER_BG,
         padding=ft.Padding.all(CENTER_PANEL_PADDING),
-        content=content,
+        content=ft.Column(spacing=12, controls=stacked_controls),
     )
 
 
@@ -325,13 +414,17 @@ def _build_focus_empty_mode(state: MainScreenLocalState) -> ft.Control:
             _build_placeholder_card(
                 title="Visor (sticky) vacío",
                 body=(
-                    "En #53 el visor se mantiene separado de la navegación. "
-                    "Cuando selecciones una entry, seguirá visible aunque cambies de year/week."
+                    "En #53/#54 el visor se mantiene separado de la navegación. "
+                    "Cuando selecciones una entry mock, seguirá visible aunque cambies de año/week."
                 ),
                 min_height=108,
             ),
             _build_placeholder_card(
-                title=f"Navegación actual (mock): Año {state.selected_year}",
+                title=(
+                    f"Navegación actual: Año {state.selected_year}"
+                    if state.selected_year is not None
+                    else "Navegación actual: sin año disponible"
+                ),
                 body="No hay week seleccionada todavía.",
                 min_height=74,
             ),
@@ -360,7 +453,7 @@ def _build_focus_week_mode(week: MockWeek) -> ft.Control:
                 ],
             ),
             _build_placeholder_card(
-                title="Notas de la week (mock)",
+                title="Notas de la week",
                 body=week.notes_preview,
                 min_height=110,
             ),
@@ -379,32 +472,35 @@ def _build_focus_entry_mode(
     *,
     state: MainScreenLocalState,
     viewer_entry: MockEntry,
-    active_entry_mock: MockEntry | None,
+    active_entry_ref: EntryRef | None,
+    active_entry_label: str | None,
 ) -> ft.Control:
     viewer_matches_selected_week = _entry_ref_matches_selected_week(state, viewer_entry.ref)
-    active_here = active_entry_mock is not None and active_entry_mock.ref == viewer_entry.ref
+    active_here = active_entry_ref is not None and active_entry_ref == viewer_entry.ref
 
     context_lines = [
-        f"Viendo: {viewer_entry.label} · Week {viewer_entry.ref.week_number} · Año {viewer_entry.ref.year_number}",
         (
-            f"Navegación actual: Año {state.selected_year}"
-            + (
-                f" · Week {state.selected_week}"
-                if state.selected_week is not None
-                else " · sin week seleccionada"
-            )
+            f"Viendo: {viewer_entry.label} · Week {viewer_entry.ref.week_number} · "
+            f"Año {viewer_entry.ref.year_number}"
         ),
+        _format_navigation_line(state),
     ]
     if not viewer_matches_selected_week:
         context_lines.append(
             "Visor sticky: la entry visible no coincide con la week navegada actualmente."
         )
 
-    session_mock_text = (
-        "Con sesión activa (mock) en esta entry."
-        if active_here
-        else "Sin sesión activa (mock) en esta entry."
-    )
+    if active_entry_ref is None:
+        session_status_text = "Sin sesión activa real."
+    elif active_here:
+        session_status_text = f"Con sesión activa aquí: {active_entry_label or 'Entry activa'}."
+    else:
+        session_status_text = f"Con sesión activa en otra entry: {active_entry_label or 'Entry activa'}."
+
+    detail_body = f"Tipo: {viewer_entry.entry_type}"
+    if viewer_entry.scenario_ref:
+        detail_body += f"\nScenario ref: {viewer_entry.scenario_ref}"
+    detail_body += "\nDatos reales de entries/sesiones quedan para Q5/Q8."
 
     return ft.Column(
         spacing=12,
@@ -421,7 +517,7 @@ def _build_focus_entry_mode(
                     ),
                     _build_badge(viewer_entry.entry_type, "#E7E0FF", "#4F46A5"),
                     _build_badge(
-                        "activo aquí (mock)" if active_here else "visor (mock)",
+                        "activo aquí" if active_here else "visor",
                         "#DFF4FF" if active_here else "#F0F0F0",
                         "#0E5E78" if active_here else "#666666",
                     ),
@@ -433,33 +529,159 @@ def _build_focus_entry_mode(
                 min_height=110,
             ),
             _build_placeholder_card(
-                title="Detalle de entry (mock)",
-                body=(
-                    f"Tipo: {viewer_entry.entry_type}\n"
-                    + (
-                        f"Scenario ref: {viewer_entry.scenario_ref}\n"
-                        if viewer_entry.scenario_ref
-                        else ""
-                    )
-                    + "Datos reales y sincronización llegarán en #54+."
-                ),
+                title="Detalle de entry (mock hasta Q5)",
+                body=detail_body,
                 min_height=96,
             ),
             _build_placeholder_card(
-                title="Bloque de sesión (mock)",
+                title="Bloque de sesión (mock hasta Q8)",
                 body=(
-                    f"{session_mock_text}\n"
-                    "Start/Stop reales y sesiones persistidas quedan fuera de #53."
+                    f"{session_status_text}\n"
+                    "Start/Stop reales y sesiones persistidas quedan fuera de #54."
                 ),
                 min_height=84,
             ),
             _build_placeholder_card(
                 title="Recursos de la entry (mock)",
-                body="Placeholder visual de recursos. Sin datos reales ni mutaciones.",
+                body="El visor sigue mock en #54; los totales globales sí vienen de Q1.",
                 min_height=72,
             ),
         ],
     )
+
+
+def _build_bottom_status_bar(
+    *,
+    env_name: str,
+    viewer_entry: MockEntry | None,
+    active_entry_ref: EntryRef | None,
+    active_entry_label: str | None,
+    active_status_error_message: str | None,
+    campaign_resource_totals: dict[str, int] | None,
+    on_manual_refresh: Callable[[], None],
+) -> ft.Control:
+    active_text, active_detail_text = _active_status_texts(
+        active_entry_ref=active_entry_ref,
+        active_entry_label=active_entry_label,
+        active_status_error_message=active_status_error_message,
+        viewer_entry=viewer_entry,
+    )
+    viewer_text = (
+        f"Viendo: {_entry_short_label(viewer_entry)}"
+        if viewer_entry is not None
+        else "Sin entry en visor"
+    )
+
+    return ft.Container(
+        height=BOTTOM_BAR_HEIGHT,
+        bgcolor=COLOR_BOTTOM_BAR_BG,
+        padding=ft.Padding(left=16, top=12, right=16, bottom=12),
+        content=ft.Row(
+            alignment=ft.MainAxisAlignment.SPACE_BETWEEN,
+            vertical_alignment=ft.CrossAxisAlignment.CENTER,
+            controls=[
+                ft.Column(
+                    spacing=2,
+                    horizontal_alignment=ft.CrossAxisAlignment.START,
+                    controls=[
+                        ft.Text(
+                            "Totales (read-only)",
+                            size=16,
+                            weight=ft.FontWeight.BOLD,
+                            color=COLOR_WHITE,
+                        ),
+                        ft.Text(
+                            _format_resource_totals(campaign_resource_totals),
+                            size=12,
+                            color="#EAF9FF",
+                        ),
+                    ],
+                ),
+                ft.Row(
+                    spacing=12,
+                    vertical_alignment=ft.CrossAxisAlignment.CENTER,
+                    controls=[
+                        ft.Column(
+                            spacing=2,
+                            horizontal_alignment=ft.CrossAxisAlignment.END,
+                            controls=[
+                                ft.Text(
+                                    active_text,
+                                    size=13,
+                                    weight=ft.FontWeight.BOLD,
+                                    color=COLOR_WHITE,
+                                    text_align=ft.TextAlign.RIGHT,
+                                ),
+                                ft.Text(
+                                    active_detail_text or viewer_text,
+                                    size=12,
+                                    color="#EAF9FF",
+                                    text_align=ft.TextAlign.RIGHT,
+                                ),
+                                ft.Text(
+                                    f"{viewer_text} · env={env_name}",
+                                    size=11,
+                                    color="#DDF5FF",
+                                    text_align=ft.TextAlign.RIGHT,
+                                ),
+                            ],
+                        ),
+                        _build_refresh_button(on_manual_refresh),
+                    ],
+                ),
+            ],
+        ),
+    )
+
+
+def _build_refresh_button(on_click: Callable[[], None]) -> ft.Control:
+    return ft.Container(
+        padding=ft.Padding(left=10, top=8, right=10, bottom=8),
+        bgcolor="#21A4D3",
+        border_radius=8,
+        border=ft.Border.all(1, "#BFEFFF"),
+        on_click=lambda _e: on_click(),
+        content=ft.Text(
+            "Refresh",
+            size=12,
+            weight=ft.FontWeight.BOLD,
+            color=COLOR_WHITE,
+        ),
+    )
+
+
+def _active_status_texts(
+    *,
+    active_entry_ref: EntryRef | None,
+    active_entry_label: str | None,
+    active_status_error_message: str | None,
+    viewer_entry: MockEntry | None,
+) -> tuple[str, str]:
+    if active_status_error_message:
+        return (
+            "Estado activo no disponible",
+            _truncate(active_status_error_message, 80),
+        )
+
+    if active_entry_ref is None:
+        return ("Sin sesión activa", "")
+
+    label = active_entry_label or f"Entry {active_entry_ref.entry_id}"
+    if viewer_entry is not None and viewer_entry.ref == active_entry_ref:
+        return (f"Con sesión activa: {label} · aquí", "")
+    return (f"Con sesión activa: {label} · en otra entry", "")
+
+
+def _format_resource_totals(resource_totals: dict[str, int] | None) -> str:
+    if resource_totals is None:
+        return "Totales no disponibles (Q1 no cargado)"
+    if not resource_totals:
+        return "Sin recursos materializados"
+
+    items = sorted(resource_totals.items(), key=lambda item: item[0])
+    visible = [f"{key}={value}" for key, value in items[:4]]
+    suffix = " …" if len(items) > 4 else ""
+    return " · ".join(visible) + suffix
 
 
 def _build_badge(label: str, background: str, foreground: str) -> ft.Control:
@@ -472,6 +694,29 @@ def _build_badge(label: str, background: str, foreground: str) -> ft.Control:
             size=12,
             color=foreground,
             weight=ft.FontWeight.W_500,
+        ),
+    )
+
+
+def _build_status_banner(
+    *,
+    title: str,
+    body: str,
+    background: str,
+    border_color: str,
+    foreground: str,
+) -> ft.Control:
+    return ft.Container(
+        padding=ft.Padding.all(12),
+        bgcolor=background,
+        border=ft.Border.all(1, border_color),
+        border_radius=8,
+        content=ft.Column(
+            spacing=4,
+            controls=[
+                ft.Text(title, size=14, weight=ft.FontWeight.BOLD, color=foreground),
+                ft.Text(body, size=12, color=foreground),
+            ],
         ),
     )
 
@@ -503,91 +748,6 @@ def _build_placeholder_card(title: str, body: str, min_height: int) -> ft.Contro
     )
 
 
-def _build_bottom_status_bar(
-    *,
-    env_name: str,
-    viewer_entry: MockEntry | None,
-    active_entry_mock: MockEntry | None,
-) -> ft.Control:
-    active_text = _active_mock_status_text(active_entry_mock, viewer_entry)
-    viewer_text = (
-        f"Viendo: {_entry_short_label(viewer_entry)}"
-        if viewer_entry is not None
-        else "Sin entry en visor"
-    )
-
-    return ft.Container(
-        height=BOTTOM_BAR_HEIGHT,
-        bgcolor=COLOR_BOTTOM_BAR_BG,
-        padding=ft.Padding(left=16, top=12, right=16, bottom=12),
-        content=ft.Row(
-            alignment=ft.MainAxisAlignment.SPACE_BETWEEN,
-            vertical_alignment=ft.CrossAxisAlignment.CENTER,
-            controls=[
-                ft.Column(
-                    spacing=2,
-                    horizontal_alignment=ft.CrossAxisAlignment.START,
-                    controls=[
-                        ft.Text(
-                            "Totales (placeholder)",
-                            size=16,
-                            weight=ft.FontWeight.BOLD,
-                            color=COLOR_WHITE,
-                        ),
-                        ft.Text(
-                            "Se conectarán con Q1 y reglas de recursos en #54+.",
-                            size=12,
-                            color="#EAF9FF",
-                        ),
-                    ],
-                ),
-                ft.Column(
-                    spacing=2,
-                    horizontal_alignment=ft.CrossAxisAlignment.END,
-                    controls=[
-                        ft.Text(
-                            active_text,
-                            size=13,
-                            weight=ft.FontWeight.BOLD,
-                            color=COLOR_WHITE,
-                            text_align=ft.TextAlign.RIGHT,
-                        ),
-                        ft.Text(
-                            viewer_text,
-                            size=12,
-                            color="#EAF9FF",
-                            text_align=ft.TextAlign.RIGHT,
-                        ),
-                        ft.Text(
-                            f"env={env_name}",
-                            size=11,
-                            color="#DDF5FF",
-                            text_align=ft.TextAlign.RIGHT,
-                        ),
-                    ],
-                ),
-            ],
-        ),
-    )
-
-
-def _active_mock_status_text(
-    active_entry_mock: MockEntry | None,
-    viewer_entry: MockEntry | None,
-) -> str:
-    if active_entry_mock is None:
-        return "Sin sesión activa (mock)"
-
-    base = f"Con sesión activa (mock): {_entry_short_label(active_entry_mock)}"
-    if viewer_entry is not None and viewer_entry.ref == active_entry_mock.ref:
-        return f"{base} · aquí"
-    return f"{base} · en otra entry"
-
-
-def _entry_short_label(entry: MockEntry) -> str:
-    return f"{entry.label} (W{entry.ref.week_number})"
-
-
 def _find_selected_week(
     state: MainScreenLocalState,
     weeks_for_selected_year: list[MockWeek],
@@ -614,7 +774,26 @@ def _entry_ref_matches_selected_week(
     entry_ref: EntryRef,
 ) -> bool:
     return (
-        state.selected_week is not None
+        state.selected_year is not None
+        and state.selected_week is not None
         and entry_ref.year_number == state.selected_year
         and entry_ref.week_number == state.selected_week
     )
+
+
+def _entry_short_label(entry: MockEntry) -> str:
+    return f"{entry.label} (W{entry.ref.week_number})"
+
+
+def _format_navigation_line(state: MainScreenLocalState) -> str:
+    if state.selected_year is None:
+        return "Navegación actual: sin año visible"
+    if state.selected_week is None:
+        return f"Navegación actual: Año {state.selected_year} · sin week seleccionada"
+    return f"Navegación actual: Año {state.selected_year} · Week {state.selected_week}"
+
+
+def _truncate(value: str, max_length: int) -> str:
+    if len(value) <= max_length:
+        return value
+    return value[: max_length - 1] + "…"


### PR DESCRIPTION
## Resumen
- integra lecturas read-only reales de Firestore para la pantalla principal (`Q1`, `Q2`, `Q3`, `Q4`, `Q6`, `Q7`)
- a�ade refresh manual on-demand y manejo de errores visibles (globales y parciales)
- mantiene `viewer` sticky y tabs/visor mock de `#53` (`Q5`/`Q8` siguen fuera de alcance)

## Incluye
- cliente Firestore y validaci�n de configuraci�n (`.env` + credenciales por ruta)
- snapshot read-only para arranque/navegaci�n base
- derivaci�n de `selected_year` desde `week_cursor`
- barra inferior con activo real y bot�n temporal `Refresh`
- `.secrets/` ignorado en Git

## No incluye
- `Q5` / `Q8`
- mutaciones de dominio
- listeners realtime

Closes #54
