### PR TITLE
feat(reads): integra Q5 y Q8 en panel de entry

### DIFF
--- a/src/frosthaven_campaign_journal/data/__init__.py
+++ b/src/frosthaven_campaign_journal/data/__init__.py
@@ -10,16 +10,23 @@ from .main_screen_reads import (
     ActiveEntryRead,
     ActiveSessionRead,
     CampaignMainRead,
+    EntryRead,
+    EntrySessionRead,
     MainScreenSnapshot,
     WeekRead,
     derive_year_from_week_cursor,
     load_main_screen_snapshot,
+    read_entry_by_ref,
+    read_q5_entries_for_selected_week,
+    read_q8_sessions_for_entry,
 )
 
 __all__ = [
     "ActiveEntryRead",
     "ActiveSessionRead",
     "CampaignMainRead",
+    "EntryRead",
+    "EntrySessionRead",
     "FirestoreConfigError",
     "FirestoreReadError",
     "MainScreenSnapshot",
@@ -28,4 +35,7 @@ __all__ = [
     "derive_year_from_week_cursor",
     "describe_firestore_status",
     "load_main_screen_snapshot",
+    "read_entry_by_ref",
+    "read_q5_entries_for_selected_week",
+    "read_q8_sessions_for_entry",
 ]

--- a/src/frosthaven_campaign_journal/data/main_screen_reads.py
+++ b/src/frosthaven_campaign_journal/data/main_screen_reads.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any
 
 from google.cloud import firestore
@@ -27,6 +28,27 @@ class WeekRead:
     week_number: int
     status: str
     notes: str | None
+
+
+@dataclass(frozen=True)
+class EntryRead:
+    ref: EntryRef
+    label: str
+    entry_type: str
+    scenario_ref: int | None
+    order_index: int
+    resource_deltas: dict[str, int]
+    created_at_utc: Any | None
+    updated_at_utc: Any | None
+
+
+@dataclass(frozen=True)
+class EntrySessionRead:
+    session_id: str
+    started_at_utc: Any | None
+    ended_at_utc: Any | None
+    created_at_utc: Any | None
+    updated_at_utc: Any | None
 
 
 @dataclass(frozen=True)
@@ -213,6 +235,130 @@ def read_q6_active_session_global(client: firestore.Client) -> ActiveSessionRead
     )
 
 
