### PR TITLE
feat(week): mutaciones de week con recálculo de cursor

### DIFF
--- a/src/frosthaven_campaign_journal/data/__init__.py
+++ b/src/frosthaven_campaign_journal/data/__init__.py
@@ -28,6 +28,13 @@ from .session_writes import (
     start_session,
     stop_session,
 )
+from .week_writes import (
+    WeekWriteResult,
+    close_week,
+    reopen_week,
+    reclose_week,
+    update_week_notes,
+)
 from .write_errors import (
     FirestoreConflictError,
     FirestoreTransitionInvalidError,
@@ -50,7 +57,9 @@ __all__ = [
     "MainScreenSnapshot",
     "SessionWriteResult",
     "WeekRead",
+    "WeekWriteResult",
     "build_firestore_client",
+    "close_week",
     "derive_year_from_week_cursor",
     "describe_firestore_status",
     "load_main_screen_snapshot",
@@ -60,6 +69,9 @@ __all__ = [
     "read_entry_by_ref",
     "read_q5_entries_for_selected_week",
     "read_q8_sessions_for_entry",
+    "reclose_week",
+    "reopen_week",
     "start_session",
     "stop_session",
+    "update_week_notes",
 ]

--- a/src/frosthaven_campaign_journal/data/week_writes.py
+++ b/src/frosthaven_campaign_journal/data/week_writes.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from google.api_core.exceptions import Aborted
+from google.cloud import firestore
+from google.cloud.firestore_v1.base_query import FieldFilter
+
+from frosthaven_campaign_journal.data.write_errors import (
+    FirestoreConflictError,
+    FirestoreTransitionInvalidError,
+    FirestoreValidationError,
+    FirestoreWriteError,
+)
+
+
+CAMPAIGN_ID = "01"
+WEEKS_PER_YEAR = 20
+SEASON_TYPES = ("summer", "winter")
+
+
+@dataclass(frozen=True)
+class WeekWriteResult:
+    week_number: int
+    new_status: str | None = None
+    week_cursor: int | None = None
+    auto_stopped_session_id: str | None = None
+
+
+def update_week_notes(
+    client: firestore.Client,
+    *,
+    year_number: int,
+    week_number: int,
+    notes: str,
+) -> WeekWriteResult:
+    if not isinstance(notes, str):
+        raise FirestoreValidationError("Las notas de week deben ser texto.")
+
+    week_doc_ref = _week_doc_ref(client, year_number=year_number, week_number=week_number)
+    transaction = client.transaction()
+
+    @firestore.transactional
+    def _run(txn: firestore.Transaction) -> None:
+        snapshot = _get_doc_snapshot(txn, week_doc_ref)
+        if not snapshot.exists:
+            raise FirestoreTransitionInvalidError("La week ya no existe.")
+        txn.update(
+            week_doc_ref,
+            {
+                "notes": notes,
+                "updated_at_utc": firestore.SERVER_TIMESTAMP,
+            },
+        )
+
+    try:
+        _run(transaction)
+    except (FirestoreWriteError, FirestoreConflictError, FirestoreTransitionInvalidError, FirestoreValidationError):
+        raise
+    except Exception as exc:  # pragma: no cover - defensive mapping
+        _map_firestore_write_exception(exc)
+
+    return WeekWriteResult(week_number=week_number)
+
+
+def close_week(
+    client: firestore.Client,
+    *,
+    year_number: int,
+    week_number: int,
+) -> WeekWriteResult:
+    return _close_like_week_operation(
+        client,
+        year_number=year_number,
+        week_number=week_number,
+        operation_label="cerrar",
+    )
+
+
+def reclose_week(
+    client: firestore.Client,
+    *,
+    year_number: int,
+    week_number: int,
+) -> WeekWriteResult:
+    return _close_like_week_operation(
+        client,
+        year_number=year_number,
+        week_number=week_number,
+        operation_label="re-cerrar",
+    )
+
+
+def reopen_week(
+    client: firestore.Client,
+    *,
+    year_number: int,
+    week_number: int,
+) -> WeekWriteResult:
+    week_doc_ref = _week_doc_ref(client, year_number=year_number, week_number=week_number)
+    campaign_doc_ref = _campaign_doc_ref(client)
+    transaction = client.transaction()
+
+    @firestore.transactional
+    def _run(txn: firestore.Transaction) -> WeekWriteResult:
+        target_snapshot = _get_doc_snapshot(txn, week_doc_ref)
+        if not target_snapshot.exists:
+            raise FirestoreTransitionInvalidError("La week ya no existe.")
+
+        target_data = target_snapshot.to_dict() or {}
+        current_status = target_data.get("status")
+        if current_status not in {"open", "closed"}:
+            raise FirestoreValidationError(
+                f"Estado de week no soportado: {current_status!r}."
+            )
+        if current_status != "closed":
+            raise FirestoreTransitionInvalidError(
+                "La week no está cerrada; no se puede reabrir."
+            )
+
+        weeks_state = _read_all_weeks_state(txn, client)
+        if week_number not in weeks_state:
+            raise FirestoreTransitionInvalidError("La week ya no existe en la estructura temporal.")
+        weeks_state[week_number] = "open"
+
+        next_cursor = _first_open_week_number(weeks_state)
+        if next_cursor is None:
+            raise FirestoreValidationError(
+                "La operación dejaría 0 weeks abiertas, lo cual no está permitido."
+            )
+
+        txn.update(
+            week_doc_ref,
+            {
+                "status": "open",
+                "updated_at_utc": firestore.SERVER_TIMESTAMP,
+            },
+        )
+        txn.update(
+            campaign_doc_ref,
+            {
+                "week_cursor": next_cursor,
+                "updated_at_utc": firestore.SERVER_TIMESTAMP,
+            },
+        )
+        return WeekWriteResult(
+            week_number=week_number,
+            new_status="open",
+            week_cursor=next_cursor,
+        )
+
+    try:
+        return _run(transaction)
+    except (FirestoreWriteError, FirestoreConflictError, FirestoreTransitionInvalidError, FirestoreValidationError):
+        raise
+    except Exception as exc:  # pragma: no cover - defensive mapping
+        _map_firestore_write_exception(exc)
+
+
+def _close_like_week_operation(
+    client: firestore.Client,
+    *,
+    year_number: int,
+    week_number: int,
+    operation_label: str,
+) -> WeekWriteResult:
+    week_doc_ref = _week_doc_ref(client, year_number=year_number, week_number=week_number)
+    campaign_doc_ref = _campaign_doc_ref(client)
+    transaction = client.transaction()
+
+    @firestore.transactional
+    def _run(txn: firestore.Transaction) -> WeekWriteResult:
+        target_snapshot = _get_doc_snapshot(txn, week_doc_ref)
+        if not target_snapshot.exists:
+            raise FirestoreTransitionInvalidError("La week ya no existe.")
+
+        target_data = target_snapshot.to_dict() or {}
+        current_status = target_data.get("status")
+        if current_status not in {"open", "closed"}:
+            raise FirestoreValidationError(
+                f"Estado de week no soportado: {current_status!r}."
+            )
+        if current_status != "open":
+            raise FirestoreTransitionInvalidError(
+                f"La week no está abierta; no se puede {operation_label}."
+            )
+
+        weeks_state = _read_all_weeks_state(txn, client)
+        if week_number not in weeks_state:
+            raise FirestoreTransitionInvalidError("La week ya no existe en la estructura temporal.")
+        weeks_state[week_number] = "closed"
+
+        next_cursor = _first_open_week_number(weeks_state)
+        if next_cursor is None:
+            raise FirestoreValidationError(
+                "La operación dejaría 0 weeks abiertas, lo cual no está permitido."
+            )
+
+        auto_stopped_session_id: str | None = None
+        active_session_snapshot = _read_active_session(txn, client)
+        if active_session_snapshot is not None:
+            active_year, active_week = _week_owner_from_session_ref(active_session_snapshot.reference)
+            if active_year == year_number and active_week == week_number:
+                txn.update(
+                    active_session_snapshot.reference,
+                    {
+                        "ended_at_utc": firestore.SERVER_TIMESTAMP,
+                        "updated_at_utc": firestore.SERVER_TIMESTAMP,
+                    },
+                )
+                auto_stopped_session_id = active_session_snapshot.id
+
+        txn.update(
+            week_doc_ref,
+            {
+                "status": "closed",
+                "updated_at_utc": firestore.SERVER_TIMESTAMP,
+            },
+        )
+        txn.update(
+            campaign_doc_ref,
+            {
+                "week_cursor": next_cursor,
+                "updated_at_utc": firestore.SERVER_TIMESTAMP,
+            },
+        )
+        return WeekWriteResult(
+            week_number=week_number,
+            new_status="closed",
+            week_cursor=next_cursor,
+            auto_stopped_session_id=auto_stopped_session_id,
+        )
+
+    try:
+        return _run(transaction)
+    except (FirestoreWriteError, FirestoreConflictError, FirestoreTransitionInvalidError, FirestoreValidationError):
+        raise
+    except Exception as exc:  # pragma: no cover - defensive mapping
+        _map_firestore_write_exception(exc)
+
+
+def _campaign_doc_ref(client: firestore.Client) -> Any:
+    return client.collection("campaigns").document(CAMPAIGN_ID)
+
+
+def _week_doc_ref(client: firestore.Client, *, year_number: int, week_number: int) -> Any:
+    season_type = _resolve_season_type_for_week(year_number=year_number, week_number=week_number)
+    return (
+        _campaign_doc_ref(client)
+        .collection("years")
+        .document(str(year_number))
+        .collection("seasons")
+        .document(season_type)
+        .collection("weeks")
+        .document(str(week_number))
+    )
+
+
+def _resolve_season_type_for_week(*, year_number: int, week_number: int) -> str:
+    local_week = week_number - ((year_number - 1) * WEEKS_PER_YEAR)
+    if not 1 <= local_week <= WEEKS_PER_YEAR:
+        raise FirestoreValidationError(
+            f"Week {week_number} no pertenece al año {year_number} según el template temporal MVP."
+        )
+    return "summer" if local_week <= 10 else "winter"
+
+
+def _read_all_weeks_state(txn: firestore.Transaction, client: firestore.Client) -> dict[int, str]:
+    years_query = _campaign_doc_ref(client).collection("years").order_by("year_number")
+    year_snaps = list(years_query.stream(transaction=txn))
+    weeks_state: dict[int, str] = {}
+    for year_snap in year_snaps:
+        try:
+            year_number = int(year_snap.id)
+        except ValueError as exc:
+            raise FirestoreValidationError(f"ID de año inválido: {year_snap.id!r}.") from exc
+
+        year_doc_ref = year_snap.reference
+        for season_type in SEASON_TYPES:
+            weeks_query = (
+                year_doc_ref.collection("seasons")
+                .document(season_type)
+                .collection("weeks")
+                .order_by("week_number")
+            )
+            for week_snap in weeks_query.stream(transaction=txn):
+                data = week_snap.to_dict() or {}
+                week_number_raw = data.get("week_number")
+                status = data.get("status")
+                if not isinstance(week_number_raw, int):
+                    raise FirestoreValidationError(
+                        f"Week inválida en {week_snap.reference.path}: `week_number` no es entero."
+                    )
+                if status not in {"open", "closed"}:
+                    raise FirestoreValidationError(
+                        f"Week inválida en {week_snap.reference.path}: estado no soportado {status!r}."
+                    )
+                expected_year = ((week_number_raw - 1) // WEEKS_PER_YEAR) + 1
+                if expected_year != year_number:
+                    raise FirestoreValidationError(
+                        f"Inconsistencia temporal: week {week_number_raw} no pertenece al año {year_number}."
+                    )
+                weeks_state[week_number_raw] = status
+    return weeks_state
+
+
+def _first_open_week_number(weeks_state: dict[int, str]) -> int | None:
+    open_weeks = [week_number for week_number, status in weeks_state.items() if status == "open"]
+    if not open_weeks:
+        return None
+    return min(open_weeks)
+
+
+def _read_active_session(txn: firestore.Transaction, client: firestore.Client) -> Any | None:
+    query = (
+        client.collection_group("sessions")
+        .where(filter=FieldFilter("ended_at_utc", "==", None))
+        .limit(1)
+    )
+    snaps = list(query.stream(transaction=txn))
+    return snaps[0] if snaps else None
+
+
+def _week_owner_from_session_ref(session_doc_ref: Any) -> tuple[int, int]:
+    try:
+        entry_doc_ref = session_doc_ref.parent.parent
+        week_doc_ref = entry_doc_ref.parent.parent
+        year_doc_ref = week_doc_ref.parent.parent.parent.parent
+    except Exception as exc:  # pragma: no cover - defensive
+        raise FirestoreConflictError(
+            "No se pudo resolver la week owner de la sesión activa."
+        ) from exc
+
+    try:
+        return int(year_doc_ref.id), int(week_doc_ref.id)
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise FirestoreConflictError("No se pudo resolver year/week numéricos desde la sesión activa.") from exc
+
+
+def _get_doc_snapshot(txn: firestore.Transaction, doc_ref: Any) -> Any:
+    snapshot_or_iter = txn.get(doc_ref)
+    if hasattr(snapshot_or_iter, "exists"):
+        return snapshot_or_iter
+    snapshots = list(snapshot_or_iter)
+    if not snapshots:
+        raise FirestoreTransitionInvalidError("El documento ya no existe.")
+    return snapshots[0]
+
+
+def _map_firestore_write_exception(exc: Exception) -> None:
+    if isinstance(exc, FirestoreWriteError):
+        raise exc
+    if isinstance(exc, Aborted):
+        raise FirestoreConflictError(
+            "La operación de escritura entró en conflicto. Pulsa Refresh y reintenta."
+        ) from exc
+    raise FirestoreWriteError(f"Error de escritura en Firestore: {exc}") from exc
+

--- a/src/frosthaven_campaign_journal/ui/app_root.py
+++ b/src/frosthaven_campaign_journal/ui/app_root.py
@@ -14,18 +14,24 @@ from frosthaven_campaign_journal.data import (
     FirestoreReadError,
     FirestoreTransitionInvalidError,
     FirestoreValidationError,
+    FirestoreWriteError,
     WeekRead,
+    WeekWriteResult,
     build_firestore_client,
+    close_week,
     derive_year_from_week_cursor,
     load_main_screen_snapshot,
     manual_create_session,
     manual_delete_session,
     manual_update_session,
+    reopen_week,
     read_entry_by_ref,
     read_q5_entries_for_selected_week,
     read_q8_sessions_for_entry,
+    reclose_week,
     start_session,
     stop_session,
+    update_week_notes,
 )
 from frosthaven_campaign_journal.state.placeholders import (
     EntryRef,
@@ -61,6 +67,8 @@ class EntryPanelReadState:
     viewer_sessions_error_message: str | None = None
     session_write_error_message: str | None = None
     session_write_pending: bool = False
+    week_write_error_message: str | None = None
+    week_write_pending: bool = False
 
 
 def build_app_root(page: ft.Page) -> ft.Control:
@@ -96,6 +104,8 @@ def build_app_root(page: ft.Page) -> ft.Control:
             viewer_sessions_error_message=entry_panel_state.viewer_sessions_error_message,
             session_write_error_message=entry_panel_state.session_write_error_message,
             session_write_pending=entry_panel_state.session_write_pending,
+            week_write_error_message=entry_panel_state.week_write_error_message,
+            week_write_pending=entry_panel_state.week_write_pending,
             active_entry_ref=read_state.active_entry_ref,
             active_entry_label=read_state.active_entry_label,
             active_status_error_message=read_state.active_status_error_message,
@@ -114,6 +124,10 @@ def build_app_root(page: ft.Page) -> ft.Control:
             on_open_manual_create_session=handle_open_create_session_modal,
             on_open_manual_edit_session=handle_open_edit_session_modal,
             on_open_manual_delete_session=handle_open_delete_session_confirm,
+            on_open_week_notes_modal=handle_open_week_notes_modal,
+            on_request_close_week=handle_request_close_week,
+            on_request_reopen_week=handle_request_reopen_week,
+            on_request_reclose_week=handle_request_reclose_week,
         )
 
     def _build_client():
@@ -264,6 +278,7 @@ def build_app_root(page: ft.Page) -> ft.Control:
         local_state.selected_year = read_state.years[current_index - 1]
         local_state.selected_week = None
         _clear_session_write_error()
+        _clear_week_write_error()
         entry_panel_state.entries_for_selected_week = []
         entry_panel_state.entries_panel_error_message = None
         refresh_and_render(selected_year_override=local_state.selected_year, reload_q8=False)
@@ -278,6 +293,7 @@ def build_app_root(page: ft.Page) -> ft.Control:
         local_state.selected_year = read_state.years[current_index + 1]
         local_state.selected_week = None
         _clear_session_write_error()
+        _clear_week_write_error()
         entry_panel_state.entries_for_selected_week = []
         entry_panel_state.entries_panel_error_message = None
         refresh_and_render(selected_year_override=local_state.selected_year, reload_q8=False)
@@ -290,6 +306,7 @@ def build_app_root(page: ft.Page) -> ft.Control:
             return
         local_state.selected_week = week_number
         _clear_session_write_error()
+        _clear_week_write_error()
         load_entries_for_selected_week()  # Q5 solo, el visor sticky no recarga Q8 por navegación
         render_shell()
         page.update()
@@ -297,12 +314,14 @@ def build_app_root(page: ft.Page) -> ft.Control:
     def handle_select_entry(entry_ref: EntryRef) -> None:
         local_state.viewer_entry_ref = entry_ref
         _clear_session_write_error()
+        _clear_week_write_error()
         load_viewer_entry_and_sessions()  # Q8 sigue al visor sticky
         render_shell()
         page.update()
 
     def handle_manual_refresh() -> None:
         _clear_session_write_error()
+        _clear_week_write_error()
         refresh_and_render(
             selected_year_override=local_state.selected_year,
             reload_q5=(local_state.selected_week is not None),
@@ -314,6 +333,74 @@ def build_app_root(page: ft.Page) -> ft.Control:
 
     def _set_session_write_error(message: str) -> None:
         entry_panel_state.session_write_error_message = message
+
+    def _clear_week_write_error() -> None:
+        entry_panel_state.week_write_error_message = None
+
+    def _set_week_write_error(message: str) -> None:
+        entry_panel_state.week_write_error_message = message
+
+    def _get_selected_week_for_write() -> MockWeek | None:
+        if local_state.selected_week is None:
+            return None
+        for week in current_weeks_for_selected_year():
+            if week.week_number == local_state.selected_week:
+                return week
+        return None
+
+    def _viewer_matches_week(year_number: int, week_number: int) -> bool:
+        return (
+            local_state.viewer_entry_ref is not None
+            and local_state.viewer_entry_ref.year_number == year_number
+            and local_state.viewer_entry_ref.week_number == week_number
+        )
+
+    def _run_week_write(action) -> WeekWriteResult | None:
+        target_week = _get_selected_week_for_write()
+        if local_state.selected_year is None or local_state.selected_week is None or target_week is None:
+            _set_week_write_error("No hay week seleccionada para ejecutar la acción.")
+            render_shell()
+            page.update()
+            return None
+
+        year_number = local_state.selected_year
+        week_number = local_state.selected_week
+
+        entry_panel_state.week_write_pending = True
+        _clear_week_write_error()
+        render_shell()
+        page.update()
+
+        result: WeekWriteResult | None = None
+        success = True
+        try:
+            client = _build_client()
+            result = action(client, year_number, week_number)
+        except FirestoreConflictError as exc:
+            _set_week_write_error(str(exc))
+            success = False
+        except (
+            FirestoreTransitionInvalidError,
+            FirestoreValidationError,
+            FirestoreReadError,
+            FirestoreWriteError,
+        ) as exc:
+            _set_week_write_error(str(exc))
+            success = False
+        finally:
+            entry_panel_state.week_write_pending = False
+
+        if not success:
+            render_shell()
+            page.update()
+            return None
+
+        refresh_and_render(
+            selected_year_override=local_state.selected_year,
+            reload_q5=False,
+            reload_q8=_viewer_matches_week(year_number, week_number),
+        )
+        return result
 
     def _run_session_write(action) -> bool:
         if local_state.viewer_entry_ref is None:
@@ -357,6 +444,148 @@ def build_app_root(page: ft.Page) -> ft.Control:
 
     def handle_stop_session() -> None:
         _run_session_write(lambda client, entry_ref: stop_session(client, entry_ref=entry_ref))
+
+    def _show_week_notes_modal() -> None:
+        target_week = _get_selected_week_for_write()
+        if target_week is None:
+            _set_week_write_error("No hay week seleccionada para editar notas.")
+            render_shell()
+            page.update()
+            return
+
+        notes_field = ft.TextField(
+            label=f"Notas week {target_week.week_number}",
+            multiline=True,
+            min_lines=4,
+            max_lines=10,
+            value=target_week.notes_preview or "",
+            autofocus=True,
+            expand=True,
+        )
+
+        def _submit(_e) -> None:
+            notes_value = (notes_field.value or "").strip()
+            _close_dialog()
+            _run_week_write(
+                lambda client, year_number, week_number: update_week_notes(
+                    client,
+                    year_number=year_number,
+                    week_number=week_number,
+                    notes=notes_value,
+                )
+            )
+
+        dialog = ft.AlertDialog(
+            modal=True,
+            title=ft.Text("Editar notas de week"),
+            content=ft.Container(width=520, content=notes_field),
+            actions=[
+                ft.TextButton("Cancelar", on_click=lambda _e: _close_dialog()),
+                ft.FilledButton("Guardar", on_click=_submit),
+            ],
+            actions_alignment=ft.MainAxisAlignment.END,
+        )
+        page.dialog = dialog
+        dialog.open = True
+        page.update()
+
+    def _show_week_state_confirm_dialog(
+        *,
+        title: str,
+        body: str,
+        confirm_label: str,
+        action,
+    ) -> None:
+        def _confirm(_e) -> None:
+            _close_dialog()
+            result = _run_week_write(action)
+            if result is None:
+                return
+            if result.auto_stopped_session_id:
+                page.snack_bar = ft.SnackBar(
+                    content=ft.Text(
+                        f"Week actualizada. Se auto-cerró la sesión {result.auto_stopped_session_id}."
+                    ),
+                    open=True,
+                )
+                page.update()
+
+        dialog = ft.AlertDialog(
+            modal=True,
+            title=ft.Text(title),
+            content=ft.Text(body),
+            actions=[
+                ft.TextButton("Cancelar", on_click=lambda _e: _close_dialog()),
+                ft.FilledButton(confirm_label, on_click=_confirm),
+            ],
+            actions_alignment=ft.MainAxisAlignment.END,
+        )
+        page.dialog = dialog
+        dialog.open = True
+        page.update()
+
+    def handle_open_week_notes_modal() -> None:
+        _show_week_notes_modal()
+
+    def handle_request_close_week() -> None:
+        target_week = _get_selected_week_for_write()
+        if target_week is None:
+            _set_week_write_error("No hay week seleccionada para cerrar.")
+            render_shell()
+            page.update()
+            return
+        _show_week_state_confirm_dialog(
+            title="Cerrar week",
+            body=(
+                f"¿Seguro que quieres cerrar la week {target_week.week_number}? "
+                "Si hay una sesión activa en esta week se auto-cerrará."
+            ),
+            confirm_label="Cerrar",
+            action=lambda client, year_number, week_number: close_week(
+                client,
+                year_number=year_number,
+                week_number=week_number,
+            ),
+        )
+
+    def handle_request_reopen_week() -> None:
+        target_week = _get_selected_week_for_write()
+        if target_week is None:
+            _set_week_write_error("No hay week seleccionada para reabrir.")
+            render_shell()
+            page.update()
+            return
+        _show_week_state_confirm_dialog(
+            title="Reabrir week",
+            body=f"¿Seguro que quieres reabrir la week {target_week.week_number}?",
+            confirm_label="Reabrir",
+            action=lambda client, year_number, week_number: reopen_week(
+                client,
+                year_number=year_number,
+                week_number=week_number,
+            ),
+        )
+
+    def handle_request_reclose_week() -> None:
+        target_week = _get_selected_week_for_write()
+        if target_week is None:
+            _set_week_write_error("No hay week seleccionada para re-cerrar.")
+            render_shell()
+            page.update()
+            return
+        _show_week_state_confirm_dialog(
+            title="Re-cerrar week",
+            body=(
+                f"¿Seguro que quieres re-cerrar la week {target_week.week_number}? "
+                "Si hay una sesión activa en esta week se auto-cerrará."
+            ),
+            confirm_label="Re-cerrar",
+            action=lambda client, year_number, week_number: reclose_week(
+                client,
+                year_number=year_number,
+                week_number=week_number,
+            ),
+        )
 
     def _close_dialog() -> None:
         if page.dialog is not None:
@@ -594,7 +823,7 @@ def build_app_root(page: ft.Page) -> ft.Control:
 
 def _map_week_read_to_mock(week: WeekRead) -> MockWeek:
     is_closed = week.status == "closed"
-    notes_preview = week.notes or f"Sin notas en la week {week.week_number}."
+    notes_preview = week.notes or ""
     return MockWeek(
         year_number=week.year_number,
         week_number=week.week_number,

--- a/src/frosthaven_campaign_journal/ui/views/main_shell_view.py
+++ b/src/frosthaven_campaign_journal/ui/views/main_shell_view.py
@@ -54,6 +54,8 @@ def build_main_shell_view(
     viewer_sessions_error_message: str | None,
     session_write_error_message: str | None,
     session_write_pending: bool,
+    week_write_error_message: str | None,
+    week_write_pending: bool,
     active_entry_ref: EntryRef | None,
     active_entry_label: str | None,
     active_status_error_message: str | None,
@@ -72,6 +74,10 @@ def build_main_shell_view(
     on_open_manual_create_session: Callable[[], None],
     on_open_manual_edit_session: Callable[[str], None],
     on_open_manual_delete_session: Callable[[str], None],
+    on_open_week_notes_modal: Callable[[], None],
+    on_request_close_week: Callable[[], None],
+    on_request_reopen_week: Callable[[], None],
+    on_request_reclose_week: Callable[[], None],
 ) -> ft.Control:
     return ft.Container(
         expand=True,
@@ -105,6 +111,8 @@ def build_main_shell_view(
                     viewer_sessions_error_message=viewer_sessions_error_message,
                     session_write_error_message=session_write_error_message,
                     session_write_pending=session_write_pending,
+                    week_write_error_message=week_write_error_message,
+                    week_write_pending=week_write_pending,
                     active_entry_ref=active_entry_ref,
                     active_entry_label=active_entry_label,
                     read_error_message=read_error_message,
@@ -114,6 +122,10 @@ def build_main_shell_view(
                     on_open_manual_create_session=on_open_manual_create_session,
                     on_open_manual_edit_session=on_open_manual_edit_session,
                     on_open_manual_delete_session=on_open_manual_delete_session,
+                    on_open_week_notes_modal=on_open_week_notes_modal,
+                    on_request_close_week=on_request_close_week,
+                    on_request_reopen_week=on_request_reopen_week,
+                    on_request_reclose_week=on_request_reclose_week,
                 ),
                 _build_bottom_status_bar(
                     env_name=env_name,
@@ -385,6 +397,8 @@ def _build_center_focus_panel(
     viewer_sessions_error_message: str | None,
     session_write_error_message: str | None,
     session_write_pending: bool,
+    week_write_error_message: str | None,
+    week_write_pending: bool,
     active_entry_ref: EntryRef | None,
     active_entry_label: str | None,
     read_error_message: str | None,
@@ -394,6 +408,10 @@ def _build_center_focus_panel(
     on_open_manual_create_session: Callable[[], None],
     on_open_manual_edit_session: Callable[[str], None],
     on_open_manual_delete_session: Callable[[str], None],
+    on_open_week_notes_modal: Callable[[], None],
+    on_request_close_week: Callable[[], None],
+    on_request_reopen_week: Callable[[], None],
+    on_request_reclose_week: Callable[[], None],
 ) -> ft.Control:
     selected_week = _find_selected_week(state, weeks_for_selected_year)
 
@@ -414,7 +432,15 @@ def _build_center_focus_panel(
             on_open_manual_delete_session=on_open_manual_delete_session,
         )
     elif selected_week is not None:
-        primary_content = _build_focus_week_mode(selected_week)
+        primary_content = _build_focus_week_mode(
+            selected_week,
+            week_write_error_message=week_write_error_message,
+            week_write_pending=week_write_pending,
+            on_open_week_notes_modal=on_open_week_notes_modal,
+            on_request_close_week=on_request_close_week,
+            on_request_reopen_week=on_request_reopen_week,
+            on_request_reclose_week=on_request_reclose_week,
+        )
     else:
         primary_content = _build_focus_empty_mode(state)
 
@@ -485,9 +511,86 @@ def _build_focus_empty_mode(state: MainScreenLocalState) -> ft.Control:
     )
 
 
-def _build_focus_week_mode(week: MockWeek) -> ft.Control:
+def _build_focus_week_mode(
+    week: MockWeek,
+    *,
+    week_write_error_message: str | None,
+    week_write_pending: bool,
+    on_open_week_notes_modal: Callable[[], None],
+    on_request_close_week: Callable[[], None],
+    on_request_reopen_week: Callable[[], None],
+    on_request_reclose_week: Callable[[], None],
+) -> ft.Control:
     badge_bg = "#EDEDED" if week.is_closed else "#D9F2D9"
     badge_fg = "#6A6A6A" if week.is_closed else "#237A3B"
+    action_buttons: list[ft.Control] = [
+        ft.OutlinedButton(
+            "Editar notas",
+            on_click=lambda _e: on_open_week_notes_modal(),
+            disabled=week_write_pending,
+            height=32,
+        )
+    ]
+    if week.is_closed:
+        action_buttons.append(
+            ft.FilledButton(
+                "Reopen",
+                on_click=lambda _e: on_request_reopen_week(),
+                disabled=week_write_pending,
+                height=32,
+            )
+        )
+    else:
+        action_buttons.extend(
+            [
+                ft.FilledButton(
+                    "Close",
+                    on_click=lambda _e: on_request_close_week(),
+                    disabled=week_write_pending,
+                    height=32,
+                ),
+                ft.OutlinedButton(
+                    "Reclose",
+                    on_click=lambda _e: on_request_reclose_week(),
+                    disabled=week_write_pending,
+                    height=32,
+                ),
+            ]
+        )
+
+    notes_controls: list[ft.Control] = [
+        ft.Row(spacing=8, wrap=True, controls=action_buttons)
+    ]
+    if week_write_pending:
+        notes_controls.append(
+            ft.Text(
+                "Procesando acción de week…",
+                size=12,
+                color=COLOR_TEXT_MUTED,
+                italic=True,
+            )
+        )
+    if week_write_error_message:
+        notes_controls.append(
+            ft.Container(
+                padding=ft.Padding.all(8),
+                bgcolor="#FFE7E7",
+                border=ft.Border.all(1, "#D87A7A"),
+                border_radius=6,
+                content=ft.Text(
+                    _truncate(week_write_error_message, 220),
+                    size=12,
+                    color=COLOR_ERROR_TEXT,
+                ),
+            )
+        )
+    notes_controls.append(
+        _build_placeholder_card(
+            title="Notas de la week",
+            body=week.notes_preview or f"Sin notas en la week {week.week_number}.",
+            min_height=110,
+        )
+    )
 
     return ft.Column(
         spacing=12,
@@ -505,10 +608,12 @@ def _build_focus_week_mode(week: MockWeek) -> ft.Control:
                     _build_badge(week.status_label, badge_bg, badge_fg),
                 ],
             ),
-            _build_placeholder_card(
-                title="Notas de la week",
-                body=week.notes_preview,
-                min_height=110,
+            ft.Container(
+                padding=ft.Padding.all(12),
+                bgcolor="#F6F6F6",
+                border_radius=8,
+                border=ft.Border.all(1, "#D6D6D6"),
+                content=ft.Column(spacing=8, controls=notes_controls),
             ),
             _build_placeholder_card(
                 title="Sin entry en visor",


### PR DESCRIPTION
﻿## Resumen
- Implementa mutaciones de week (`update_notes`, `close`, `reopen`, `reclose`) con data layer Firestore y wiring UI.
- Añade confirmaciones de estado de week y modal de notas.
- Añade refresh dirigido tras writes, incluyendo `Q1`, `Q3/Q4` y refresco de `Q6/Q7/Q8` cuando aplica por `auto-stop`.

## Validación
- `pipenv run python -m compileall src`
- Smoke de data layer de `week_writes.py` contra Firestore real (notas + `reclose/reopen/close` con restauración)
- UI web Flet: selección de week y presencia de controles de week (`Editar notas`, `Close`, `Reclose`) en `8550`

Closes #63
