### PR TITLE
[Fase 1][Implementación] Acciones de sesión y CRUD manual de sesiones (modales)

### DIFF
--- a/src/frosthaven_campaign_journal/data/__init__.py
+++ b/src/frosthaven_campaign_journal/data/__init__.py
@@ -20,6 +20,20 @@ from .main_screen_reads import (
     read_q5_entries_for_selected_week,
     read_q8_sessions_for_entry,
 )
+from .session_writes import (
+    SessionWriteResult,
+    manual_create_session,
+    manual_delete_session,
+    manual_update_session,
+    start_session,
+    stop_session,
+)
+from .write_errors import (
+    FirestoreConflictError,
+    FirestoreTransitionInvalidError,
+    FirestoreValidationError,
+    FirestoreWriteError,
+)
 
 __all__ = [
     "ActiveEntryRead",
@@ -27,15 +41,25 @@ __all__ = [
     "CampaignMainRead",
     "EntryRead",
     "EntrySessionRead",
+    "FirestoreConflictError",
     "FirestoreConfigError",
     "FirestoreReadError",
+    "FirestoreTransitionInvalidError",
+    "FirestoreValidationError",
+    "FirestoreWriteError",
     "MainScreenSnapshot",
+    "SessionWriteResult",
     "WeekRead",
     "build_firestore_client",
     "derive_year_from_week_cursor",
     "describe_firestore_status",
     "load_main_screen_snapshot",
+    "manual_create_session",
+    "manual_delete_session",
+    "manual_update_session",
     "read_entry_by_ref",
     "read_q5_entries_for_selected_week",
     "read_q8_sessions_for_entry",
+    "start_session",
+    "stop_session",
 ]

--- a/src/frosthaven_campaign_journal/data/session_writes.py
+++ b/src/frosthaven_campaign_journal/data/session_writes.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from google.api_core.exceptions import Aborted
+from google.cloud import firestore
+from google.cloud.firestore_v1.base_query import FieldFilter
+
+from frosthaven_campaign_journal.data.write_errors import (
+    FirestoreConflictError,
+    FirestoreTransitionInvalidError,
+    FirestoreValidationError,
+    FirestoreWriteError,
+)
+from frosthaven_campaign_journal.state.placeholders import EntryRef
+
+
+CAMPAIGN_ID = "01"
+WEEKS_PER_YEAR = 20
+
+
+@dataclass(frozen=True)
+class SessionWriteResult:
+    session_id: str | None = None
+
+
+def start_session(
+    client: firestore.Client,
+    *,
+    entry_ref: EntryRef,
+) -> SessionWriteResult:
+    target_entry_ref = _entry_doc_ref(client, entry_ref)
+    target_sessions_ref = target_entry_ref.collection("sessions")
+    transaction = client.transaction()
+    created_session_id = target_sessions_ref.document().id
+
+    @firestore.transactional
+    def _run(txn: firestore.Transaction) -> None:
+        active = _read_active_session(txn, client)
+        if active is not None:
+            active_entry_ref = _entry_ref_from_session_ref(active.reference)
+            if active_entry_ref == entry_ref:
+                raise FirestoreTransitionInvalidError(
+                    "La entry del visor ya tiene una sesión activa."
+                )
+            txn.update(
+                active.reference,
+                {
+                    "ended_at_utc": firestore.SERVER_TIMESTAMP,
+                    "updated_at_utc": firestore.SERVER_TIMESTAMP,
+                },
+            )
+
+        txn.set(
+            target_sessions_ref.document(created_session_id),
+            {
+                "started_at_utc": firestore.SERVER_TIMESTAMP,
+                "ended_at_utc": None,
+                "created_at_utc": firestore.SERVER_TIMESTAMP,
+                "updated_at_utc": firestore.SERVER_TIMESTAMP,
+            },
+        )
+
+    try:
+        _run(transaction)
+    except (FirestoreWriteError, FirestoreConflictError, FirestoreTransitionInvalidError, FirestoreValidationError):
+        raise
+    except Exception as exc:  # pragma: no cover - protective mapping
+        _map_firestore_write_exception(exc)
+    return SessionWriteResult(session_id=created_session_id)
+
+
+def stop_session(
+    client: firestore.Client,
+    *,
+    entry_ref: EntryRef,
+) -> SessionWriteResult:
+    entry_doc_ref = _entry_doc_ref(client, entry_ref)
+    transaction = client.transaction()
+
+    @firestore.transactional
+    def _run(txn: firestore.Transaction) -> str:
+        active = _read_active_session_for_entry(txn, entry_doc_ref)
+        if active is None:
+            raise FirestoreTransitionInvalidError(
+                "No hay sesión activa en la entry visible para detener."
+            )
+        txn.update(
+            active.reference,
+            {
+                "ended_at_utc": firestore.SERVER_TIMESTAMP,
+                "updated_at_utc": firestore.SERVER_TIMESTAMP,
+            },
+        )
+        return active.id
+
+    try:
+        stopped_id = _run(transaction)
+    except (FirestoreWriteError, FirestoreConflictError, FirestoreTransitionInvalidError, FirestoreValidationError):
+        raise
+    except Exception as exc:  # pragma: no cover - protective mapping
+        _map_firestore_write_exception(exc)
+    return SessionWriteResult(session_id=stopped_id)
+
+
+def manual_create_session(
+    client: firestore.Client,
+    *,
+    entry_ref: EntryRef,
+    started_at_utc: datetime,
+    ended_at_utc: datetime | None,
+) -> SessionWriteResult:
+    _validate_manual_session_times(started_at_utc, ended_at_utc)
+
+    entry_doc_ref = _entry_doc_ref(client, entry_ref)
+    sessions_ref = entry_doc_ref.collection("sessions")
+    transaction = client.transaction()
+    created_session_id = sessions_ref.document().id
+
+    @firestore.transactional
+    def _run(txn: firestore.Transaction) -> None:
+        if ended_at_utc is None:
+            active = _read_active_session(txn, client)
+            if active is not None:
+                raise FirestoreValidationError(
+                    "Ya existe una sesión activa global. Cierra la sesión activa antes de crear otra activa."
+                )
+
+        txn.set(
+            sessions_ref.document(created_session_id),
+            {
+                "started_at_utc": started_at_utc,
+                "ended_at_utc": ended_at_utc,
+                "created_at_utc": firestore.SERVER_TIMESTAMP,
+                "updated_at_utc": firestore.SERVER_TIMESTAMP,
+            },
+        )
+
+    try:
+        _run(transaction)
+    except (FirestoreWriteError, FirestoreConflictError, FirestoreTransitionInvalidError, FirestoreValidationError):
+        raise
+    except Exception as exc:  # pragma: no cover - protective mapping
+        _map_firestore_write_exception(exc)
+    return SessionWriteResult(session_id=created_session_id)
+
+
+def manual_update_session(
+    client: firestore.Client,
+    *,
+    entry_ref: EntryRef,
+    session_id: str,
+    started_at_utc: datetime,
+    ended_at_utc: datetime | None,
+) -> SessionWriteResult:
+    _validate_manual_session_times(started_at_utc, ended_at_utc)
+
+    session_doc_ref = _entry_doc_ref(client, entry_ref).collection("sessions").document(session_id)
+    transaction = client.transaction()
+
+    @firestore.transactional
+    def _run(txn: firestore.Transaction) -> None:
+        snapshot = _get_doc_snapshot(txn, session_doc_ref)
+        if not snapshot.exists:
+            raise FirestoreTransitionInvalidError("La sesión ya no existe.")
+
+        if ended_at_utc is None:
+            active = _read_active_session(txn, client)
+            if active is not None and active.reference.path != session_doc_ref.path:
+                raise FirestoreValidationError(
+                    "No se puede dejar esta sesión activa porque ya existe otra sesión activa global."
+                )
+
+        txn.update(
+            session_doc_ref,
+            {
+                "started_at_utc": started_at_utc,
+                "ended_at_utc": ended_at_utc,
+                "updated_at_utc": firestore.SERVER_TIMESTAMP,
+            },
+        )
+
+    try:
+        _run(transaction)
+    except (FirestoreWriteError, FirestoreConflictError, FirestoreTransitionInvalidError, FirestoreValidationError):
+        raise
+    except Exception as exc:  # pragma: no cover - protective mapping
+        _map_firestore_write_exception(exc)
+    return SessionWriteResult(session_id=session_id)
+
+
+def manual_delete_session(
+    client: firestore.Client,
+    *,
+    entry_ref: EntryRef,
+    session_id: str,
+) -> SessionWriteResult:
+    session_doc_ref = _entry_doc_ref(client, entry_ref).collection("sessions").document(session_id)
+    transaction = client.transaction()
+
+    @firestore.transactional
+    def _run(txn: firestore.Transaction) -> None:
+        snapshot = _get_doc_snapshot(txn, session_doc_ref)
+        if not snapshot.exists:
+            raise FirestoreTransitionInvalidError("La sesión ya no existe.")
+        txn.delete(session_doc_ref)
+
+    try:
+        _run(transaction)
+    except (FirestoreWriteError, FirestoreConflictError, FirestoreTransitionInvalidError, FirestoreValidationError):
+        raise
+    except Exception as exc:  # pragma: no cover - protective mapping
+        _map_firestore_write_exception(exc)
+    return SessionWriteResult(session_id=session_id)
+
+
+def _validate_manual_session_times(started_at_utc: datetime, ended_at_utc: datetime | None) -> None:
+    if started_at_utc.tzinfo is None:
+        raise FirestoreValidationError("`started_at_utc` debe incluir zona horaria (UTC).")
+    if ended_at_utc is not None and ended_at_utc.tzinfo is None:
+        raise FirestoreValidationError("`ended_at_utc` debe incluir zona horaria (UTC).")
+    if ended_at_utc is not None and ended_at_utc < started_at_utc:
+        raise FirestoreValidationError("`ended_at_utc` no puede ser anterior a `started_at_utc`.")
+
+
+def _entry_doc_ref(client: firestore.Client, entry_ref: EntryRef) -> Any:
+    season_type = _resolve_season_type_for_week(
+        year_number=entry_ref.year_number,
+        week_number=entry_ref.week_number,
+    )
+    return (
+        client.collection("campaigns")
+        .document(CAMPAIGN_ID)
+        .collection("years")
+        .document(str(entry_ref.year_number))
+        .collection("seasons")
+        .document(season_type)
+        .collection("weeks")
+        .document(str(entry_ref.week_number))
+        .collection("entries")
+        .document(entry_ref.entry_id)
+    )
+
+
+def _resolve_season_type_for_week(*, year_number: int, week_number: int) -> str:
+    local_week = week_number - ((year_number - 1) * WEEKS_PER_YEAR)
+    if not 1 <= local_week <= WEEKS_PER_YEAR:
+        raise FirestoreValidationError(
+            f"Week {week_number} no pertenece al año {year_number} según el template temporal MVP."
+        )
+    return "summer" if local_week <= 10 else "winter"
+
+
+def _read_active_session(txn: firestore.Transaction, client: firestore.Client) -> Any | None:
+    query = (
+        client.collection_group("sessions")
+        .where(filter=FieldFilter("ended_at_utc", "==", None))
+        .limit(1)
+    )
+    snapshots = list(query.stream(transaction=txn))
+    if not snapshots:
+        return None
+    return snapshots[0]
+
+
+def _read_active_session_for_entry(txn: firestore.Transaction, entry_doc_ref: Any) -> Any | None:
+    query = (
+        entry_doc_ref.collection("sessions")
+        .where(filter=FieldFilter("ended_at_utc", "==", None))
+        .limit(1)
+    )
+    snapshots = list(query.stream(transaction=txn))
+    if not snapshots:
+        return None
+    return snapshots[0]
+
+
+def _entry_ref_from_session_ref(session_doc_ref: Any) -> EntryRef:
+    try:
+        entry_doc_ref = session_doc_ref.parent.parent
+        week_doc_ref = entry_doc_ref.parent.parent
+        year_doc_ref = week_doc_ref.parent.parent.parent.parent
+    except Exception as exc:  # pragma: no cover - defensive
+        raise FirestoreConflictError(
+            "No se pudo resolver la entry owner de la sesión activa."
+        ) from exc
+
+    return EntryRef(
+        year_number=int(year_doc_ref.id),
+        week_number=int(week_doc_ref.id),
+        entry_id=entry_doc_ref.id,
+    )
+
+
+def _get_doc_snapshot(txn: firestore.Transaction, doc_ref: Any) -> Any:
+    snapshot_or_iter = txn.get(doc_ref)
+    if hasattr(snapshot_or_iter, "exists"):
+        return snapshot_or_iter
+
+    snapshots = list(snapshot_or_iter)
+    if not snapshots:
+        raise FirestoreTransitionInvalidError("El documento ya no existe.")
+    return snapshots[0]
+
+
+def _map_firestore_write_exception(exc: Exception) -> None:
+    if isinstance(exc, FirestoreWriteError):
+        raise exc
+    if isinstance(exc, Aborted):
+        raise FirestoreConflictError(
+            "La operación de escritura entró en conflicto. Pulsa Refresh y reintenta."
+        ) from exc
+    raise FirestoreWriteError(f"Error de escritura en Firestore: {exc}") from exc

--- a/src/frosthaven_campaign_journal/data/write_errors.py
+++ b/src/frosthaven_campaign_journal/data/write_errors.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+
+class FirestoreWriteError(Exception):
+    """Base error for Firestore write operations."""
+
+
+class FirestoreConflictError(FirestoreWriteError):
+    """Concurrent/base-obsoleta conflict; caller should refresh and retry."""
+
+
+class FirestoreValidationError(FirestoreWriteError):
+    """Domain validation error; caller should fix the action locally."""
+
+
+class FirestoreTransitionInvalidError(FirestoreWriteError):
+    """Invalid state transition; caller should show local error."""
+

--- a/src/frosthaven_campaign_journal/ui/app_root.py
+++ b/src/frosthaven_campaign_journal/ui/app_root.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 
 import flet as ft
 
@@ -9,14 +10,22 @@ from frosthaven_campaign_journal.data import (
     EntryRead,
     EntrySessionRead,
     FirestoreConfigError,
+    FirestoreConflictError,
     FirestoreReadError,
+    FirestoreTransitionInvalidError,
+    FirestoreValidationError,
     WeekRead,
     build_firestore_client,
     derive_year_from_week_cursor,
     load_main_screen_snapshot,
+    manual_create_session,
+    manual_delete_session,
+    manual_update_session,
     read_entry_by_ref,
     read_q5_entries_for_selected_week,
     read_q8_sessions_for_entry,
+    start_session,
+    stop_session,
 )
 from frosthaven_campaign_journal.state.placeholders import (
     EntryRef,
@@ -50,6 +59,8 @@ class EntryPanelReadState:
     viewer_entry_snapshot: MockEntry | None = None
     viewer_sessions: list[ViewerSessionItem] = field(default_factory=list)
     viewer_sessions_error_message: str | None = None
+    session_write_error_message: str | None = None
+    session_write_pending: bool = False
 
 
 def build_app_root(page: ft.Page) -> ft.Control:
@@ -83,6 +94,8 @@ def build_app_root(page: ft.Page) -> ft.Control:
             viewer_sessions=entry_panel_state.viewer_sessions,
             entries_panel_error_message=entry_panel_state.entries_panel_error_message,
             viewer_sessions_error_message=entry_panel_state.viewer_sessions_error_message,
+            session_write_error_message=entry_panel_state.session_write_error_message,
+            session_write_pending=entry_panel_state.session_write_pending,
             active_entry_ref=read_state.active_entry_ref,
             active_entry_label=read_state.active_entry_label,
             active_status_error_message=read_state.active_status_error_message,
@@ -96,6 +109,11 @@ def build_app_root(page: ft.Page) -> ft.Control:
             on_select_week=handle_select_week,
             on_select_entry=handle_select_entry,
             on_manual_refresh=handle_manual_refresh,
+            on_start_session=handle_start_session,
+            on_stop_session=handle_stop_session,
+            on_open_manual_create_session=handle_open_create_session_modal,
+            on_open_manual_edit_session=handle_open_edit_session_modal,
+            on_open_manual_delete_session=handle_open_delete_session_confirm,
         )
 
     def _build_client():
@@ -245,6 +263,7 @@ def build_app_root(page: ft.Page) -> ft.Control:
 
         local_state.selected_year = read_state.years[current_index - 1]
         local_state.selected_week = None
+        _clear_session_write_error()
         entry_panel_state.entries_for_selected_week = []
         entry_panel_state.entries_panel_error_message = None
         refresh_and_render(selected_year_override=local_state.selected_year, reload_q8=False)
@@ -258,6 +277,7 @@ def build_app_root(page: ft.Page) -> ft.Control:
 
         local_state.selected_year = read_state.years[current_index + 1]
         local_state.selected_week = None
+        _clear_session_write_error()
         entry_panel_state.entries_for_selected_week = []
         entry_panel_state.entries_panel_error_message = None
         refresh_and_render(selected_year_override=local_state.selected_year, reload_q8=False)
@@ -269,22 +289,302 @@ def build_app_root(page: ft.Page) -> ft.Control:
         if not any(week.week_number == week_number for week in visible_weeks):
             return
         local_state.selected_week = week_number
+        _clear_session_write_error()
         load_entries_for_selected_week()  # Q5 solo, el visor sticky no recarga Q8 por navegación
         render_shell()
         page.update()
 
     def handle_select_entry(entry_ref: EntryRef) -> None:
         local_state.viewer_entry_ref = entry_ref
+        _clear_session_write_error()
         load_viewer_entry_and_sessions()  # Q8 sigue al visor sticky
         render_shell()
         page.update()
 
     def handle_manual_refresh() -> None:
+        _clear_session_write_error()
         refresh_and_render(
             selected_year_override=local_state.selected_year,
             reload_q5=(local_state.selected_week is not None),
             reload_q8=(local_state.viewer_entry_ref is not None),
         )
+
+    def _clear_session_write_error() -> None:
+        entry_panel_state.session_write_error_message = None
+
+    def _set_session_write_error(message: str) -> None:
+        entry_panel_state.session_write_error_message = message
+
+    def _run_session_write(action) -> bool:
+        if local_state.viewer_entry_ref is None:
+            _set_session_write_error("No hay entry en el visor para ejecutar la acción de sesión.")
+            render_shell()
+            page.update()
+            return False
+
+        entry_panel_state.session_write_pending = True
+        _clear_session_write_error()
+        render_shell()
+        page.update()
+        success = True
+
+        try:
+            client = _build_client()
+            action(client, local_state.viewer_entry_ref)
+        except FirestoreConflictError as exc:
+            _set_session_write_error(str(exc))
+            success = False
+        except (FirestoreTransitionInvalidError, FirestoreValidationError, FirestoreReadError) as exc:
+            _set_session_write_error(str(exc))
+            success = False
+        finally:
+            entry_panel_state.session_write_pending = False
+
+        if not success:
+            render_shell()
+            page.update()
+            return False
+
+        refresh_and_render(
+            selected_year_override=local_state.selected_year,
+            reload_q5=False,
+            reload_q8=(local_state.viewer_entry_ref is not None),
+        )
+        return True
+
+    def handle_start_session() -> None:
+        _run_session_write(lambda client, entry_ref: start_session(client, entry_ref=entry_ref))
+
+    def handle_stop_session() -> None:
+        _run_session_write(lambda client, entry_ref: stop_session(client, entry_ref=entry_ref))
+
+    def _close_dialog() -> None:
+        if page.dialog is not None:
+            page.dialog.open = False
+            page.update()
+        page.dialog = None
+
+    def _show_snack_error(message: str) -> None:
+        page.snack_bar = ft.SnackBar(
+            content=ft.Text(message),
+            bgcolor="#8A1F1F",
+            open=True,
+        )
+        page.update()
+
+    def _to_local_strings(value: object | None) -> tuple[str, str]:
+        if not isinstance(value, datetime):
+            return "", ""
+        dt = value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+        local_dt = dt.astimezone()
+        return local_dt.strftime("%Y-%m-%d"), local_dt.strftime("%H:%M")
+
+    def _parse_local_datetime(date_value: str, time_value: str, *, field_label: str) -> datetime:
+        date_clean = date_value.strip()
+        time_clean = time_value.strip()
+        if not date_clean or not time_clean:
+            raise ValueError(f"{field_label}: fecha y hora son obligatorias.")
+        try:
+            naive = datetime.strptime(f"{date_clean} {time_clean}", "%Y-%m-%d %H:%M")
+        except ValueError as exc:
+            raise ValueError(f"{field_label}: usa formato YYYY-MM-DD y HH:MM.") from exc
+        local_tz = datetime.now().astimezone().tzinfo
+        if local_tz is None:
+            raise ValueError("No se pudo resolver la zona horaria local.")
+        local_dt = naive.replace(tzinfo=local_tz)
+        return local_dt.astimezone(timezone.utc)
+
+    def _parse_optional_local_datetime(
+        date_value: str,
+        time_value: str,
+        *,
+        field_label: str,
+    ) -> datetime | None:
+        if not date_value.strip() and not time_value.strip():
+            return None
+        return _parse_local_datetime(date_value, time_value, field_label=field_label)
+
+    def _show_session_form_dialog(
+        *,
+        mode: str,
+        session_to_edit: ViewerSessionItem | None = None,
+    ) -> None:
+        if local_state.viewer_entry_ref is None:
+            _set_session_write_error("No hay entry en el visor para gestionar sesiones.")
+            render_shell()
+            page.update()
+            return
+
+        started_date_default, started_time_default = _to_local_strings(
+            session_to_edit.started_at_utc if session_to_edit else None
+        )
+        ended_date_default, ended_time_default = _to_local_strings(
+            session_to_edit.ended_at_utc if session_to_edit else None
+        )
+        active_default = bool(session_to_edit and session_to_edit.ended_at_utc is None)
+
+        started_date_field = ft.TextField(
+            label="Inicio (fecha local)",
+            hint_text="YYYY-MM-DD",
+            value=started_date_default,
+            dense=True,
+            width=180,
+        )
+        started_time_field = ft.TextField(
+            label="Inicio (hora local)",
+            hint_text="HH:MM",
+            value=started_time_default,
+            dense=True,
+            width=140,
+        )
+        ended_date_field = ft.TextField(
+            label="Fin (fecha local)",
+            hint_text="YYYY-MM-DD",
+            value=ended_date_default,
+            dense=True,
+            width=180,
+        )
+        ended_time_field = ft.TextField(
+            label="Fin (hora local)",
+            hint_text="HH:MM",
+            value=ended_time_default,
+            dense=True,
+            width=140,
+        )
+        active_checkbox = ft.Checkbox(
+            label="Sesión activa (sin fin)",
+            value=active_default if mode == "edit" else False,
+        )
+        dialog_error = ft.Text("", color="#8A1F1F", size=12, visible=False)
+
+        def _apply_active_checkbox(_e=None) -> None:
+            disable_end = bool(active_checkbox.value)
+            ended_date_field.disabled = disable_end
+            ended_time_field.disabled = disable_end
+            page.update()
+
+        active_checkbox.on_change = _apply_active_checkbox
+
+        def _submit(_e) -> None:
+            try:
+                started_at_utc = _parse_local_datetime(
+                    started_date_field.value or "",
+                    started_time_field.value or "",
+                    field_label="Inicio",
+                )
+                if active_checkbox.value:
+                    ended_at_utc = None
+                else:
+                    ended_at_utc = _parse_optional_local_datetime(
+                        ended_date_field.value or "",
+                        ended_time_field.value or "",
+                        field_label="Fin",
+                    )
+                    if ended_at_utc is None:
+                        raise ValueError(
+                            "Fin: rellena fecha y hora o marca 'Sesión activa (sin fin)'."
+                        )
+            except ValueError as exc:
+                dialog_error.value = str(exc)
+                dialog_error.visible = True
+                page.update()
+                return
+
+            _close_dialog()
+            if mode == "create":
+                _run_session_write(
+                    lambda client, entry_ref: manual_create_session(
+                        client,
+                        entry_ref=entry_ref,
+                        started_at_utc=started_at_utc,
+                        ended_at_utc=ended_at_utc,
+                    )
+                )
+            elif mode == "edit" and session_to_edit is not None:
+                _run_session_write(
+                    lambda client, entry_ref: manual_update_session(
+                        client,
+                        entry_ref=entry_ref,
+                        session_id=session_to_edit.session_id,
+                        started_at_utc=started_at_utc,
+                        ended_at_utc=ended_at_utc,
+                    )
+                )
+
+        title = "Crear sesión manual" if mode == "create" else "Editar sesión"
+        submit_label = "Crear" if mode == "create" else "Guardar"
+
+        dialog = ft.AlertDialog(
+            modal=True,
+            title=ft.Text(title),
+            content=ft.Container(
+                width=420,
+                content=ft.Column(
+                    tight=True,
+                    spacing=8,
+                    controls=[
+                        ft.Row([started_date_field, started_time_field], spacing=8),
+                        ft.Row([ended_date_field, ended_time_field], spacing=8),
+                        active_checkbox,
+                        dialog_error,
+                    ],
+                ),
+            ),
+            actions=[
+                ft.TextButton("Cancelar", on_click=lambda _e: _close_dialog()),
+                ft.FilledButton(submit_label, on_click=_submit),
+            ],
+            actions_alignment=ft.MainAxisAlignment.END,
+        )
+        page.dialog = dialog
+        dialog.open = True
+        _apply_active_checkbox()
+
+    def handle_open_create_session_modal() -> None:
+        _show_session_form_dialog(mode="create")
+
+    def handle_open_edit_session_modal(session_id: str) -> None:
+        session = _find_viewer_session_item(entry_panel_state.viewer_sessions, session_id)
+        if session is None:
+            _set_session_write_error("La sesión seleccionada ya no está visible en el visor.")
+            render_shell()
+            page.update()
+            return
+        _show_session_form_dialog(mode="edit", session_to_edit=session)
+
+    def handle_open_delete_session_confirm(session_id: str) -> None:
+        session = _find_viewer_session_item(entry_panel_state.viewer_sessions, session_id)
+        if session is None:
+            _set_session_write_error("La sesión seleccionada ya no está visible en el visor.")
+            render_shell()
+            page.update()
+            return
+
+        def _confirm(_e) -> None:
+            _close_dialog()
+            _run_session_write(
+                lambda client, entry_ref: manual_delete_session(
+                    client,
+                    entry_ref=entry_ref,
+                    session_id=session_id,
+                )
+            )
+
+        dialog = ft.AlertDialog(
+            modal=True,
+            title=ft.Text("Borrar sesión"),
+            content=ft.Text(
+                f"¿Seguro que quieres borrar la sesión `{session_id}`? Esta acción es irreversible."
+            ),
+            actions=[
+                ft.TextButton("Cancelar", on_click=lambda _e: _close_dialog()),
+                ft.FilledButton("Borrar", on_click=_confirm),
+            ],
+            actions_alignment=ft.MainAxisAlignment.END,
+        )
+        page.dialog = dialog
+        dialog.open = True
+        page.update()
 
     # Carga inicial: si falla, el shell se renderiza con error visible.
     load_readonly_snapshot(selected_year_override=local_state.selected_year)
@@ -340,4 +640,14 @@ def _find_entry_in_list(entries: list[MockEntry], entry_ref: EntryRef) -> MockEn
     for entry in entries:
         if entry.ref == entry_ref:
             return entry
+    return None
+
+
+def _find_viewer_session_item(
+    sessions: list[ViewerSessionItem],
+    session_id: str,
+) -> ViewerSessionItem | None:
+    for session in sessions:
+        if session.session_id == session_id:
+            return session
     return None

--- a/src/frosthaven_campaign_journal/ui/views/main_shell_view.py
+++ b/src/frosthaven_campaign_journal/ui/views/main_shell_view.py
@@ -52,6 +52,8 @@ def build_main_shell_view(
     viewer_sessions: list[ViewerSessionItem],
     entries_panel_error_message: str | None,
     viewer_sessions_error_message: str | None,
+    session_write_error_message: str | None,
+    session_write_pending: bool,
     active_entry_ref: EntryRef | None,
     active_entry_label: str | None,
     active_status_error_message: str | None,
@@ -65,6 +67,11 @@ def build_main_shell_view(
     on_select_week: Callable[[int], None],
     on_select_entry: Callable[[EntryRef], None],
     on_manual_refresh: Callable[[], None],
+    on_start_session: Callable[[], None],
+    on_stop_session: Callable[[], None],
+    on_open_manual_create_session: Callable[[], None],
+    on_open_manual_edit_session: Callable[[str], None],
+    on_open_manual_delete_session: Callable[[str], None],
 ) -> ft.Control:
     return ft.Container(
         expand=True,
@@ -96,10 +103,17 @@ def build_main_shell_view(
                     viewer_entry=viewer_entry,
                     viewer_sessions=viewer_sessions,
                     viewer_sessions_error_message=viewer_sessions_error_message,
+                    session_write_error_message=session_write_error_message,
+                    session_write_pending=session_write_pending,
                     active_entry_ref=active_entry_ref,
                     active_entry_label=active_entry_label,
                     read_error_message=read_error_message,
                     read_warning_message=read_warning_message,
+                    on_start_session=on_start_session,
+                    on_stop_session=on_stop_session,
+                    on_open_manual_create_session=on_open_manual_create_session,
+                    on_open_manual_edit_session=on_open_manual_edit_session,
+                    on_open_manual_delete_session=on_open_manual_delete_session,
                 ),
                 _build_bottom_status_bar(
                     env_name=env_name,
@@ -369,10 +383,17 @@ def _build_center_focus_panel(
     viewer_entry: MockEntry | None,
     viewer_sessions: list[ViewerSessionItem],
     viewer_sessions_error_message: str | None,
+    session_write_error_message: str | None,
+    session_write_pending: bool,
     active_entry_ref: EntryRef | None,
     active_entry_label: str | None,
     read_error_message: str | None,
     read_warning_message: str | None,
+    on_start_session: Callable[[], None],
+    on_stop_session: Callable[[], None],
+    on_open_manual_create_session: Callable[[], None],
+    on_open_manual_edit_session: Callable[[str], None],
+    on_open_manual_delete_session: Callable[[str], None],
 ) -> ft.Control:
     selected_week = _find_selected_week(state, weeks_for_selected_year)
 
@@ -382,8 +403,15 @@ def _build_center_focus_panel(
             viewer_entry=viewer_entry,
             viewer_sessions=viewer_sessions,
             viewer_sessions_error_message=viewer_sessions_error_message,
+            session_write_error_message=session_write_error_message,
+            session_write_pending=session_write_pending,
             active_entry_ref=active_entry_ref,
             active_entry_label=active_entry_label,
+            on_start_session=on_start_session,
+            on_stop_session=on_stop_session,
+            on_open_manual_create_session=on_open_manual_create_session,
+            on_open_manual_edit_session=on_open_manual_edit_session,
+            on_open_manual_delete_session=on_open_manual_delete_session,
         )
     elif selected_week is not None:
         primary_content = _build_focus_week_mode(selected_week)
@@ -499,8 +527,15 @@ def _build_focus_entry_mode(
     viewer_entry: MockEntry,
     viewer_sessions: list[ViewerSessionItem],
     viewer_sessions_error_message: str | None,
+    session_write_error_message: str | None,
+    session_write_pending: bool,
     active_entry_ref: EntryRef | None,
     active_entry_label: str | None,
+    on_start_session: Callable[[], None],
+    on_stop_session: Callable[[], None],
+    on_open_manual_create_session: Callable[[], None],
+    on_open_manual_edit_session: Callable[[str], None],
+    on_open_manual_delete_session: Callable[[str], None],
 ) -> ft.Control:
     viewer_matches_selected_week = _entry_ref_matches_selected_week(state, viewer_entry.ref)
     active_here = active_entry_ref is not None and active_entry_ref == viewer_entry.ref
@@ -550,7 +585,14 @@ def _build_focus_entry_mode(
     sessions_card = _build_sessions_card(
         viewer_sessions=viewer_sessions,
         viewer_sessions_error_message=viewer_sessions_error_message,
+        session_write_error_message=session_write_error_message,
+        session_write_pending=session_write_pending,
         session_status_text=session_status_text,
+        on_start_session=on_start_session,
+        on_stop_session=on_stop_session,
+        on_open_manual_create_session=on_open_manual_create_session,
+        on_open_manual_edit_session=on_open_manual_edit_session,
+        on_open_manual_delete_session=on_open_manual_delete_session,
     )
 
     resources_note_card = _build_placeholder_card(
@@ -596,40 +638,184 @@ def _build_sessions_card(
     *,
     viewer_sessions: list[ViewerSessionItem],
     viewer_sessions_error_message: str | None,
+    session_write_error_message: str | None,
+    session_write_pending: bool,
     session_status_text: str,
+    on_start_session: Callable[[], None],
+    on_stop_session: Callable[[], None],
+    on_open_manual_create_session: Callable[[], None],
+    on_open_manual_edit_session: Callable[[str], None],
+    on_open_manual_delete_session: Callable[[str], None],
 ) -> ft.Control:
-    if viewer_sessions_error_message:
-        body = (
-            session_status_text
-            + "\n"
-            + "Error local Q8: "
-            + _truncate(viewer_sessions_error_message, 220)
-        )
-        return _build_placeholder_card(
-            title="Bloque de sesión (Q8 con error parcial)",
-            body=body,
-            min_height=96,
-        )
-
     total_duration = _sum_finished_sessions_duration(viewer_sessions)
     total_text = _format_duration(total_duration) if total_duration is not None else "0 min"
     has_active_session = any(session.ended_at_utc is None for session in viewer_sessions)
+    body_controls: list[ft.Control] = [
+        ft.Text(session_status_text, size=13, color=COLOR_TEXT_MUTED),
+        ft.Text(f"Total jugado (Q8): {total_text}", size=13, color=COLOR_TEXT_MUTED),
+        ft.Row(
+            spacing=8,
+            wrap=True,
+            controls=[
+                ft.FilledButton(
+                    "Start",
+                    on_click=lambda _e: on_start_session(),
+                    disabled=session_write_pending,
+                    height=32,
+                ),
+                ft.OutlinedButton(
+                    "Stop",
+                    on_click=lambda _e: on_stop_session(),
+                    disabled=session_write_pending,
+                    height=32,
+                ),
+                ft.OutlinedButton(
+                    "Nueva sesión",
+                    on_click=lambda _e: on_open_manual_create_session(),
+                    disabled=session_write_pending,
+                    height=32,
+                ),
+            ],
+        ),
+    ]
 
-    lines: list[str] = [session_status_text, f"Total jugado (Q8): {total_text}"]
+    if session_write_pending:
+        body_controls.append(
+            ft.Text(
+                "Procesando acción de sesión…",
+                size=12,
+                color=COLOR_TEXT_MUTED,
+                italic=True,
+            )
+        )
+
+    if session_write_error_message:
+        body_controls.append(
+            ft.Container(
+                padding=ft.Padding.all(8),
+                bgcolor="#FFE7E7",
+                border=ft.Border.all(1, "#D87A7A"),
+                border_radius=6,
+                content=ft.Text(
+                    _truncate(session_write_error_message, 220),
+                    size=12,
+                    color=COLOR_ERROR_TEXT,
+                ),
+            )
+        )
+
+    if viewer_sessions_error_message:
+        body_controls.append(
+            ft.Container(
+                padding=ft.Padding.all(8),
+                bgcolor="#FFE7E7",
+                border=ft.Border.all(1, "#D87A7A"),
+                border_radius=6,
+                content=ft.Text(
+                    "Error local Q8: " + _truncate(viewer_sessions_error_message, 220),
+                    size=12,
+                    color=COLOR_ERROR_TEXT,
+                ),
+            )
+        )
+
     if not viewer_sessions:
-        lines.append("Sin sesiones para la entry visible.")
+        body_controls.append(
+            ft.Text(
+                "Sin sesiones para la entry visible.",
+                size=12,
+                color=COLOR_TEXT_MUTED,
+                italic=True,
+            )
+        )
     else:
-        for index, session in enumerate(viewer_sessions[:5], start=1):
-            lines.append(f"{index}. {_format_session_line(session)}")
-        if len(viewer_sessions) > 5:
-            lines.append(f"… y {len(viewer_sessions) - 5} sesión(es) más")
+        rows: list[ft.Control] = []
+        for index, session in enumerate(viewer_sessions[:8], start=1):
+            rows.append(
+                ft.Container(
+                    padding=ft.Padding(left=8, top=6, right=8, bottom=6),
+                    bgcolor="#FFFFFF",
+                    border=ft.Border.all(1, "#E2E2E2"),
+                    border_radius=6,
+                    content=ft.Row(
+                        alignment=ft.MainAxisAlignment.SPACE_BETWEEN,
+                        vertical_alignment=ft.CrossAxisAlignment.CENTER,
+                        controls=[
+                            ft.Column(
+                                expand=True,
+                                spacing=2,
+                                controls=[
+                                    ft.Text(
+                                        f"{index}. {_format_session_line(session)}",
+                                        size=12,
+                                        color=COLOR_TEXT_PRIMARY,
+                                    ),
+                                    ft.Text(
+                                        "Activa" if session.ended_at_utc is None else "Histórica",
+                                        size=11,
+                                        color=COLOR_TEXT_MUTED,
+                                    ),
+                                ],
+                            ),
+                            ft.Row(
+                                spacing=4,
+                                controls=[
+                                    ft.TextButton(
+                                        "Editar",
+                                        on_click=lambda _e, sid=session.session_id: on_open_manual_edit_session(sid),
+                                        disabled=session_write_pending,
+                                    ),
+                                    ft.TextButton(
+                                        "Borrar",
+                                        on_click=lambda _e, sid=session.session_id: on_open_manual_delete_session(sid),
+                                        disabled=session_write_pending,
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                )
+            )
+        body_controls.extend(rows)
+        if len(viewer_sessions) > 8:
+            body_controls.append(
+                ft.Text(
+                    f"… y {len(viewer_sessions) - 8} sesión(es) más",
+                    size=11,
+                    color=COLOR_TEXT_MUTED,
+                )
+            )
     if has_active_session:
-        lines.append("Hay una sesión activa en la lista (ended_at_utc = null).")
+        body_controls.append(
+            ft.Text(
+                "Hay una sesión activa en la lista (ended_at_utc = null).",
+                size=11,
+                color=COLOR_TEXT_MUTED,
+            )
+        )
 
-    return _build_placeholder_card(
-        title="Bloque de sesión (Q8)",
-        body="\n".join(lines),
-        min_height=120,
+    return ft.Container(
+        padding=ft.Padding.all(12),
+        bgcolor="#F6F6F6",
+        border_radius=8,
+        border=ft.Border.all(1, "#D6D6D6"),
+        content=ft.Column(
+            spacing=8,
+            controls=[
+                ft.Text(
+                    "Bloque de sesión (Q8 + acciones #62)",
+                    size=14,
+                    weight=ft.FontWeight.BOLD,
+                    color=COLOR_TEXT_PRIMARY,
+                ),
+                ft.Container(
+                    padding=ft.Padding.all(8),
+                    bgcolor="#FFFFFF",
+                    border_radius=6,
+                    content=ft.Column(spacing=8, controls=body_controls),
+                ),
+            ],
+        ),
     )
 
 


### PR DESCRIPTION
﻿## Resumen
- Implementa acciones de sesión `start/stop` en el bloque de sesión del visor
- Añade CRUD manual de sesiones (`create/update/delete`) con modales
- Mantiene estrategia de refresh dirigido (sin UI optimista)
- Añade capa de writes de sesiones con clasificación de errores (`conflicto`, `transicion_invalida`, `validacion`)

## Cambios principales
- `data/session_writes.py` con writes de sesión y soporte de `auto-stop` embebido en `start`
- `data/write_errors.py` con errores tipados de writes
- `app_root.py` con handlers, modales y refresh dirigido (`Q6/Q7/Q8`)
- `main_shell_view.py` con acciones Start/Stop y acciones manuales por sesión

## Validación
- `pipenv run python -m compileall src`
- Smoke UI web (carga shell sin tracebacks)
- Guion de writes reales en Firestore dev (`campaigns/01`):
  - `start/stop`
  - duplicate start/stop (`transicion_invalida`)
  - `manual_create/update/delete`
  - validación de timestamps (`ended_at < started`)
  - restauración de sesión activa en `w36-e1`

Closes #62