+def read_q5_entries_for_selected_week(
+    client: firestore.Client,
+    *,
+    year_number: int,
+    week_number: int,
+) -> list[EntryRead]:
+    season_type = _resolve_season_type_for_week(year_number=year_number, week_number=week_number)
+    entries: list[EntryRead] = []
+    try:
+        query = (
+            client.collection("campaigns")
+            .document(CAMPAIGN_ID)
+            .collection("years")
+            .document(str(year_number))
+            .collection("seasons")
+            .document(season_type)
+            .collection("weeks")
+            .document(str(week_number))
+            .collection("entries")
+            .order_by("order_index")
+        )
+        for snapshot in query.stream():
+            entries.append(_map_entry_snapshot(snapshot, year_number=year_number, week_number=week_number))
+    except FirestoreReadError:
+        raise
+    except Exception as exc:
+        raise FirestoreReadError(
+            f"Error leyendo Q5 (`entries_selected_week`) para week {week_number} (año {year_number}): {exc}"
+        ) from exc
+
+    return sorted(
+        entries,
+        key=lambda entry: (
+            entry.order_index,
+            _sortable_dt_asc(entry.created_at_utc),
+            entry.ref.entry_id,
+        ),
+    )
+
+
+def read_entry_by_ref(client: firestore.Client, entry_ref: EntryRef) -> EntryRead:
+    season_type = _resolve_season_type_for_week(
+        year_number=entry_ref.year_number,
+        week_number=entry_ref.week_number,
+    )
+    entry_doc_ref = (
+        client.collection("campaigns")
+        .document(CAMPAIGN_ID)
+        .collection("years")
+        .document(str(entry_ref.year_number))
+        .collection("seasons")
+        .document(season_type)
+        .collection("weeks")
+        .document(str(entry_ref.week_number))
+        .collection("entries")
+        .document(entry_ref.entry_id)
+    )
+    try:
+        snapshot = entry_doc_ref.get()
+    except Exception as exc:
+        raise FirestoreReadError(
+            f"Error leyendo entry del visor (`{entry_doc_ref.path}`): {exc}"
+        ) from exc
+    if not snapshot.exists:
+        raise FirestoreReadError(f"La entry del visor ya no existe: `{entry_doc_ref.path}`.")
+    return _map_entry_snapshot(
+        snapshot,
+        year_number=entry_ref.year_number,
+        week_number=entry_ref.week_number,
+    )
+
+
+def read_q8_sessions_for_entry(
+    client: firestore.Client,
+    *,
+    entry_ref: EntryRef,
+) -> list[EntrySessionRead]:
+    season_type = _resolve_season_type_for_week(
+        year_number=entry_ref.year_number,
+        week_number=entry_ref.week_number,
+    )
+    sessions: list[EntrySessionRead] = []
+    try:
+        query = (
+            client.collection("campaigns")
+            .document(CAMPAIGN_ID)
+            .collection("years")
+            .document(str(entry_ref.year_number))
+            .collection("seasons")
+            .document(season_type)
+            .collection("weeks")
+            .document(str(entry_ref.week_number))
+            .collection("entries")
+            .document(entry_ref.entry_id)
+            .collection("sessions")
+            .order_by("started_at_utc", direction=firestore.Query.DESCENDING)
+        )
+        for snapshot in query.stream():
+            data = snapshot.to_dict() or {}
+            sessions.append(
+                EntrySessionRead(
+                    session_id=snapshot.id,
+                    started_at_utc=data.get("started_at_utc"),
+                    ended_at_utc=data.get("ended_at_utc"),
+                    created_at_utc=data.get("created_at_utc"),
+                    updated_at_utc=data.get("updated_at_utc"),
+                )
+            )
+    except Exception as exc:
+        raise FirestoreReadError(
+            f"Error leyendo Q8 (`sessions_selected_entry_combined`) para `{entry_ref.entry_id}`: {exc}"
+        ) from exc
+
+    return sorted(
+        sessions,
+        key=lambda session: (
+            0 if session.ended_at_utc is None else 1,
+            _sortable_dt_desc(session.started_at_utc),
+            _sortable_dt_desc(session.updated_at_utc),
+            session.session_id,
+        ),
+    )
+
+
 def read_q7_active_entry_doc_if_needed(
     client: firestore.Client,
     active_session: ActiveSessionRead | None,
@@ -310,6 +456,67 @@ def derive_year_from_week_cursor(week_cursor: int) -> int:
     return ((week_cursor - 1) // WEEKS_PER_YEAR) + 1
 
 
+def _resolve_season_type_for_week(*, year_number: int, week_number: int) -> str:
+    local_week = week_number - ((year_number - 1) * WEEKS_PER_YEAR)
+    if not 1 <= local_week <= WEEKS_PER_YEAR:
+        raise FirestoreReadError(
+            f"Week {week_number} no pertenece al año {year_number} según el template temporal MVP."
+        )
+    return "summer" if local_week <= 10 else "winter"
+
+
+def _map_entry_snapshot(snapshot: Any, *, year_number: int, week_number: int) -> EntryRead:
+    data = snapshot.to_dict() or {}
+    entry_type = data.get("type")
+    if not isinstance(entry_type, str) or not entry_type:
+        raise FirestoreReadError(f"Q5/Q7 inválido: `type` no válido en `{snapshot.reference.path}`.")
+
+    order_index = data.get("order_index")
+    if isinstance(order_index, bool) or not isinstance(order_index, int) or order_index <= 0:
+        raise FirestoreReadError(
+            f"Q5/Q7 inválido: `order_index` no válido en `{snapshot.reference.path}`."
+        )
+
+    scenario_ref_raw = data.get("scenario_ref")
+    scenario_ref: int | None
+    if scenario_ref_raw is None:
+        scenario_ref = None
+    elif isinstance(scenario_ref_raw, bool) or not isinstance(scenario_ref_raw, int):
+        raise FirestoreReadError(
+            f"Q5/Q7 inválido: `scenario_ref` no válido en `{snapshot.reference.path}`."
+        )
+    else:
+        scenario_ref = scenario_ref_raw
+
+    resource_deltas_raw = data.get("resource_deltas") or {}
+    if not isinstance(resource_deltas_raw, dict):
+        raise FirestoreReadError(
+            f"Q5/Q7 inválido: `resource_deltas` debe ser mapa en `{snapshot.reference.path}`."
+        )
+    resource_deltas: dict[str, int] = {}
+    for key, value in resource_deltas_raw.items():
+        if not isinstance(key, str):
+            raise FirestoreReadError(
+                f"Q5/Q7 inválido: clave de `resource_deltas` no string en `{snapshot.reference.path}`."
+            )
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise FirestoreReadError(
+                f"Q5/Q7 inválido: `resource_deltas[{key}]` no entero en `{snapshot.reference.path}`."
+            )
+        resource_deltas[key] = value
+
+    return EntryRead(
+        ref=EntryRef(year_number=year_number, week_number=week_number, entry_id=snapshot.id),
+        label=_build_entry_label(entry_type=entry_type, scenario_ref=scenario_ref, entry_id=snapshot.id),
+        entry_type=entry_type,
+        scenario_ref=scenario_ref,
+        order_index=order_index,
+        resource_deltas=resource_deltas,
+        created_at_utc=data.get("created_at_utc"),
+        updated_at_utc=data.get("updated_at_utc"),
+    )
+
+
 def _entry_ref_from_entry_doc_ref(entry_doc_ref: Any) -> EntryRef:
     try:
         week_doc_ref = entry_doc_ref.parent.parent
@@ -340,3 +547,19 @@ def _build_entry_label(*, entry_type: str, scenario_ref: int | None, entry_id: s
     if entry_type == "outpost":
         return "Puesto fronterizo"
     return f"Entry {entry_id}"
+
+
+def _sortable_dt_asc(value: Any | None) -> tuple[int, datetime]:
+    if value is None:
+        return (1, datetime.min.replace(tzinfo=timezone.utc))
+    return (0, value)
+
+
+def _sortable_dt_desc(value: Any | None) -> tuple[int, float]:
+    if value is None:
+        return (1, 0.0)
+    try:
+        ts = value.timestamp()
+    except Exception:
+        return (1, 0.0)
+    return (0, -ts)

--- a/src/frosthaven_campaign_journal/state/placeholders.py
+++ b/src/frosthaven_campaign_journal/state/placeholders.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import NamedTuple
 
 
@@ -16,7 +16,20 @@ class MockEntry:
     ref: EntryRef
     label: str
     entry_type: str
-    scenario_ref: str | None = None
+    scenario_ref: int | None = None
+    order_index: int | None = None
+    resource_deltas: dict[str, int] = field(default_factory=dict)
+    created_at_utc: object | None = None
+    updated_at_utc: object | None = None
+
+
+@dataclass(frozen=True)
+class ViewerSessionItem:
+    session_id: str
+    started_at_utc: object | None
+    ended_at_utc: object | None
+    created_at_utc: object | None = None
+    updated_at_utc: object | None = None
 
 
 @dataclass(frozen=True)
@@ -85,13 +98,13 @@ def build_mock_entries_by_week() -> dict[tuple[int, int], list[MockEntry]]:
             ref=EntryRef(year_number=2, week_number=35, entry_id="w35-e1"),
             label="Escenario 51",
             entry_type="scenario",
-            scenario_ref="scenario_51",
+            scenario_ref=51,
         ),
         MockEntry(
             ref=EntryRef(year_number=2, week_number=35, entry_id="w35-e2"),
             label="Escenario 42",
             entry_type="scenario",
-            scenario_ref="scenario_42",
+            scenario_ref=42,
         ),
         MockEntry(
             ref=EntryRef(year_number=2, week_number=35, entry_id="w35-e3"),
@@ -107,13 +120,13 @@ def build_mock_entries_by_week() -> dict[tuple[int, int], list[MockEntry]]:
             ref=EntryRef(year_number=2, week_number=36, entry_id="w36-e1"),
             label="Escenario 51",
             entry_type="scenario",
-            scenario_ref="scenario_51",
+            scenario_ref=51,
         ),
         MockEntry(
             ref=EntryRef(year_number=2, week_number=36, entry_id="w36-e2"),
             label="Escenario 42",
             entry_type="scenario",
-            scenario_ref="scenario_42",
+            scenario_ref=42,
         ),
         MockEntry(
             ref=EntryRef(year_number=2, week_number=36, entry_id="w36-e3"),
@@ -129,7 +142,7 @@ def build_mock_entries_by_week() -> dict[tuple[int, int], list[MockEntry]]:
             ref=EntryRef(year_number=2, week_number=34, entry_id="w34-e1"),
             label="Escenario 17",
             entry_type="scenario",
-            scenario_ref="scenario_17",
+            scenario_ref=17,
         )
     ]
 

--- a/src/frosthaven_campaign_journal/ui/app_root.py
+++ b/src/frosthaven_campaign_journal/ui/app_root.py
@@ -6,20 +6,25 @@ import flet as ft
 
 from frosthaven_campaign_journal.config import load_settings
 from frosthaven_campaign_journal.data import (
+    EntryRead,
+    EntrySessionRead,
     FirestoreConfigError,
     FirestoreReadError,
     WeekRead,
     build_firestore_client,
     derive_year_from_week_cursor,
     load_main_screen_snapshot,
+    read_entry_by_ref,
+    read_q5_entries_for_selected_week,
+    read_q8_sessions_for_entry,
 )
 from frosthaven_campaign_journal.state.placeholders import (
     EntryRef,
     MainScreenLocalState,
     MockEntry,
     MockWeek,
+    ViewerSessionItem,
     build_initial_main_screen_state,
-    build_mock_main_screen_dataset,
 )
 from frosthaven_campaign_journal.ui.views import build_main_shell_view
 
@@ -38,15 +43,19 @@ class MainScreenReadState:
     active_status_error_message: str | None = None
 
 
+@dataclass
+class EntryPanelReadState:
+    entries_for_selected_week: list[MockEntry] = field(default_factory=list)
+    entries_panel_error_message: str | None = None
+    viewer_entry_snapshot: MockEntry | None = None
+    viewer_sessions: list[ViewerSessionItem] = field(default_factory=list)
+    viewer_sessions_error_message: str | None = None
+
+
 def build_app_root(page: ft.Page) -> ft.Control:
-    mock_dataset = build_mock_main_screen_dataset()
-    mock_entry_index = {
-        entry.ref: entry
-        for entries in mock_dataset.entries_by_week.values()
-        for entry in entries
-    }
     local_state = build_initial_main_screen_state()
     read_state = MainScreenReadState()
+    entry_panel_state = EntryPanelReadState()
 
     shell_host = ft.Container(expand=True)
     root = ft.SafeArea(content=shell_host)
@@ -57,17 +66,12 @@ def build_app_root(page: ft.Page) -> ft.Control:
         return read_state.weeks_by_year.get(local_state.selected_year, [])
 
     def current_entries_for_selected_week() -> list[MockEntry]:
-        if local_state.selected_year is None or local_state.selected_week is None:
+        if local_state.selected_week is None:
             return []
-        return mock_dataset.entries_by_week.get(
-            (local_state.selected_year, local_state.selected_week),
-            [],
-        )
+        return entry_panel_state.entries_for_selected_week
 
     def current_viewer_entry() -> MockEntry | None:
-        if local_state.viewer_entry_ref is None:
-            return None
-        return mock_entry_index.get(local_state.viewer_entry_ref)
+        return entry_panel_state.viewer_entry_snapshot
 
     def render_shell() -> None:
         shell_host.content = build_main_shell_view(
@@ -76,6 +80,9 @@ def build_app_root(page: ft.Page) -> ft.Control:
             weeks_for_selected_year=current_weeks_for_selected_year(),
             entries_for_selected_week=current_entries_for_selected_week(),
             viewer_entry=current_viewer_entry(),
+            viewer_sessions=entry_panel_state.viewer_sessions,
+            entries_panel_error_message=entry_panel_state.entries_panel_error_message,
+            viewer_sessions_error_message=entry_panel_state.viewer_sessions_error_message,
             active_entry_ref=read_state.active_entry_ref,
             active_entry_label=read_state.active_entry_label,
             active_status_error_message=read_state.active_status_error_message,
@@ -91,10 +98,13 @@ def build_app_root(page: ft.Page) -> ft.Control:
             on_manual_refresh=handle_manual_refresh,
         )
 
+    def _build_client():
+        settings = load_settings()
+        return build_firestore_client(settings)
+
     def load_readonly_snapshot(*, selected_year_override: int | None) -> bool:
         try:
-            settings = load_settings()
-            client = build_firestore_client(settings)
+            client = _build_client()
             snapshot = load_main_screen_snapshot(
                 client,
                 selected_year=selected_year_override,
@@ -143,8 +153,86 @@ def build_app_root(page: ft.Page) -> ft.Control:
 
         return True
 
-    def refresh_and_render(*, selected_year_override: int | None) -> None:
+    def load_entries_for_selected_week() -> None:
+        if local_state.selected_year is None or local_state.selected_week is None:
+            entry_panel_state.entries_for_selected_week = []
+            entry_panel_state.entries_panel_error_message = None
+            return
+
+        try:
+            client = _build_client()
+            entries = read_q5_entries_for_selected_week(
+                client,
+                year_number=local_state.selected_year,
+                week_number=local_state.selected_week,
+            )
+        except (FirestoreConfigError, FirestoreReadError) as exc:
+            entry_panel_state.entries_for_selected_week = []
+            entry_panel_state.entries_panel_error_message = str(exc)
+            return
+
+        entry_panel_state.entries_for_selected_week = [_map_entry_read_to_mock(entry) for entry in entries]
+        entry_panel_state.entries_panel_error_message = None
+
+        # Reconciliar snapshot del visor si la entry visible pertenece a la week cargada.
+        if local_state.viewer_entry_ref is None:
+            return
+
+        if not _entry_ref_matches_selected_week(local_state, local_state.viewer_entry_ref):
+            return
+
+        updated_entry = _find_entry_in_list(
+            entry_panel_state.entries_for_selected_week,
+            local_state.viewer_entry_ref,
+        )
+        if updated_entry is not None:
+            entry_panel_state.viewer_entry_snapshot = updated_entry
+
+    def load_viewer_entry_and_sessions() -> None:
+        if local_state.viewer_entry_ref is None:
+            entry_panel_state.viewer_entry_snapshot = None
+            entry_panel_state.viewer_sessions = []
+            entry_panel_state.viewer_sessions_error_message = None
+            return
+
+        try:
+            client = _build_client()
+            viewer_entry_read = read_entry_by_ref(client, local_state.viewer_entry_ref)
+        except (FirestoreConfigError, FirestoreReadError) as exc:
+            entry_panel_state.viewer_sessions_error_message = str(exc)
+            entry_panel_state.viewer_sessions = []
+            if (
+                entry_panel_state.viewer_entry_snapshot is not None
+                and entry_panel_state.viewer_entry_snapshot.ref != local_state.viewer_entry_ref
+            ):
+                entry_panel_state.viewer_entry_snapshot = None
+            return
+
+        entry_panel_state.viewer_entry_snapshot = _map_entry_read_to_mock(viewer_entry_read)
+
+        try:
+            sessions = read_q8_sessions_for_entry(client, entry_ref=local_state.viewer_entry_ref)
+        except FirestoreReadError as exc:
+            entry_panel_state.viewer_sessions = []
+            entry_panel_state.viewer_sessions_error_message = str(exc)
+            return
+
+        entry_panel_state.viewer_sessions = [
+            _map_session_read_to_viewer_session(session) for session in sessions
+        ]
+        entry_panel_state.viewer_sessions_error_message = None
+
+    def refresh_and_render(
+        *,
+        selected_year_override: int | None,
+        reload_q5: bool = False,
+        reload_q8: bool = False,
+    ) -> None:
         load_readonly_snapshot(selected_year_override=selected_year_override)
+        if reload_q5:
+            load_entries_for_selected_week()
+        if reload_q8:
+            load_viewer_entry_and_sessions()
         render_shell()
         page.update()
 
@@ -157,7 +245,9 @@ def build_app_root(page: ft.Page) -> ft.Control:
 
         local_state.selected_year = read_state.years[current_index - 1]
         local_state.selected_week = None
-        refresh_and_render(selected_year_override=local_state.selected_year)
+        entry_panel_state.entries_for_selected_week = []
+        entry_panel_state.entries_panel_error_message = None
+        refresh_and_render(selected_year_override=local_state.selected_year, reload_q8=False)
 
     def handle_next_year() -> None:
         if local_state.selected_year is None or local_state.selected_year not in read_state.years:
@@ -168,7 +258,9 @@ def build_app_root(page: ft.Page) -> ft.Control:
 
         local_state.selected_year = read_state.years[current_index + 1]
         local_state.selected_week = None
-        refresh_and_render(selected_year_override=local_state.selected_year)
+        entry_panel_state.entries_for_selected_week = []
+        entry_panel_state.entries_panel_error_message = None
+        refresh_and_render(selected_year_override=local_state.selected_year, reload_q8=False)
 
     def handle_select_week(week_number: int) -> None:
         if local_state.selected_year is None:
@@ -177,16 +269,22 @@ def build_app_root(page: ft.Page) -> ft.Control:
         if not any(week.week_number == week_number for week in visible_weeks):
             return
         local_state.selected_week = week_number
+        load_entries_for_selected_week()  # Q5 solo, el visor sticky no recarga Q8 por navegación
         render_shell()
         page.update()
 
     def handle_select_entry(entry_ref: EntryRef) -> None:
         local_state.viewer_entry_ref = entry_ref
+        load_viewer_entry_and_sessions()  # Q8 sigue al visor sticky
         render_shell()
         page.update()
 
     def handle_manual_refresh() -> None:
-        refresh_and_render(selected_year_override=local_state.selected_year)
+        refresh_and_render(
+            selected_year_override=local_state.selected_year,
+            reload_q5=(local_state.selected_week is not None),
+            reload_q8=(local_state.viewer_entry_ref is not None),
+        )
 
     # Carga inicial: si falla, el shell se renderiza con error visible.
     load_readonly_snapshot(selected_year_override=local_state.selected_year)
@@ -204,3 +302,42 @@ def _map_week_read_to_mock(week: WeekRead) -> MockWeek:
         status_label=week.status,
         notes_preview=notes_preview,
     )
+
+
+def _map_entry_read_to_mock(entry: EntryRead) -> MockEntry:
+    return MockEntry(
+        ref=entry.ref,
+        label=entry.label,
+        entry_type=entry.entry_type,
+        scenario_ref=entry.scenario_ref,
+        order_index=entry.order_index,
+        resource_deltas=dict(entry.resource_deltas),
+        created_at_utc=entry.created_at_utc,
+        updated_at_utc=entry.updated_at_utc,
+    )
+
+
+def _map_session_read_to_viewer_session(session: EntrySessionRead) -> ViewerSessionItem:
+    return ViewerSessionItem(
+        session_id=session.session_id,
+        started_at_utc=session.started_at_utc,
+        ended_at_utc=session.ended_at_utc,
+        created_at_utc=session.created_at_utc,
+        updated_at_utc=session.updated_at_utc,
+    )
+
+
+def _entry_ref_matches_selected_week(state: MainScreenLocalState, entry_ref: EntryRef) -> bool:
+    return (
+        state.selected_year is not None
+        and state.selected_week is not None
+        and entry_ref.year_number == state.selected_year
+        and entry_ref.week_number == state.selected_week
+    )
+
+
+def _find_entry_in_list(entries: list[MockEntry], entry_ref: EntryRef) -> MockEntry | None:
+    for entry in entries:
+        if entry.ref == entry_ref:
+            return entry
+    return None

--- a/src/frosthaven_campaign_journal/ui/views/main_shell_view.py
+++ b/src/frosthaven_campaign_journal/ui/views/main_shell_view.py
@@ -1,5 +1,6 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from typing import Callable
 
 import flet as ft
@@ -9,6 +10,7 @@ from frosthaven_campaign_journal.state.placeholders import (
     MainScreenLocalState,
     MockEntry,
     MockWeek,
+    ViewerSessionItem,
 )
 
 
@@ -47,6 +49,9 @@ def build_main_shell_view(
     weeks_for_selected_year: list[MockWeek],
     entries_for_selected_week: list[MockEntry],
     viewer_entry: MockEntry | None,
+    viewer_sessions: list[ViewerSessionItem],
+    entries_panel_error_message: str | None,
+    viewer_sessions_error_message: str | None,
     active_entry_ref: EntryRef | None,
     active_entry_label: str | None,
     active_status_error_message: str | None,
@@ -82,12 +87,15 @@ def build_main_shell_view(
                     state=state,
                     entries_for_selected_week=entries_for_selected_week,
                     viewer_entry=viewer_entry,
+                    entries_panel_error_message=entries_panel_error_message,
                     on_select_entry=on_select_entry,
                 ),
                 _build_center_focus_panel(
                     state=state,
                     weeks_for_selected_year=weeks_for_selected_year,
                     viewer_entry=viewer_entry,
+                    viewer_sessions=viewer_sessions,
+                    viewer_sessions_error_message=viewer_sessions_error_message,
                     active_entry_ref=active_entry_ref,
                     active_entry_label=active_entry_label,
                     read_error_message=read_error_message,
@@ -128,7 +136,7 @@ def _build_top_temporal_bar(
     else:
         has_prev_year = False
         has_next_year = False
-        year_title = "Año —"
+        year_title = "Año -"
 
     if read_status == "error" and not weeks_for_selected_year:
         week_strip_content: ft.Control = ft.Row(
@@ -253,6 +261,7 @@ def _build_entry_tabs_bar(
     state: MainScreenLocalState,
     entries_for_selected_week: list[MockEntry],
     viewer_entry: MockEntry | None,
+    entries_panel_error_message: str | None,
     on_select_entry: Callable[[EntryRef], None],
 ) -> ft.Control:
     if state.selected_week is None:
@@ -268,13 +277,25 @@ def _build_entry_tabs_bar(
                 )
             ],
         )
+    elif entries_panel_error_message:
+        content = ft.Row(
+            alignment=ft.MainAxisAlignment.CENTER,
+            vertical_alignment=ft.CrossAxisAlignment.CENTER,
+            controls=[
+                ft.Text(
+                    _truncate(f"Error Q5: {entries_panel_error_message}", 140),
+                    size=12,
+                    color=COLOR_ERROR_TEXT,
+                )
+            ],
+        )
     elif not entries_for_selected_week:
         content = ft.Row(
             alignment=ft.MainAxisAlignment.CENTER,
             vertical_alignment=ft.CrossAxisAlignment.CENTER,
             controls=[
                 ft.Text(
-                    f"Week {state.selected_week} sin entries (mock)",
+                    f"Week {state.selected_week} sin entries",
                     size=13,
                     color=COLOR_TEXT_MUTED,
                     italic=True,
@@ -315,7 +336,7 @@ def _build_entry_tab(
 ) -> ft.Control:
     underline_color = COLOR_ENTRY_TAB_SELECTED_UNDERLINE if is_selected else "transparent"
     text_weight = ft.FontWeight.W_600 if is_selected else ft.FontWeight.NORMAL
-    underline_width = max(36, min(120, len(entry.label) * 7))
+    underline_width = max(36, min(140, len(entry.label) * 7))
 
     return ft.Container(
         padding=ft.Padding(left=12, top=6, right=12, bottom=2),
@@ -346,6 +367,8 @@ def _build_center_focus_panel(
     state: MainScreenLocalState,
     weeks_for_selected_year: list[MockWeek],
     viewer_entry: MockEntry | None,
+    viewer_sessions: list[ViewerSessionItem],
+    viewer_sessions_error_message: str | None,
     active_entry_ref: EntryRef | None,
     active_entry_label: str | None,
     read_error_message: str | None,
@@ -357,6 +380,8 @@ def _build_center_focus_panel(
         primary_content = _build_focus_entry_mode(
             state=state,
             viewer_entry=viewer_entry,
+            viewer_sessions=viewer_sessions,
+            viewer_sessions_error_message=viewer_sessions_error_message,
             active_entry_ref=active_entry_ref,
             active_entry_label=active_entry_label,
         )
@@ -414,8 +439,8 @@ def _build_focus_empty_mode(state: MainScreenLocalState) -> ft.Control:
             _build_placeholder_card(
                 title="Visor (sticky) vacío",
                 body=(
-                    "En #53/#54 el visor se mantiene separado de la navegación. "
-                    "Cuando selecciones una entry mock, seguirá visible aunque cambies de año/week."
+                    "El visor se mantiene separado de la navegación. "
+                    "Cuando selecciones una entry, seguirá visible aunque cambies de año o week."
                 ),
                 min_height=108,
             ),
@@ -472,6 +497,8 @@ def _build_focus_entry_mode(
     *,
     state: MainScreenLocalState,
     viewer_entry: MockEntry,
+    viewer_sessions: list[ViewerSessionItem],
+    viewer_sessions_error_message: str | None,
     active_entry_ref: EntryRef | None,
     active_entry_label: str | None,
 ) -> ft.Control:
@@ -495,12 +522,42 @@ def _build_focus_entry_mode(
     elif active_here:
         session_status_text = f"Con sesión activa aquí: {active_entry_label or 'Entry activa'}."
     else:
-        session_status_text = f"Con sesión activa en otra entry: {active_entry_label or 'Entry activa'}."
+        session_status_text = (
+            f"Con sesión activa en otra entry: {active_entry_label or 'Entry activa'}."
+        )
 
-    detail_body = f"Tipo: {viewer_entry.entry_type}"
-    if viewer_entry.scenario_ref:
-        detail_body += f"\nScenario ref: {viewer_entry.scenario_ref}"
-    detail_body += "\nDatos reales de entries/sesiones quedan para Q5/Q8."
+    detail_lines = [f"Tipo: {viewer_entry.entry_type}"]
+    if viewer_entry.scenario_ref is not None:
+        detail_lines.append(f"Scenario ref: {viewer_entry.scenario_ref}")
+    if viewer_entry.order_index is not None:
+        detail_lines.append(f"Order index: {viewer_entry.order_index}")
+    if viewer_entry.resource_deltas:
+        detail_lines.append(
+            "resource_deltas: "
+            + ", ".join(
+                f"{k}={v}" for k, v in sorted(viewer_entry.resource_deltas.items(), key=lambda item: item[0])
+            )
+        )
+    else:
+        detail_lines.append("resource_deltas: sin cambios en esta entry")
+
+    entry_detail_card = _build_placeholder_card(
+        title="Detalle de entry (Q5)",
+        body="\n".join(detail_lines),
+        min_height=120,
+    )
+
+    sessions_card = _build_sessions_card(
+        viewer_sessions=viewer_sessions,
+        viewer_sessions_error_message=viewer_sessions_error_message,
+        session_status_text=session_status_text,
+    )
+
+    resources_note_card = _build_placeholder_card(
+        title="Recursos de la entry",
+        body="En #61 se muestran datos read-only de la entry (Q5). Las mutaciones de recursos llegan en #64.",
+        min_height=68,
+    )
 
     return ft.Column(
         spacing=12,
@@ -528,26 +585,62 @@ def _build_focus_entry_mode(
                 body="\n".join(context_lines),
                 min_height=110,
             ),
-            _build_placeholder_card(
-                title="Detalle de entry (mock hasta Q5)",
-                body=detail_body,
-                min_height=96,
-            ),
-            _build_placeholder_card(
-                title="Bloque de sesión (mock hasta Q8)",
-                body=(
-                    f"{session_status_text}\n"
-                    "Start/Stop reales y sesiones persistidas quedan fuera de #54."
-                ),
-                min_height=84,
-            ),
-            _build_placeholder_card(
-                title="Recursos de la entry (mock)",
-                body="El visor sigue mock en #54; los totales globales sí vienen de Q1.",
-                min_height=72,
-            ),
+            entry_detail_card,
+            sessions_card,
+            resources_note_card,
         ],
     )
+
+
+def _build_sessions_card(
+    *,
+    viewer_sessions: list[ViewerSessionItem],
+    viewer_sessions_error_message: str | None,
+    session_status_text: str,
+) -> ft.Control:
+    if viewer_sessions_error_message:
+        body = (
+            session_status_text
+            + "\n"
+            + "Error local Q8: "
+            + _truncate(viewer_sessions_error_message, 220)
+        )
+        return _build_placeholder_card(
+            title="Bloque de sesión (Q8 con error parcial)",
+            body=body,
+            min_height=96,
+        )
+
+    total_duration = _sum_finished_sessions_duration(viewer_sessions)
+    total_text = _format_duration(total_duration) if total_duration is not None else "0 min"
+    has_active_session = any(session.ended_at_utc is None for session in viewer_sessions)
+
+    lines: list[str] = [session_status_text, f"Total jugado (Q8): {total_text}"]
+    if not viewer_sessions:
+        lines.append("Sin sesiones para la entry visible.")
+    else:
+        for index, session in enumerate(viewer_sessions[:5], start=1):
+            lines.append(f"{index}. {_format_session_line(session)}")
+        if len(viewer_sessions) > 5:
+            lines.append(f"… y {len(viewer_sessions) - 5} sesión(es) más")
+    if has_active_session:
+        lines.append("Hay una sesión activa en la lista (ended_at_utc = null).")
+
+    return _build_placeholder_card(
+        title="Bloque de sesión (Q8)",
+        body="\n".join(lines),
+        min_height=120,
+    )
+
+
+def _format_session_line(session: ViewerSessionItem) -> str:
+    started = _format_dt_short(session.started_at_utc)
+    ended = _format_dt_short(session.ended_at_utc)
+    if session.ended_at_utc is None:
+        return f"{session.session_id}: {started} → activa"
+    duration = _session_duration(session)
+    duration_text = _format_duration(duration) if duration is not None else "duración n/d"
+    return f"{session.session_id}: {started} → {ended} · {duration_text}"
 
 
 def _build_bottom_status_bar(
@@ -791,6 +884,54 @@ def _format_navigation_line(state: MainScreenLocalState) -> str:
     if state.selected_week is None:
         return f"Navegación actual: Año {state.selected_year} · sin week seleccionada"
     return f"Navegación actual: Año {state.selected_year} · Week {state.selected_week}"
+
+
+def _sum_finished_sessions_duration(sessions: list[ViewerSessionItem]) -> timedelta | None:
+    total = timedelta(0)
+    has_any = False
+    for session in sessions:
+        duration = _session_duration(session)
+        if duration is None:
+            continue
+        has_any = True
+        total += duration
+    return total if has_any else timedelta(0)
+
+
+def _session_duration(session: ViewerSessionItem) -> timedelta | None:
+    started = _as_datetime(session.started_at_utc)
+    ended = _as_datetime(session.ended_at_utc)
+    if started is None or ended is None:
+        return None
+    if ended < started:
+        return None
+    return ended - started
+
+
+def _as_datetime(value: object | None) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value
+    return None
+
+
+def _format_dt_short(value: object | None) -> str:
+    dt_value = _as_datetime(value)
+    if dt_value is None:
+        return "n/d"
+    return dt_value.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%MZ")
+
+
+def _format_duration(duration: timedelta) -> str:
+    total_seconds = int(duration.total_seconds())
+    hours, rem = divmod(total_seconds, 3600)
+    minutes, _seconds = divmod(rem, 60)
+    if hours > 0:
+        return f"{hours} h {minutes} min"
+    return f"{minutes} min"
 
 
 def _truncate(value: str, max_length: int) -> str:


### PR DESCRIPTION
﻿## Resumen
- integra lecturas read-only `Q5` y `Q8` para panel de entry seleccionada
- reemplaza tabs/visor/sesiones mock por datos reales de Firestore
- mantiene semántica de visor sticky (`Q8` sigue a la entry visible)
- introduce errores parciales para `Q5/Q8` sin bloquear navegación base

## Validación
- `pipenv run python -m compileall src`
- lectura directa de `Q5` / `Q8` contra Firestore real
- smoke UI web (`Flutter app loaded`)

Closes #61
