### PR TITLE
#75 corrige Entry.delete en transacción Firestore

### DIFF
--- a/src/frosthaven_campaign_journal/data/entry_writes.py
+++ b/src/frosthaven_campaign_journal/data/entry_writes.py
@@ -144,7 +144,8 @@ def delete_entry(
             session_data = session_snap.to_dict() or {}
             if session_data.get("ended_at_utc") is None and auto_stopped_session_id is None:
                 auto_stopped_session_id = session_snap.id
-            txn.delete(session_snap.reference)
+
+        next_resource_totals: dict[str, int] | None = None
 
         if resource_deltas:
             campaign_snapshot = _get_doc_snapshot(txn, campaign_doc_ref)
@@ -168,16 +169,23 @@ def delete_entry(
                     )
                 resource_totals[key] = next_total
 
+            next_resource_totals = resource_totals
+
+        # En transacciones Firestore, todas las lecturas deben ocurrir antes de la primera escritura.
+        existing = _read_entries_for_week(txn, entries_ref)
+        _normalize_entries_order_if_needed(txn, existing)
+
+        for session_snap in session_snaps:
+            txn.delete(session_snap.reference)
+
+        if next_resource_totals is not None:
             txn.update(
                 campaign_doc_ref,
                 {
-                    "resource_totals": resource_totals,
+                    "resource_totals": next_resource_totals,
                     "updated_at_utc": firestore.SERVER_TIMESTAMP,
                 },
             )
-
-        existing = _read_entries_for_week(txn, entries_ref)
-        _normalize_entries_order_if_needed(txn, existing)
         remaining = [item for item in existing if item["snapshot"].reference.path != entry_doc_ref.path]
 
         txn.delete(entry_doc_ref)


### PR DESCRIPTION
## Resumen

Corrige el bug de `#75` en `Entry.delete`: la transacción hacía escrituras (borrado de sesiones / update de recursos) y luego intentaba leer las entries de la week, patrón inválido en Firestore (`read-after-write` dentro de una transacción), provocando rollback y dejando la entry sin borrar.

## Cambio aplicado

- `src/frosthaven_campaign_journal/data/entry_writes.py`
  - `delete_entry(...)` refactorizado a fases:
    - lecturas y cálculo en memoria primero
    - escrituras después
  - se evita cualquier lectura Firestore tras la primera escritura
  - se añade comentario defensivo sobre la regla transaccional

## Verificación

- `python -m compileall -q src` ✅
- Validación micro UI (Flet web + Charlotte) ✅
  - `Escenario 42` (W35) activo
  - `Borrar` + confirmar
  - `Refresh`
  - resultado: desaparece la entry, visor limpio (`Sin entry en visor`), `Sin sesión activa`, y ajuste de totales visible (`lumber` baja)

Closes #75