### PR TITLE
#69 extensión temporal +1 año en barra superior

### DIFF
--- a/src/frosthaven_campaign_journal/data/__init__.py
+++ b/src/frosthaven_campaign_journal/data/__init__.py
@@ -6,6 +6,10 @@ from .firestore_client import (
     build_firestore_client,
 )
 from .firestore_placeholder import describe_firestore_status
+from .campaign_writes import (
+    CampaignWriteResult,
+    extend_years_plus_one,
+)
 from .main_screen_reads import (
     ActiveEntryRead,
     ActiveSessionRead,
@@ -58,6 +62,7 @@ from .write_errors import (
 __all__ = [
     "ActiveEntryRead",
     "ActiveSessionRead",
+    "CampaignWriteResult",
     "CampaignMainRead",
     "EntryWriteResult",
     "EntryRead",
@@ -81,6 +86,7 @@ __all__ = [
     "delete_entry",
     "derive_year_from_week_cursor",
     "describe_firestore_status",
+    "extend_years_plus_one",
     "load_main_screen_snapshot",
     "manual_create_session",
     "manual_delete_session",

--- a/src/frosthaven_campaign_journal/data/campaign_writes.py
+++ b/src/frosthaven_campaign_journal/data/campaign_writes.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from google.api_core.exceptions import Aborted
+from google.cloud import firestore
+
+from frosthaven_campaign_journal.data.write_errors import (
+    FirestoreConflictError,
+    FirestoreTransitionInvalidError,
+    FirestoreValidationError,
+    FirestoreWriteError,
+)
+
+
+CAMPAIGN_ID = "01"
+WEEKS_PER_YEAR = 20
+WEEKS_PER_SEASON = 10
+SEASON_TYPES = ("summer", "winter")
+
+
+@dataclass(frozen=True)
+class CampaignWriteResult:
+    new_year_number: int
+    created_week_start: int
+    created_week_end: int
+    week_cursor: int
+
+
+def extend_years_plus_one(client: firestore.Client) -> CampaignWriteResult:
+    campaign_doc_ref = _campaign_doc_ref(client)
+    transaction = client.transaction()
+
+    @firestore.transactional
+    def _run(txn: firestore.Transaction) -> CampaignWriteResult:
+        campaign_snapshot = _get_doc_snapshot(txn, campaign_doc_ref)
+        if not campaign_snapshot.exists:
+            raise FirestoreTransitionInvalidError("La campaña ya no existe.")
+
+        campaign_data = campaign_snapshot.to_dict() or {}
+        week_cursor_raw = campaign_data.get("week_cursor")
+        if isinstance(week_cursor_raw, bool) or not isinstance(week_cursor_raw, int) or week_cursor_raw <= 0:
+            raise FirestoreValidationError("`campaign.week_cursor` debe ser un entero positivo.")
+
+        years_state = _read_years_state(txn, client)
+        if not years_state:
+            raise FirestoreTransitionInvalidError(
+                "La campaña no tiene años provisionados; no se puede extender +1 año."
+            )
+        last_year_number = max(years_state)
+        new_year_number = last_year_number + 1
+
+        weeks_state, max_existing_week_number = _read_all_weeks_state(txn, client)
+        if max_existing_week_number is None:
+            raise FirestoreTransitionInvalidError(
+                "La campaña no tiene weeks provisionadas; no se puede extender +1 año."
+            )
+
+        created_week_start = max_existing_week_number + 1
+        created_week_end = max_existing_week_number + WEEKS_PER_YEAR
+
+        year_doc_ref = campaign_doc_ref.collection("years").document(str(new_year_number))
+        year_snapshot = _get_doc_snapshot(txn, year_doc_ref)
+        if year_snapshot.exists:
+            raise FirestoreValidationError(
+                f"Ya existe el año {new_year_number}; no se puede extender +1 año."
+            )
+
+        _validate_new_week_range_absent(
+            weeks_state=weeks_state,
+            created_week_start=created_week_start,
+            created_week_end=created_week_end,
+        )
+
+        server_ts = firestore.SERVER_TIMESTAMP
+        txn.set(
+            year_doc_ref,
+            {
+                "year_number": new_year_number,
+                "created_at_utc": server_ts,
+                "updated_at_utc": server_ts,
+            },
+        )
+
+        next_week_number = created_week_start
+        for season_type in SEASON_TYPES:
+            season_doc_ref = year_doc_ref.collection("seasons").document(season_type)
+            txn.set(
+                season_doc_ref,
+                {
+                    "season_type": season_type,
+                    "created_at_utc": server_ts,
+                    "updated_at_utc": server_ts,
+                },
+            )
+
+            for _ in range(WEEKS_PER_SEASON):
+                txn.set(
+                    season_doc_ref.collection("weeks").document(str(next_week_number)),
+                    {
+                        "week_number": next_week_number,
+                        "status": "open",
+                        "notes": None,
+                        "created_at_utc": server_ts,
+                        "updated_at_utc": server_ts,
+                    },
+                )
+                weeks_state[next_week_number] = "open"
+                next_week_number += 1
+
+        next_week_cursor = _first_open_week_number(weeks_state)
+        if next_week_cursor is None:
+            raise FirestoreValidationError(
+                "La extensión dejaría 0 weeks abiertas, lo cual no está permitido."
+            )
+
+        txn.update(
+            campaign_doc_ref,
+            {
+                "week_cursor": next_week_cursor,
+                "updated_at_utc": server_ts,
+            },
+        )
+
+        return CampaignWriteResult(
+            new_year_number=new_year_number,
+            created_week_start=created_week_start,
+            created_week_end=created_week_end,
+            week_cursor=next_week_cursor,
+        )
+
+    try:
+        return _run(transaction)
+    except (FirestoreWriteError, FirestoreConflictError, FirestoreTransitionInvalidError, FirestoreValidationError):
+        raise
+    except Exception as exc:  # pragma: no cover - defensive mapping
+        _map_firestore_write_exception(exc)
+
+
+def _read_years_state(txn: firestore.Transaction, client: firestore.Client) -> set[int]:
+    years_query = _campaign_doc_ref(client).collection("years").order_by("year_number")
+    year_snaps = list(years_query.stream(transaction=txn))
+    year_numbers: set[int] = set()
+    for year_snap in year_snaps:
+        data = year_snap.to_dict() or {}
+        year_number = data.get("year_number")
+        if year_number is None:
+            try:
+                year_number = int(year_snap.id)
+            except ValueError as exc:
+                raise FirestoreValidationError(
+                    f"Year inválido: `{year_snap.reference.path}` sin `year_number` parseable."
+                ) from exc
+        if isinstance(year_number, bool) or not isinstance(year_number, int) or year_number <= 0:
+            raise FirestoreValidationError(
+                f"Year inválido en `{year_snap.reference.path}`: `year_number` no válido."
+            )
+        if year_number in year_numbers:
+            raise FirestoreValidationError(f"Hay años duplicados con `year_number={year_number}`.")
+        year_numbers.add(year_number)
+    return year_numbers
+
+
+def _read_all_weeks_state(
+    txn: firestore.Transaction,
+    client: firestore.Client,
+) -> tuple[dict[int, str], int | None]:
+    years_query = _campaign_doc_ref(client).collection("years").order_by("year_number")
+    year_snaps = list(years_query.stream(transaction=txn))
+    weeks_state: dict[int, str] = {}
+    max_week_number: int | None = None
+
+    for year_snap in year_snaps:
+        data = year_snap.to_dict() or {}
+        year_number = data.get("year_number")
+        if year_number is None:
+            try:
+                year_number = int(year_snap.id)
+            except ValueError as exc:
+                raise FirestoreValidationError(f"ID de año inválido: {year_snap.id!r}.") from exc
+        if isinstance(year_number, bool) or not isinstance(year_number, int) or year_number <= 0:
+            raise FirestoreValidationError(
+                f"Year inválido en `{year_snap.reference.path}`: `year_number` no válido."
+            )
+
+        year_doc_ref = year_snap.reference
+        for season_type in SEASON_TYPES:
+            weeks_query = (
+                year_doc_ref.collection("seasons")
+                .document(season_type)
+                .collection("weeks")
+                .order_by("week_number")
+            )
+            for week_snap in weeks_query.stream(transaction=txn):
+                week_data = week_snap.to_dict() or {}
+                week_number = week_data.get("week_number")
+                status = week_data.get("status")
+                if isinstance(week_number, bool) or not isinstance(week_number, int) or week_number <= 0:
+                    raise FirestoreValidationError(
+                        f"Week inválida en {week_snap.reference.path}: `week_number` no es entero positivo."
+                    )
+                if status not in {"open", "closed"}:
+                    raise FirestoreValidationError(
+                        f"Week inválida en {week_snap.reference.path}: estado no soportado {status!r}."
+                    )
+                expected_year = ((week_number - 1) // WEEKS_PER_YEAR) + 1
+                if expected_year != year_number:
+                    raise FirestoreValidationError(
+                        f"Inconsistencia temporal: week {week_number} no pertenece al año {year_number}."
+                    )
+                if week_number in weeks_state:
+                    raise FirestoreValidationError(
+                        f"Duplicado temporal: week {week_number} repetida en la estructura."
+                    )
+                weeks_state[week_number] = status
+                if max_week_number is None or week_number > max_week_number:
+                    max_week_number = week_number
+
+    return weeks_state, max_week_number
+
+
+def _validate_new_week_range_absent(
+    *,
+    weeks_state: dict[int, str],
+    created_week_start: int,
+    created_week_end: int,
+) -> None:
+    for week_number in range(created_week_start, created_week_end + 1):
+        if week_number in weeks_state:
+            raise FirestoreValidationError(
+                f"La extensión +1 año duplicaría la week {week_number}."
+            )
+
+
+def _first_open_week_number(weeks_state: dict[int, str]) -> int | None:
+    open_weeks = [week_number for week_number, status in weeks_state.items() if status == "open"]
+    if not open_weeks:
+        return None
+    return min(open_weeks)
+
+
+def _campaign_doc_ref(client: firestore.Client) -> Any:
+    return client.collection("campaigns").document(CAMPAIGN_ID)
+
+
+def _get_doc_snapshot(txn: firestore.Transaction, doc_ref: Any) -> Any:
+    snapshot_or_iter = txn.get(doc_ref)
+    if hasattr(snapshot_or_iter, "exists"):
+        return snapshot_or_iter
+    snapshots = list(snapshot_or_iter)
+    if not snapshots:
+        raise FirestoreTransitionInvalidError("El documento ya no existe.")
+    return snapshots[0]
+
+
+def _map_firestore_write_exception(exc: Exception) -> None:
+    if isinstance(exc, FirestoreWriteError):
+        raise exc
+    if isinstance(exc, Aborted):
+        raise FirestoreConflictError(
+            "La operación de escritura entró en conflicto. Pulsa Refresh y reintenta."
+        ) from exc
+    raise FirestoreWriteError(f"Error de escritura en Firestore: {exc}") from exc

--- a/src/frosthaven_campaign_journal/ui/app_root.py
+++ b/src/frosthaven_campaign_journal/ui/app_root.py
@@ -8,6 +8,7 @@ import flet as ft
 
 from frosthaven_campaign_journal.config import load_settings
 from frosthaven_campaign_journal.data import (
+    CampaignWriteResult,
     EntryWriteResult,
     EntryRead,
     EntrySessionRead,
@@ -26,6 +27,7 @@ from frosthaven_campaign_journal.data import (
     create_entry,
     delete_entry,
     derive_year_from_week_cursor,
+    extend_years_plus_one,
     load_main_screen_snapshot,
     manual_create_session,
     manual_delete_session,
@@ -65,6 +67,7 @@ class MainScreenReadState:
     active_entry_ref: EntryRef | None = None
     active_entry_label: str | None = None
     active_status_error_message: str | None = None
+    campaign_write_pending: bool = False
 
 
 @dataclass
@@ -139,6 +142,7 @@ def build_app_root(page: ft.Page) -> ft.Control:
             entry_write_pending=entry_panel_state.entry_write_pending,
             resource_write_error_message=entry_panel_state.resource_write_error_message,
             resource_write_pending=entry_panel_state.resource_write_pending,
+            campaign_write_pending=read_state.campaign_write_pending,
             resource_draft_values=(
                 dict(entry_panel_state.resource_draft_values)
                 if _resource_draft_attached_to_viewer()
@@ -156,6 +160,7 @@ def build_app_root(page: ft.Page) -> ft.Control:
             env_name=load_settings().env,
             on_prev_year=handle_prev_year,
             on_next_year=handle_next_year,
+            on_open_extend_year_plus_one_confirm=handle_open_extend_year_plus_one_confirm,
             on_select_week=handle_select_week,
             on_select_entry=handle_select_entry,
             on_manual_refresh=handle_manual_refresh,
@@ -634,6 +639,38 @@ def build_app_root(page: ft.Page) -> ft.Control:
     def _get_viewer_entry_ref_for_resource_write() -> EntryRef | None:
         return local_state.viewer_entry_ref
 
+    def _run_campaign_write(action) -> CampaignWriteResult | None:
+        read_state.campaign_write_pending = True
+        render_shell()
+        page.update()
+
+        result: CampaignWriteResult | None = None
+        success = True
+        try:
+            client = _build_client()
+            result = action(client)
+        except FirestoreConflictError as exc:
+            _show_snack_error(str(exc))
+            success = False
+        except (
+            FirestoreConfigError,
+            FirestoreTransitionInvalidError,
+            FirestoreValidationError,
+            FirestoreReadError,
+            FirestoreWriteError,
+        ) as exc:
+            _show_snack_error(str(exc))
+            success = False
+        finally:
+            read_state.campaign_write_pending = False
+
+        if not success:
+            render_shell()
+            page.update()
+            return None
+
+        return result
+
     def _run_week_write(action) -> WeekWriteResult | None:
         target_week = _get_selected_week_for_write()
         if local_state.selected_year is None or local_state.selected_week is None or target_week is None:
@@ -958,8 +995,83 @@ def build_app_root(page: ft.Page) -> ft.Control:
         )
         _open_dialog(dialog)
 
+    def _get_extend_year_plus_one_target() -> tuple[int, int] | None:
+        if not read_state.years:
+            _show_snack_error("No hay años provisionados en la campaña.")
+            return None
+        selected_year = local_state.selected_year
+        if selected_year is None or selected_year not in read_state.years:
+            _show_snack_error("No hay un año válido seleccionado para extender la campaña.")
+            return None
+        last_year = max(read_state.years)
+        if selected_year != last_year:
+            _show_snack_error("Solo se puede extender +1 año desde el último año provisionado.")
+            return None
+        return selected_year, (last_year + 1)
+
+    def _show_extend_year_plus_one_confirm_dialog() -> None:
+        target = _get_extend_year_plus_one_target()
+        if target is None:
+            return
+        current_year, next_year_number = target
+
+        def _confirm(_e) -> None:
+            _close_dialog()
+            result = _run_campaign_write(lambda client: extend_years_plus_one(client))
+            if result is None:
+                return
+
+            local_state.selected_year = result.new_year_number
+            local_state.selected_week = None
+            _clear_session_write_error()
+            _clear_week_write_error()
+            _clear_entry_write_error()
+            _clear_resource_write_error()
+            entry_panel_state.entries_for_selected_week = []
+            entry_panel_state.entries_panel_error_message = None
+            refresh_and_render(
+                selected_year_override=result.new_year_number,
+                reload_q5=False,
+                reload_q8=(local_state.viewer_entry_ref is not None),
+            )
+            _show_snack_info(
+                f"Año {result.new_year_number} añadido correctamente "
+                f"(weeks {result.created_week_start}-{result.created_week_end})."
+            )
+
+        dialog = ft.AlertDialog(
+            modal=True,
+            title=ft.Text("Extender campaña (+1 año)"),
+            content=ft.Text(
+                (
+                    f"Vas a extender la campaña desde Año {current_year} a Año {next_year_number}.\n\n"
+                    "Se añadirá exactamente 1 año completo (20 weeks) con confirmación explícita."
+                )
+            ),
+            actions=[
+                ft.TextButton("Cancelar", on_click=lambda _e: _close_dialog()),
+                ft.FilledButton(
+                    "Extender",
+                    on_click=_confirm,
+                    disabled=read_state.campaign_write_pending,
+                ),
+            ],
+            actions_alignment=ft.MainAxisAlignment.END,
+        )
+        _open_dialog(dialog)
+
     def handle_open_week_notes_modal() -> None:
         _show_week_notes_modal()
+
+    def handle_open_extend_year_plus_one_confirm() -> None:
+        if read_state.campaign_write_pending:
+            return
+        if _get_extend_year_plus_one_target() is None:
+            return
+        _run_or_confirm_resource_draft_before_context_change(
+            _show_extend_year_plus_one_confirm_dialog,
+            action_label="extender +1 año",
+        )
 
     def handle_request_close_week() -> None:
         target_week = _get_selected_week_for_write()

--- a/src/frosthaven_campaign_journal/ui/views/main_shell_view.py
+++ b/src/frosthaven_campaign_journal/ui/views/main_shell_view.py
@@ -61,6 +61,7 @@ def build_main_shell_view(
     entry_write_pending: bool,
     resource_write_error_message: str | None,
     resource_write_pending: bool,
+    campaign_write_pending: bool,
     resource_draft_values: dict[str, int] | None,
     resource_draft_dirty: bool,
     resource_draft_attached_to_viewer: bool,
@@ -74,6 +75,7 @@ def build_main_shell_view(
     env_name: str,
     on_prev_year: Callable[[], None],
     on_next_year: Callable[[], None],
+    on_open_extend_year_plus_one_confirm: Callable[[], None],
     on_select_week: Callable[[int], None],
     on_select_entry: Callable[[EntryRef], None],
     on_manual_refresh: Callable[[], None],
@@ -101,8 +103,10 @@ def build_main_shell_view(
         weeks_for_selected_year=weeks_for_selected_year,
         read_status=read_status,
         read_error_message=read_error_message,
+        campaign_write_pending=campaign_write_pending,
         on_prev_year=on_prev_year,
         on_next_year=on_next_year,
+        on_open_extend_year_plus_one_confirm=on_open_extend_year_plus_one_confirm,
         on_select_week=on_select_week,
         embedded_in_appbar=True,
     )
@@ -202,8 +206,10 @@ def _build_top_temporal_bar(
     weeks_for_selected_year: list[MockWeek],
     read_status: str,
     read_error_message: str | None,
+    campaign_write_pending: bool,
     on_prev_year: Callable[[], None],
     on_next_year: Callable[[], None],
+    on_open_extend_year_plus_one_confirm: Callable[[], None],
     on_select_week: Callable[[int], None],
     embedded_in_appbar: bool = False,
 ) -> ft.Control:
@@ -213,11 +219,26 @@ def _build_top_temporal_bar(
         year_index = years.index(selected_year)
         has_prev_year = year_index > 0
         has_next_year = year_index < len(years) - 1
+        is_last_year = year_index == len(years) - 1
         year_title = f"Año {selected_year}"
     else:
         has_prev_year = False
         has_next_year = False
+        is_last_year = False
         year_title = "Año -"
+
+    left_year_action = on_prev_year if has_prev_year and not campaign_write_pending else None
+    if not has_valid_selected_year:
+        right_year_label = "→"
+        right_year_action = None
+    elif is_last_year:
+        right_year_label = "+"
+        right_year_action = (
+            on_open_extend_year_plus_one_confirm if not campaign_write_pending else None
+        )
+    else:
+        right_year_label = "→"
+        right_year_action = on_next_year if has_next_year and not campaign_write_pending else None
 
     if read_status == "error" and not weeks_for_selected_year:
         week_strip_content: ft.Control = ft.Row(
@@ -255,6 +276,7 @@ def _build_top_temporal_bar(
                     week=week,
                     is_selected=(week.week_number == state.selected_week),
                     on_select_week=on_select_week,
+                    disabled=campaign_write_pending,
                 )
                 for week in weeks_for_selected_year
             ],
@@ -271,14 +293,14 @@ def _build_top_temporal_bar(
                 spacing=12,
                 vertical_alignment=ft.CrossAxisAlignment.CENTER,
                 controls=[
-                    _build_year_nav_button("←", on_prev_year if has_prev_year else None),
+                    _build_year_nav_button("←", left_year_action),
                     ft.Text(
                         year_title,
                         size=32,
                         weight=ft.FontWeight.BOLD,
                         color=COLOR_TEXT_PRIMARY,
                     ),
-                    _build_year_nav_button("→", on_next_year if has_next_year else None),
+                    _build_year_nav_button(right_year_label, right_year_action),
                 ],
             ),
             ft.Container(expand=True, content=week_strip_content),
@@ -324,6 +346,7 @@ def _build_week_tile(
     week: MockWeek,
     is_selected: bool,
     on_select_week: Callable[[int], None],
+    disabled: bool = False,
 ) -> ft.Control:
     border = ft.Border.all(2, COLOR_WEEK_TILE_SELECTED_BORDER) if is_selected else None
     bgcolor = COLOR_WEEK_TILE_CLOSED_BG if week.is_closed else COLOR_WEEK_TILE_BG
@@ -336,7 +359,9 @@ def _build_week_tile(
         border=border,
         border_radius=2,
         alignment=ft.Alignment.CENTER,
-        on_click=lambda _e, week_number=week.week_number: on_select_week(week_number),
+        on_click=(
+            None if disabled else (lambda _e, week_number=week.week_number: on_select_week(week_number))
+        ),
         content=ft.Text(
             str(week.week_number),
             size=13,


### PR DESCRIPTION
## Resumen\n\nImplementa la acción +1 año en la barra temporal superior con confirmación, write real en Firestore y salto automático al nuevo año tras éxito.\n\n## Cambios\n\n- Nuevo write de campaña extend_years_plus_one() en data/campaign_writes.py.\n- Export de CampaignWriteResult y extend_years_plus_one en data/__init__.py.\n- Botón + en la barra superior cuando el año visible es el último provisionado.\n- Confirmación de extensión +1 año en UI.\n- Refresh dirigido tras éxito y salto al nuevo año.\n- Integración con confirmación de borrador de recursos sucio (#68).\n\n## Verificación\n\n- python -m compileall -q src\n\nCloses #69