### PR TITLE
#76 reencuadra modelo temporal a semana actual derivada

### DIFF
--- a/docs/campaign-temporal-controls.md
+++ b/docs/campaign-temporal-controls.md
@@ -24,7 +24,7 @@ Incluye:
 - selector de año y selector de semanas del año seleccionado;
 - provisión inicial automática de años en `campaign/01`;
 - extensión manual de años (`+1`) con confirmación;
-- semántica de navegación de semana vs cambio de `week_cursor`;
+- semántica de navegación de semana vs semana actual derivada;
 - patrón de UI del selector de entry al pulsar semana (a nivel de intención).
 
 No incluye:
@@ -63,7 +63,8 @@ No incluye:
 
 1. El selector de semanas muestra semanas del **año seleccionado**.
 1. Su función principal en esta issue es navegación/foco temporal.
-1. Pulsar una semana **no cambia automáticamente** `campaign.week_cursor`.
+1. Pulsar una semana **no cambia automáticamente** la semana actual derivada
+   (primera `Week` abierta).
 1. Al pulsar una semana se abre el flujo de selección de entry (popover/modal
    anclado), definido en esta issue a nivel de patrón e intención.
 
@@ -83,22 +84,25 @@ No incluye:
 1. Tras confirmar, se añade **1 año** nuevo.
 1. No hay extensión automática por umbral en el MVP.
 
-## Política de `week_cursor` (actualización posterior de dominio)
+## Política de semana actual derivada (actualización posterior de dominio y reencuadre `#76`)
 
 1. La semántica original de ajuste manual explícito de `week_cursor` definida en
    esta issue fue **actualizada** por la Issue `#37`
    (`docs/editability-policy.md`).
-1. En el MVP actual, `week_cursor` apunta a la **primera `Week` abierta**
-   (menor `week_number` abierta) y se recalcula tras cambios de estado de
-   `Week`.
+1. El canon de producto/documentación vigente define la **semana actual** como
+   concepto **derivado no persistido**: la primera `Week` abierta (menor
+   `week_number` abierta), recalculada tras cambios de estado de `Week`.
 1. Seleccionar semana para navegar/focalizar sigue siendo una acción separada de
-   la navegación temporal y no cambia automáticamente `week_cursor`.
-1. El marcador visual de `current week` (derivado de `week_cursor`) y la
+   la navegación temporal y no cambia automáticamente la semana actual derivada.
+1. El marcador visual de `current week` (derivado de la semana actual) y la
    selección `Week`/`Entry` usada por el flujo de sesión se tratan como
    conceptos separados (ver `docs/active-session-flow.md`, Issue `#14`).
 1. Default de arranque de pantalla principal (`#16`): la barra superior se
    sitúa en el año de `current week`, pero la selección inicial de `Week` y
    `Entry` es vacía (`none`).
+1. **Nota de transición (`#76`)**: la implementación actual del repo todavía
+   persiste/lee `campaign.week_cursor` en backend/UI como mecanismo transitorio.
+   La migración técnica para retirar esa dependencia se sigue en `#81`.
 
 ## Click en semana y selector de entry (patrón + intención)
 
@@ -113,7 +117,8 @@ No incluye:
 ## Límites y dependencias
 
 - **Issue #9** (esta decisión): navegación temporal superior + provisión/
-  extensión de años + semántica de `week_cursor`.
+  extensión de años + semántica de semana actual derivada (históricamente
+  referida como `week_cursor`).
 - **Issue #13**: detalle técnico de inicialización y extensión de
   `year/season/week`.
 - **Issue #14** (o equivalente): detalle del popover de entries y flujo de
@@ -125,7 +130,7 @@ No incluye:
 - **Issue #12**: contrato de operaciones Firestore por agregado (implementación
   técnica de operaciones como provisión/extensión/cambio de cursor).
 - **Issue #37**: política de editabilidad manual del MVP y semántica derivada de
-  `week_cursor` (primera `Week` abierta), que actualiza esta decisión.
+  la semana actual (primera `Week` abierta), que actualiza esta decisión.
 - **Issue #18**: timestamps y desempates de orden estable entre dispositivos.
 
 ## Referencias

--- a/docs/context-governance.md
+++ b/docs/context-governance.md
@@ -135,6 +135,23 @@ Se valida:
   - Alcance aplicado: validación de uso individual con alternancia en dos tabs y `Refresh`, sin claims multi-writer concurrente real.
   - Reencuadre explícito: `DEF-001` se ejecuta como viewport equivalente (`desktop` + `mobile/tablet`) en vez de dispositivo físico en esta unidad.
 
+### Hito H1-03
+
+- Fecha: 2026-02-26
+- Objetivo: reencuadrar el modelo temporal del MVP a “semana actual derivada no persistida” (`#76`) y dejar trazabilidad de transición.
+- Resultado: completado (decisión+docs+trazabilidad) con migración técnica diferida
+- Verificación A: aprobado (issue `#76` reencuadrada + comentario histórico en `#70`)
+- Verificación B: aprobado (docs núcleo alineados y issue técnica de migración creada)
+- Evidencia:
+  - Issue `#76` (reencuadre de discrepancia de modelo temporal)
+  - Issue `#81` (migración técnica de implementación para retirar dependencia de `campaign.week_cursor`)
+  - Comentario en `#70` (reinterpretación/superseded del bloqueo temporal)
+  - PR de la unidad `#76` (decisión+docs)
+- Resumen:
+  - Canon documental actualizado: la “semana actual” pasa a definirse como concepto derivado (primera `Week` abierta) y no como campo persistido canónico.
+  - Se acepta divergencia transitoria: el código actual sigue usando `campaign.week_cursor` hasta ejecutar `#81`.
+  - `#76` se cierra como unidad de decisión+docs; no incluye migración técnica ni revalidación de `TC-TEMPORAL-01/02`.
+
 ## Conocimiento migrado desde legado
 
 - `important.txt`

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -757,3 +757,37 @@
   `src/frosthaven_campaign_journal/ui/views/main_shell_view.py`,
   `src/frosthaven_campaign_journal/state/placeholders.py`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/53`
+
+### DEC-0034
+
+- `date`: 2026-02-26
+- `status`: accepted
+- `problem`: existe una discrepancia entre el modelo temporal deseado por
+  producto (semana actual derivada no persistida = primera `Week` abierta) y el
+  estado actual del repo, que todavía persiste/consume `campaign.week_cursor`
+  como campo canónico en lecturas y writes temporales. La issue `#76` nació como
+  gap de observabilidad UI de `week_cursor`, pero esa formulación deja de ser
+  correcta si `week_cursor` ya no debe existir como concepto vigente.
+- `decision`: reencuadrar `#76` como unidad de decisión+documentación para
+  fijar el canon de **semana actual derivada no persistida**, marcar
+  `campaign.week_cursor` como implementación transitoria (no contrato objetivo)
+  y abrir una issue técnica separada para migrar código/datos. No se realiza la
+  migración técnica en `#76`.
+- `rationale`: simplifica el modelo conceptual (semana actual = primera week
+  abierta), evita diseñar UX/testabilidad alrededor de un campo técnico que se
+  quiere retirar y reduce retrabajo al separar claramente reencuadre documental
+  de migración de implementación.
+- `impact`: actualiza docs núcleo (temporal, editabilidad, lecturas, contrato,
+  glosario, invariantes) con nota de transición; añade trazabilidad histórica en
+  `#70`; crea una issue técnica de migración (`#81`); y deja una divergencia
+  transitoria aceptada entre docs canónicas y código actual hasta ejecutar esa
+  migración.
+- `references`: `docs/campaign-temporal-controls.md`,
+  `docs/editability-policy.md`, `docs/minimal-read-queries.md`,
+  `docs/firestore-operation-contract.md`, `docs/domain-glossary.md`,
+  `docs/domain-invariant-test-plan.md`, `docs/context-governance.md`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/76`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/81`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/70`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/19`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`

--- a/docs/domain-glossary.md
+++ b/docs/domain-glossary.md
@@ -20,9 +20,14 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
 ### Campaign
 
 - `campaign_id`: string fijo, valor `01`.
-- `week_cursor`: entero, semana actual activa.
-  - En MVP apunta a la **primera `Week` abierta** (menor `week_number` abierta)
-    y se recalcula tras operaciones que cambian el estado de `Week`.
+- **Semana actual derivada** (concepto canónico): primera `Week` abierta
+  (menor `week_number` abierta) y se recalcula tras operaciones que cambian el
+  estado de `Week`.
+  - No se persiste como dato canónico del modelo.
+- `week_cursor` (término técnico transitorio / implementación actual): entero
+  persistido que hoy representa la semana actual derivada.
+  - Se mantiene como detalle legacy hasta la migración técnica de `#81`
+    (reencuadre documental en `#76`).
 - `resource_totals`: mapa `resource_key -> int` derivado de la suma de
   `Entry.resource_deltas` en la campaña.
   - Ausencia de clave = total `0` para cálculo (las claves nunca usadas pueden
@@ -97,11 +102,15 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
 
 - Persistencia temporal en UTC.
 - `week_number` global inmutable.
-- Seleccionar `Week` para navegación/foco no implica cambiar `week_cursor`.
-- `week_cursor` se deriva de la primera `Week` abierta (menor `week_number`
-  abierta) según `docs/editability-policy.md`.
+- Seleccionar `Week` para navegación/foco no implica cambiar la semana actual
+  derivada.
+- La semana actual derivada se define como la primera `Week` abierta (menor
+  `week_number` abierta) según `docs/editability-policy.md`.
 - Las correcciones manuales de `Week.status` (`reopen`/`reclose`) recalculan
-  `week_cursor`.
+  la semana actual derivada.
+- Nota de transición (`#76` -> `#81`): la implementación actual aún persiste y
+  actualiza `campaign.week_cursor`, pero se trata de un detalle transitorio y
+  no del contrato canónico del MVP.
 - `year_number` y `season_type` son coherentes con `week_number` y la jerarquía.
 - En esta issue no se define provisión inicial de años (por ejemplo, crear 4
   años en bloque).
@@ -130,11 +139,11 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
 1. `Week.status` puede corregirse manualmente (`reopen`/`reclose`) en MVP.
 1. Se permiten correcciones manuales completas de `Session` (crear/editar/
    borrar), manteniendo `0..1` sesión activa global.
-1. `week_cursor` siempre apunta a la primera `Week` abierta (menor
+1. La semana actual derivada siempre apunta a la primera `Week` abierta (menor
    `week_number` abierta) y se recalcula tras cambios de estado de `Week`;
-   navegar semanas no cambia el cursor.
+   navegar semanas no la cambia.
 1. Debe existir al menos una `Week` abierta provisionada para mantener
-   `week_cursor` como entero válido.
+   una semana actual derivada válida.
 1. Cada `Entry.resource_deltas[resource_key]` es entero firmado y se valida que
    el estado final de totales no sea negativo.
 1. `scenario_ref` es obligatorio y entero positivo para `scenario`.
@@ -156,12 +165,12 @@ entidad `Entry` (`scenario|outpost`) y jerarquía temporal explícita:
 1. Borrar `Entry` debe eliminar en cascada sus hijos.
 1. Si el delta neto de un recurso en `Entry.resource_deltas` llega a `0`, la
    clave se elimina del mapa.
-1. Reabrir o re-cerrar una `Week` recalcula `week_cursor` a la primera `Week`
-   abierta.
+1. Reabrir o re-cerrar una `Week` recalcula la semana actual derivada a la
+   primera `Week` abierta.
 1. No se permite cerrar/re-cerrar una `Week` si la operación dejaría `0` weeks
    abiertas provisionadas.
 1. Operaciones que dejen totales finales negativos deben rechazarse.
-1. Cerrar `Week` con sesión activa debe cerrar sesión y recalcular `week_cursor`
-   según la primera `Week` abierta.
+1. Cerrar `Week` con sesión activa debe cerrar sesión y recalcular la semana
+   actual derivada según la primera `Week` abierta.
 1. Seleccionar una semana en el control temporal superior no debe cambiar
-   `week_cursor` sin acción explícita adicional.
+   la semana actual derivada sin acción explícita adicional.

--- a/docs/domain-invariant-test-plan.md
+++ b/docs/domain-invariant-test-plan.md
@@ -86,9 +86,9 @@ No incluye:
 | `INV-SESSION-02` | `auto-stop` embebido preserva invariantes | `dominio` | Operaciones compuestas con `auto-stop` (`start`, `Week.close/reclose`, `Entry.delete`) no dejan estados parciales válidos asumidos | `#12`, `#14` | `critical` | Compuesto + side-effects |
 | `INV-SESSION-03` | Clasificación/recuperación de errores en flujo de sesión | `consistencia_visible` | `conflicto` vs `transicion_invalida` vs `validacion` se diferencian y recuperan según contrato | `#8`, `#12`, `#14` | `high` | Afecta UX/reintento |
 | `INV-SESSION-04` | Separación foco vs activo | `consistencia_visible` | La UI distingue `selected_entry` y `active_entry` con carga/refresh coherentes | `#14`, `#16`, `#18` | `critical` | Relacionado con Q6/Q7 |
-| `INV-TEMPORAL-01` | `week_cursor` = primera week abierta | `dominio` | `week_cursor` se recalcula a la primera `Week` abierta tras cambios de estado | `#37`, `#12`, `#9`, glosario | `critical` | Cursor derivado |
+| `INV-TEMPORAL-01` | Semana actual derivada = primera week abierta | `dominio` | La semana actual derivada se recalcula a la primera `Week` abierta tras cambios de estado | `#37`, `#12`, `#9`, glosario | `critical` | Antes modelada como `week_cursor` |
 | `INV-TEMPORAL-02` | Nunca `0` weeks abiertas | `dominio` | `Week.close/reclose` no puede dejar `0` weeks abiertas | `#12`, `#37`, `#13` | `critical` | Validación bloqueante |
-| `INV-TEMPORAL-03` | Navegación/selección no cambia `week_cursor` | `consistencia_visible` | Seleccionar week/entry no muta `campaign.week_cursor` | `#9`, `#14`, `#16`, glosario | `high` | Separa navegación de cursor |
+| `INV-TEMPORAL-03` | Navegación/selección no cambia semana actual derivada | `consistencia_visible` | Seleccionar week/entry no muta la semana actual derivada (históricamente representada por `campaign.week_cursor`) | `#9`, `#14`, `#16`, glosario | `high` | Separa navegación de semana actual derivada |
 | `INV-TEMPORAL-04` | Estructura temporal fija del MVP | `dominio` | `summer -> winter`, 10 semanas/estación, 4 años iniciales, extensión `+1` | `#13`, `#12` | `high` | Estructural |
 | `INV-TEMPORAL-05` | `week_number` global único/inmutable | `dominio` | `week_number` es correlativo, único e inmutable | `#13`, glosario, `#12` | `high` | Impacta lecturas/orden |
 | `INV-ENTRY-01` | `order_index` denso `1..N` | `dominio` | Tras create/reorder, la secuencia de entries de la week es densa y estable | `#12`, `#18`, glosario | `high` | Incluye auto-normalización |
@@ -131,9 +131,9 @@ No incluye:
 | `TC-SESSION-02` | `INV-SESSION-02` | `Week.close/reclose` con activa embebida preserva invariante | Week con sesión activa en esa week | Cerrar/re-cerrar week | `auto-stop` embebido + cierre/reclose sin estado parcial asumido | `conflicto` / `validacion` | Campos mínimos + referencia al escenario compuesto | `desk_check_documental` | `P0` | `bloqueante_plan` | Relaciona `#12` + `#14` |
 | `TC-SESSION-03` | `INV-SESSION-03` | `start` sobre entry ya activa clasifica transición inválida | `selected_entry == active_entry` | Pulsar `Iniciar` | Error local; no nueva sesión ni `auto-stop` | `transicion_invalida` | Resultado observado + status | `single_device_preparado` | `P1` | `planificado_no_bloqueante` | Flujo UI |
 | `TC-SESSION-04` | `INV-SESSION-04` | Activa en otra entry y foco distinto | Existe activa global en otra entry | Cargar Q6/Q7 y seleccionar otra entry | UI distingue foco vs activo; label de activo externo coherente | `sin_error` / `conflicto` | Evidencia visual + refs de datos | `single_device_preparado` / `desk_check_documental` | `P0` | `bloqueante_plan` | Cruza `#14/#16/#18` |
-| `TC-TEMPORAL-01` | `INV-TEMPORAL-01` | Recalcular `week_cursor` tras cambio de estado | Week abierta candidata a primera abierta | Ejecutar `Week.close/reopen/reclose` | `week_cursor` apunta a primera week abierta válida | `sin_error` / `conflicto` | Resultado cursor antes/después | `desk_check_documental` | `P0` | `bloqueante_plan` | Cursor derivado |
+| `TC-TEMPORAL-01` | `INV-TEMPORAL-01` | Recalcular semana actual derivada tras cambio de estado | Week abierta candidata a primera abierta | Ejecutar `Week.close/reopen/reclose` | La semana actual derivada apunta a la primera week abierta válida | `sin_error` / `conflicto` | Resultado de semana actual derivada antes/después | `desk_check_documental` | `P0` | `bloqueante_plan` | Antes expresado como `week_cursor` |
 | `TC-TEMPORAL-02` | `INV-TEMPORAL-02` | Rechazo al dejar `0` weeks abiertas | Última week abierta identificada | Intentar `close/reclose` | Operación rechazada por validación; invariante preservada | `validacion` | Resultado esperado + status | `desk_check_documental` | `P0` | `bloqueante_plan` | Validación crítica |
-| `TC-TEMPORAL-03` | `INV-TEMPORAL-03` | Navegación no muta `week_cursor` | `week_cursor` conocido; sin side-effect de estado | `ui.select_week` / `ui.select_entry` | Selección cambia foco; `week_cursor` no cambia | `sin_error` | Evidencia visual/estado | `single_device_preparado` / `desk_check_documental` | `P1` | `planificado_no_bloqueante` | Consistencia visible |
+| `TC-TEMPORAL-03` | `INV-TEMPORAL-03` | Navegación no muta semana actual derivada | Semana actual derivada conocida; sin side-effect de estado | `ui.select_week` / `ui.select_entry` | Selección cambia foco; la semana actual derivada no cambia | `sin_error` | Evidencia visual/estado | `single_device_preparado` / `desk_check_documental` | `P1` | `planificado_no_bloqueante` | Consistencia visible |
 | `TC-TEMPORAL-04` | `INV-TEMPORAL-04` | Provisión/extensión respeta plantilla temporal | Campaña nueva o provisionada para `+1` | Provisión inicial / `extend_years_plus_one` | `summer->winter`, 10 semanas/estación, 4 años iniciales / `+1` exacto | `sin_error` / `validacion` / `conflicto` | Resultado estructural resumido | `desk_check_documental` | `P1` | `planificado_no_bloqueante` | Estructura + continuidad |
 | `TC-TEMPORAL-05` | `INV-TEMPORAL-05` | `week_number` global único e inmutable | Estructura temporal conocida | Revisar create/extend y operaciones históricas | No duplicación/reutilización; numeración correlativa mantenida | `sin_error` / `validacion` | Evidencia de rangos/resultados | `desk_check_documental` | `P1` | `planificado_no_bloqueante` | Trazable en docs |
 | `TC-ENTRY-01` | `INV-ENTRY-01` | Resecuencia densa tras create/reorder | Week con entries y/o secuencia inconsistente | `Entry.create` / `Entry.reorder_within_week` | `order_index` denso `1..N`; auto-normalización si aplica | `sin_error` / `conflicto` | Orden antes/después | `desk_check_documental` / `single_device_preparado` | `P1` | `planificado_no_bloqueante` | Incluye auto-normalización |
@@ -149,6 +149,14 @@ No incluye:
 | `TC-READ-04` | `INV-READ-04` | `ui.manual_refresh` reconcilia estado visible | UI desfasada tras conflicto o estado obsoleto | `ui.manual_refresh` | Estado visible se normaliza sin realtime | `conflicto` / `sin_error` | Resultado antes/después refresh | `single_device_preparado` / `desk_check_documental` | `P0` | `bloqueante_plan` | Núcleo de recuperación MVP |
 
 ## Mapeo a edge cases de `#17` (trazabilidad)
+
+### Nota de transición temporal (`#76`)
+
+- Tras `#76`, las referencias de este documento a `week_cursor` se interpretan
+  como **semana actual derivada** (primera `Week` abierta).
+- El bloqueo registrado en `#70` para `TC-TEMPORAL-01/02` por observabilidad de
+  `week_cursor` queda **superseded/reinterpretado** por el reencuadre de modelo.
+- La migración técnica del código/documentación residual queda trazada en `#81`.
 
 ### Regla
 
@@ -166,7 +174,7 @@ No incluye:
 | `TC-SESSION-01` | `EC-SESSION-01` | Conflicto en `start` compuesto y unicidad de activa global | `directa` | `P0` crítico |
 | `TC-ENTRY-02` | `EC-SESSION-06` | `Entry.delete` activa con `auto-stop` embebido | `directa` | Compuesto |
 | `TC-SESSION-02` | `EC-SESSION-06` | Variante de conflicto compuesto en cierre de sesión dentro de operación padre | `parcial` | Complementa `Entry.delete` / `Week.close` |
-| `TC-TEMPORAL-01` | `EC-WEEK-02` | Conflicto en estado de week con recálculo de `week_cursor` | `directa` | `P0` crítico |
+| `TC-TEMPORAL-01` | `EC-WEEK-02` | Conflicto en estado de week con recálculo de semana actual derivada | `directa` | `P0` crítico |
 | `TC-TEMPORAL-02` | `EC-WEEK-03` | No dejar `0` weeks abiertas | `directa` | `P0` crítico |
 | `TC-RESOURCE-01` | `EC-RESOURCE-02` | Recursos sobre base obsoleta afectan consistencia de totales | `parcial` | Integridad de totales |
 | `TC-RESOURCE-04` | `EC-RESOURCE-03` | Drift/inconsistencia clasificada como conflicto | `directa` | `P0` crítico |

--- a/docs/editability-policy.md
+++ b/docs/editability-policy.md
@@ -24,7 +24,7 @@ Incluye:
 - corrección manual de `Week.status` (`reopen`/`reclose`);
 - correcciones manuales completas de `Session` (crear/editar/borrar,
   incluyendo timestamps);
-- política derivada de `campaign.week_cursor` como primera `Week` abierta;
+- política derivada de semana actual (primera `Week` abierta) como concepto no persistido;
 - matriz de operaciones manuales permitidas y sus límites;
 - impacto documental sobre dominio, conflictos y orden técnico downstream.
 
@@ -39,7 +39,7 @@ No incluye:
 
 - `docs/domain-glossary.md` (modelo de dominio e invariantes actuales)
 - `docs/conflict-policy.md` (política de conflictos concurrentes MVP)
-- `docs/campaign-temporal-controls.md` (controles temporales y semántica previa de `week_cursor`)
+- `docs/campaign-temporal-controls.md` (controles temporales y semántica temporal)
 - `docs/campaign-temporal-initialization.md` (estructura temporal y provisión)
 - Decisiones de Kiko para esta issue marco:
   - reordenación manual de `Entry`: sí, con operación "mover una entry";
@@ -47,7 +47,7 @@ No incluye:
   - `order_index`: secuencia densa `1..N`;
   - `Week.reopen/reclose`: sí;
   - correcciones manuales de `Session`: completo (crear/editar/borrar, con timestamps);
-  - `week_cursor`: primera `Week` abierta (menor `week_number` entre abiertas);
+  - semana actual derivada: primera `Week` abierta (menor `week_number` entre abiertas);
   - borrado para `#12`: hard delete real (insumo downstream);
   - `Entry.update` para `#12`: amplio (insumo downstream);
   - atomicidad en `#12`: solo comportamiento (insumo downstream).
@@ -71,8 +71,8 @@ No incluye:
 | `Entry.reorder_within_week` | `week` + `entry` | Sí | Mover una `Entry` dentro de la misma `Week` | Resecuencia `order_index` densa `1..N` |
 | `Entry.update` | `entry` | Sí | Amplio (campos funcionales de `Entry`) | Contrato detallado en `#12`; no cambia de `Week` aquí |
 | `Week.update_notes` | `week` | Sí | Weeks abiertas o cerradas | Editabilidad de contenido amplia |
-| `Week.reopen` | `week` + `campaign` | Sí | `closed -> open` | Recalcula `week_cursor` |
-| `Week.reclose` | `week` + `campaign` | Sí | `open -> closed` | Recalcula `week_cursor` |
+| `Week.reopen` | `week` + `campaign` | Sí | `closed -> open` | Recalcula la semana actual derivada |
+| `Week.reclose` | `week` + `campaign` | Sí | `open -> closed` | Recalcula la semana actual derivada |
 | `Session.manual_create` | `session` + `campaign` | Sí | Histórica o activa | Preserva `0..1` sesión activa global |
 | `Session.manual_update` | `session` + `campaign` | Sí | Corrección de timestamps y estado | Preserva `0..1` sesión activa global |
 | `Session.manual_delete` | `session` + `campaign` | Sí | Borrado real | Preserva `0..1` sesión activa global |
@@ -132,21 +132,25 @@ No incluye:
    contrato de pre/postcondiciones/rechazos en `#12` (parcheado por supersesión
    parcial de recursos).
 
-## Reglas de estado y cursor (`Week.status`, `week_cursor`)
+## Reglas de estado y semana actual derivada (`Week.status`, concepto derivado)
 
-### Política global de `week_cursor`
+### Política global de semana actual derivada
 
-1. `campaign.week_cursor` apunta a la **primera `Week` abierta**, definida como
-   la `Week` abierta con **menor `week_number`** entre las weeks provisionadas.
+1. La **semana actual** del MVP se define como la **primera `Week` abierta**,
+   es decir, la `Week` abierta con **menor `week_number`** entre las weeks
+   provisionadas.
 1. Navegar o seleccionar una `Week` para foco/edición no cambia automáticamente
-   `week_cursor`.
-1. `week_cursor` pasa a ser un valor derivado de la estructura de weeks abiertas
-   y sus estados, en lugar de una selección manual libre.
+   la semana actual derivada.
+1. La semana actual se trata como un valor derivado de la estructura de weeks
+   abiertas y sus estados, en lugar de una selección manual libre.
+1. **Nota de transición (`#76`)**: la implementación actual todavía
+   persiste/consume `campaign.week_cursor` en código como mecanismo transitorio;
+   la migración técnica para retirarlo se sigue en `#81`.
 
 ### Reglas de recálculo
 
-`week_cursor` se recalcula tras operaciones que puedan cambiar la primera week
-abierta:
+La semana actual derivada se recalcula tras operaciones que puedan cambiar la
+primera week abierta:
 
 - `Week.close`
 - `Week.reopen`
@@ -163,10 +167,10 @@ abierta:
    - `docs/campaign-temporal-initialization.md`
    - `#12` (contrato por agregado)
 
-### Invariante de existencia de week abierta (soporte del cursor)
+### Invariante de existencia de week abierta (soporte de la semana actual)
 
 1. Debe existir al menos una `Week` abierta provisionada para mantener
-   `week_cursor` como entero válido.
+   una semana actual derivada válida.
 1. Si una operación (`Week.close`/`Week.reclose`) dejara **0 weeks abiertas**,
    la operación se rechaza.
 
@@ -211,7 +215,7 @@ abierta:
   - se permiten `reopen` y `reclose`.
 - Se amplía la mutabilidad de `Session`:
   - correcciones manuales completas (crear/editar/borrar).
-- Se redefine `week_cursor`:
+- Se redefine la semana actual:
   - pasa a ser la primera `Week` abierta (menor `week_number` abierta).
 
 ## Impacto sobre conflictos y contratos downstream
@@ -251,10 +255,10 @@ abierta:
    - No hay movimiento entre weeks.
 1. **Reabrir una `Week` cerrada**
    - `Week.status` cambia a `open`.
-   - `week_cursor` se recalcula a la primera week abierta.
+   - la semana actual derivada se recalcula a la primera week abierta.
 1. **Re-cerrar una `Week` reabierta**
    - `Week.status` vuelve a `closed`.
-   - `week_cursor` se recalcula con la misma regla global.
+   - la semana actual derivada se recalcula con la misma regla global.
 1. **Corrección manual completa de `Session`**
    - Se permiten create/edit/delete con timestamps.
    - No se rompe la invariante `0..1` sesión activa global.
@@ -270,7 +274,7 @@ abierta:
 - Riesgo de ampliar demasiado el alcance de `#12` si no se separa claramente
   esta decisión de dominio del contrato Firestore.
 - Riesgo de contradicción temporal si no se alinean `#9`, `#13` y esta decisión
-  respecto a `week_cursor`.
+  respecto a la semana actual derivada (históricamente `week_cursor`).
 - Riesgo de aumentar edge cases concurrentes; se asume mitigación mediante la
   política de rechazo ya vigente en `#8`.
 

--- a/docs/firestore-operation-contract.md
+++ b/docs/firestore-operation-contract.md
@@ -56,8 +56,13 @@ No incluye:
    - `refrescar + reintentar` para conflictos concurrentes;
    - error local (sin refresh por defecto) para transiciones inválidas;
    - corrección de datos/entrada para rechazos de validación.
-1. `week_cursor` se expresa como **postcondición derivada** en operaciones que
-   cambian estado de `Week` o estructura temporal.
+1. La **semana actual derivada** (primera `Week` abierta) se expresa como
+   **postcondición derivada** en operaciones que cambian estado de `Week` o
+   estructura temporal.
+1. **Nota de transición (`#76`)**: la implementación actual todavía persiste/
+   consume `campaign.week_cursor` como mecanismo técnico transitorio; este
+   documento lo trata como detalle de implementación a retirar en `#81`, no
+   como contrato canónico.
 1. `Session` no usa un campo `state`; una sesión activa se define por
    `ended_at_utc = null`.
 1. Ownership de `Session` se deriva de la ruta; no se redefine por campos.
@@ -101,11 +106,11 @@ No incluye:
 
 | operation_id | agregado_principal | agregados_afectados | tipo | disparador | estado_mvp | dependencias_documentales | notas |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `Campaign.provision_initial_years` | `campaign` | `campaign`, `year`, `season`, `week` | `compuesta` | creación/provisión inicial de campaña | `activa` | `#9`, `#13`, `#37` | `week_cursor` derivado como postcondición |
+| `Campaign.provision_initial_years` | `campaign` | `campaign`, `year`, `season`, `week` | `compuesta` | creación/provisión inicial de campaña | `activa` | `#9`, `#13`, `#37` | semana actual derivada como postcondición |
 | `Campaign.extend_years_plus_one` | `campaign` | `campaign`, `year`, `season`, `week` | `compuesta` | acción `+` de año (UI) | `activa` | `#9`, `#13`, `#37` | crea 1 año completo; cursor derivado |
 | `Campaign.set_week_cursor_manual` | `campaign` | `campaign` | `simple` | ajuste manual (semántica histórica) | `excluida` | `#9`, `#37` | semántica sustituida en MVP |
 | `Week.close` | `week` | `week`, `campaign`, `session` | `compuesta` | cierre normal de semana | `activa` | `#8`, `#37` | auto-stop si hay sesión activa |
-| `Week.reopen` | `week` | `week`, `campaign` | `compuesta` | corrección manual de estado | `activa` | `#8`, `#37` | recálculo de `week_cursor` |
+| `Week.reopen` | `week` | `week`, `campaign` | `compuesta` | corrección manual de estado | `activa` | `#8`, `#37` | recálculo de semana actual derivada |
 | `Week.reclose` | `week` | `week`, `campaign`, `session` | `compuesta` | corrección manual de estado | `activa` | `#8`, `#37` | auto-stop si hay sesión activa |
 | `Week.update_notes` | `week` | `week` | `simple` | edición de notas | `activa` | `#8`, `#37` | permitido en `open|closed` |
 | `Entry.create` | `entry` | `entry`, `week` | `compuesta` | creación manual de entry | `activa` | `#37`, glosario | auto-normaliza `order_index` si detecta secuencia inconsistente |
@@ -126,10 +131,10 @@ No incluye:
 
 | operation_id | precondiciones_dominio | precondiciones_conflicto | validaciones | postcondiciones | rechazos_esperados | categoria_rechazo | atomicidad_esperada_comportamiento | respuesta_cliente_recomendada | notas_de_implementación |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `Campaign.provision_initial_years` | campaña existe y está provisionable | base de campaña no obsoleta | crea 4 años; `summer->winter`; 10 semanas/estación; no duplicados (`year/season/week`) | estructura temporal inicial completa; `week_cursor` apunta a primera week abierta | duplicados, base obsoleta | `validacion` / `conflicto` | todo el bloque temporal se crea o falla completo | `refrescar + reintentar` si conflicto; error local si duplicado/estado inválido | no fija técnica Firestore |
-| `Campaign.extend_years_plus_one` | campaña ya provisionada; último año identificable | base de campaña/estructura temporal no obsoleta | crea exactamente 1 año; continuidad `year_number` y `week_number`; no duplicados | nuevo año completo añadido; `week_cursor` derivado válido | duplicados; continuidad inválida; base obsoleta | `validacion` / `conflicto` | se añade el año completo o falla completo | `refrescar + reintentar` si conflicto; error local si estructura inválida | disparo UI desde `+` de año |
-| `Week.close` | week existe; transición `open -> closed`; week abierta provisionada no quedará en 0 tras operación | base de `week.status` y sesión activa relevante no obsoletas | si hay sesión activa en la week, ejecutar `Session.auto_stop`; validar recálculo de `week_cursor` | week queda `closed`; sesión activa de esa week queda cerrada si existía; `week_cursor` recalculado | transición ya cerrada; dejaría 0 weeks abiertas; base obsoleta | `transicion_invalida` / `validacion` / `conflicto` | auto-stop + cierre + recálculo se consideran una sola operación lógica | error local (transición/validación); `refrescar + reintentar` si conflicto | `closed` no bloquea mutaciones por sí mismo |
-| `Week.reopen` | week existe; transición `closed -> open` | base de `week.status` no obsoleta | transición válida; recálculo de `week_cursor` | week queda `open`; `week_cursor` recalculado | transición ya abierta; base obsoleta | `transicion_invalida` / `conflicto` | cambio de estado + recálculo como operación lógica única | error local si transición inválida; `refrescar + reintentar` si conflicto | corrección manual explícita |
+| `Campaign.provision_initial_years` | campaña existe y está provisionable | base de campaña no obsoleta | crea 4 años; `summer->winter`; 10 semanas/estación; no duplicados (`year/season/week`) | estructura temporal inicial completa; semana actual derivada apunta a primera week abierta | duplicados, base obsoleta | `validacion` / `conflicto` | todo el bloque temporal se crea o falla completo | `refrescar + reintentar` si conflicto; error local si duplicado/estado inválido | no fija técnica Firestore |
+| `Campaign.extend_years_plus_one` | campaña ya provisionada; último año identificable | base de campaña/estructura temporal no obsoleta | crea exactamente 1 año; continuidad `year_number` y `week_number`; no duplicados | nuevo año completo añadido; semana actual derivada válida | duplicados; continuidad inválida; base obsoleta | `validacion` / `conflicto` | se añade el año completo o falla completo | `refrescar + reintentar` si conflicto; error local si estructura inválida | disparo UI desde `+` de año |
+| `Week.close` | week existe; transición `open -> closed`; week abierta provisionada no quedará en 0 tras operación | base de `week.status` y sesión activa relevante no obsoletas | si hay sesión activa en la week, ejecutar `Session.auto_stop`; validar recálculo de la semana actual derivada | week queda `closed`; sesión activa de esa week queda cerrada si existía; semana actual derivada recalculada | transición ya cerrada; dejaría 0 weeks abiertas; base obsoleta | `transicion_invalida` / `validacion` / `conflicto` | auto-stop + cierre + recálculo se consideran una sola operación lógica | error local (transición/validación); `refrescar + reintentar` si conflicto | `closed` no bloquea mutaciones por sí mismo |
+| `Week.reopen` | week existe; transición `closed -> open` | base de `week.status` no obsoleta | transición válida; recálculo de la semana actual derivada | week queda `open`; semana actual derivada recalculada | transición ya abierta; base obsoleta | `transicion_invalida` / `conflicto` | cambio de estado + recálculo como operación lógica única | error local si transición inválida; `refrescar + reintentar` si conflicto | corrección manual explícita |
 | `Week.reclose` | week existe; transición `open -> closed`; no dejar 0 weeks abiertas | base de `week.status` y sesión activa relevante no obsoletas | si hay sesión activa en la week, `auto-stop`; validar recálculo de cursor | week queda `closed`; cursor derivado válido | transición ya cerrada; dejaría 0 weeks abiertas; base obsoleta | `transicion_invalida` / `validacion` / `conflicto` | auto-stop + cambio de estado + recálculo como operación lógica única | error local (transición/validación); `refrescar + reintentar` si conflicto | corrección manual de estado |
 | `Week.update_notes` | week existe | base de `updated_at_utc`/versión no obsoleta | edición de texto válida; permitido en `open|closed` | `notes` actualizadas | base obsoleta; payload inválido | `conflicto` / `validacion` | una actualización simple | `refrescar + reingresar cambios` si conflicto; error local si payload inválido | sin LWW |
 | `Entry.create` | week existe; ownership por ruta válido | base de orden (`entries` de la week) no obsoleta para inserción | `Entry.type` válido; `scenario_ref` obligatorio si `scenario`; si secuencia `order_index` inconsistente, auto-normalizar denso `1..N` antes/asociado a inserción | nueva entry creada con `order_index` válido y secuencia consistente | payload inválido; week inexistente; base obsoleta no resoluble | `validacion` / `conflicto` | normalización de orden + creación forman operación lógica única | error local si payload inválido; `refrescar + reintentar` si conflicto | permitido en week `open|closed` |
@@ -154,7 +159,7 @@ batch o combinación de mecanismos Firestore.
 Operaciones compuestas mínimas:
 
 1. `Session.start` con `auto-stop` previo cuando ya existe sesión activa.
-1. `Week.close` / `Week.reclose` con `auto-stop` + recálculo de `week_cursor`.
+1. `Week.close` / `Week.reclose` con `auto-stop` + recálculo de la semana actual derivada.
 1. `Entry.delete` activa con `auto-stop` + borrado de `sessions` (y eliminación
    implícita de `resource_deltas` al borrar la `Entry`).
 1. `Entry.create` con auto-normalización de `order_index` cuando la secuencia de
@@ -162,21 +167,21 @@ Operaciones compuestas mínimas:
 1. `Entry.adjust_resource_delta`, `Entry.set_resource_delta` y
    `Entry.clear_resource_delta` con recálculo de `campaign.resource_totals`.
 1. `Campaign.provision_initial_years` y `Campaign.extend_years_plus_one` con
-   estructura temporal completa + cursor derivado válido.
+   estructura temporal completa + semana actual derivada válida.
 
 ## Alineación temporal con #13
 
 | operacion | insumo_#13 | insumo_#37 | regla_en_#12 | no_definido_en_#12 | riesgo_si_se_viola |
 | --- | --- | --- | --- | --- | --- |
-| `Campaign.provision_initial_years` | 4 años iniciales, `summer->winter`, 10 semanas/estación, `week_number` correlativo | cursor derivado; no dejar 0 abiertas | creación completa con duplicados rechazados y cursor derivado válido | técnica Firestore | estructura temporal inconsistente / cursor inválido |
-| `Campaign.extend_years_plus_one` | +1 año, continuidad `year_number`/`week_number` | cursor derivado | extensión exacta de 1 año; sin reprovisión; sin duplicados | técnica Firestore | numeración rota o duplicados |
-| `Week.close/reopen/reclose` | coherencia `week_number`/jerarquía | recálculo de cursor; transición manual | cambio de estado + postcondición de `week_cursor` | timestamp/desempate | cursor incoherente o estado inválido |
+| `Campaign.provision_initial_years` | 4 años iniciales, `summer->winter`, 10 semanas/estación, `week_number` correlativo | semana actual derivada; no dejar 0 abiertas | creación completa con duplicados rechazados y semana actual derivada válida | técnica Firestore | estructura temporal inconsistente / semana actual inválida |
+| `Campaign.extend_years_plus_one` | +1 año, continuidad `year_number`/`week_number` | semana actual derivada | extensión exacta de 1 año; sin reprovisión; sin duplicados | técnica Firestore | numeración rota o duplicados |
+| `Week.close/reopen/reclose` | coherencia `week_number`/jerarquía | recálculo de semana actual derivada; transición manual | cambio de estado + postcondición de semana actual derivada | timestamp/desempate | semana actual incoherente o estado inválido |
 | `Entry`/`Session` (incluyendo `Entry.resource_deltas`) sobre weeks históricas | weeks siguen existiendo y `week_number` no cambia | editabilidad amplia en `open|closed` | operaciones permitidas en weeks `closed` salvo validación específica | política UI | bloqueos artificiales o contradicción con `#37` |
 
 ## Alineación de editabilidad e invariantes con #37
 
 1. `Campaign.set_week_cursor_manual` se documenta como exclusión activa del MVP.
-1. `week_cursor` es derivado (postcondición) y nunca selección manual libre.
+1. La semana actual derivada (históricamente implementada como `week_cursor`) es postcondición y nunca selección manual libre.
 1. `Week.status=closed` es marcador informativo; no bloquea por sí mismo
    mutaciones de `Entry` (incluyendo `resource_deltas`) ni `Session`.
 1. `Entry.reorder_within_week` está limitado a la misma `Week` y resecuencia
@@ -210,8 +215,8 @@ Operaciones compuestas mínimas:
 
 1. `Campaign.extend_years_plus_one` crea exactamente 1 año y mantiene
    continuidad temporal de `#13`.
-1. `Week.close` con sesión activa define `auto-stop + cerrar` y recálculo de
-   `week_cursor` como operación compuesta.
+1. `Week.close` con sesión activa define `auto-stop + cerrar` y recálculo de la
+   semana actual derivada como operación compuesta.
 1. `Week.close` sobre week ya `closed` se clasifica como `transicion_invalida`
    con error local.
 1. `Week.reclose` rechaza operaciones que dejen `0` weeks abiertas.

--- a/docs/minimal-read-queries.md
+++ b/docs/minimal-read-queries.md
@@ -79,7 +79,7 @@ No incluye:
 1. Las sesiones de una `Entry` se cargan al **seleccionar la `Entry`**.
 1. No hay paginación en el MVP para years/weeks/entries/sesiones.
 1. Estado inicial de pantalla:
-   - barra superior en el año de `current week` (`week_cursor` derivado);
+  - barra superior en el año de `current week` (semana actual derivada);
    - sin `Week` seleccionada;
    - sin `Entry` seleccionada;
    - sin bloque de `Entry` visible.
@@ -91,7 +91,7 @@ No incluye:
 | `surface_id` | `descripcion` | `visible_en_estado` | `datos_necesarios` | `notas` |
 | --- | --- | --- | --- | --- |
 | `top_year_selector` | Barra superior con año actual seleccionado, navegación prev/next y `+` de extensión | Todos | años provisionados, año seleccionado, condición de último año | `+` depende del último año provisionado (`#9`) |
-| `top_week_selector` | Tira de semanas del año seleccionado (navegación/foco temporal) | Todos | weeks del año seleccionado (`week_number`, `status`), marcador `current week` | Seleccionar week no cambia `week_cursor` (`#9`) |
+| `top_week_selector` | Tira de semanas del año seleccionado (navegación/foco temporal) | Todos | weeks del año seleccionado (`week_number`, `status`), marcador `current week` (semana actual derivada) | Seleccionar week no cambia la semana actual derivada (`#9`) |
 | `top_entry_selector_tabs` | Selector de `Entry` de la week seleccionada (tabs) | `week_selected_no_entry`, `entry_selected_*` | entries de la week seleccionada ordenadas | Puede mostrar estado vacío/acción de creación si no hay entries |
 | `focus_panel_week_state` | Panel central en modo `Week` (semana seleccionada, notas, estado) | `week_selected_no_entry` | `Week` seleccionada (`status`, `notes`) | Consume datos ya presentes en lecturas de weeks |
 | `focus_panel_entry_state` | Panel central en modo `Entry` (datos de entry, recursos, bloque sesión) | `entry_selected_*` | `Entry` seleccionada + sesiones de esa entry | `total jugado` y desplegable de sesiones dependen de lectura de `sessions` |
@@ -112,7 +112,7 @@ Estados de pantalla del MVP (canon para lecturas):
 
 | `query_id` | `superficies_que_alimenta` | `path_o_scope` | `filtros` | `query_order_prefix` | `client_canonical_order` (ref `#18`) | `trigger_de_carga` | `trigger_de_refresh` | `paginacion_mvp` | `notas` |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `Q1 campaign_main_doc` | `top_week_selector`, `bottom_totals_bar`, `active_session_indicator_summary` | `campaigns/01` (doc) | N/A | N/A | N/A | abrir pantalla | refresh manual; post-escrituras que cambian `campaign` | No aplica | Fuente de `week_cursor` y `resource_totals` |
+| `Q1 campaign_main_doc` | `bottom_totals_bar`, `active_session_indicator_summary` (+ transición temporal) | `campaigns/01` (doc) | N/A | N/A | N/A | abrir pantalla | refresh manual; post-escrituras que cambian `campaign` | No aplica | Canónico: `resource_totals`; transición: implementación actual aún usa `week_cursor` |
 | `Q2 years_list` | `top_year_selector` | `campaigns/01/years` | N/A | `year_number ASC` | `(year_number ASC)` | abrir pantalla | refresh manual; extensión `+1` año | No | Volumen bajo |
 | `Q3 weeks_selected_year_summer` | `top_week_selector`, `focus_panel_week_state` | `.../years/{selected_year}/seasons/summer/weeks` | N/A | `week_number ASC` | `(week_number ASC)` | abrir pantalla (año inicial); cambio de año | refresh manual; cambios de `Week` del año visible; provisión/extensión que afecte año visible | No | 10 weeks por estación |
 | `Q4 weeks_selected_year_winter` | `top_week_selector`, `focus_panel_week_state` | `.../years/{selected_year}/seasons/winter/weeks` | N/A | `week_number ASC` | `(week_number ASC)` | abrir pantalla (año inicial); cambio de año | refresh manual; cambios de `Week` del año visible; provisión/extensión que afecte año visible | No | Se fusiona en cliente con Q3 por `week_number` |
@@ -126,13 +126,13 @@ Estados de pantalla del MVP (canon para lecturas):
 #### Q1 — `campaign_main_doc`
 
 - **Campos lógicos mínimos**:
-  - `week_cursor`
   - `resource_totals`
   - `updated_at_utc` (y `created_at_utc` opcional técnico)
 - **Uso**:
-  - marcador `current week` (vía `week_cursor`)
   - barra de totales
   - estado general persistido de campaña
+  - **transición**: la implementación actual todavía puede leer `week_cursor`
+    hasta la migración del modelo temporal (`#76` -> `#81`)
 
 #### Q2 — `years_list`
 
@@ -209,7 +209,7 @@ Estados de pantalla del MVP (canon para lecturas):
 
 | `query_id` | `entity` | `campos_minimos_logicos` | `campos_para_orden` | `campos_para_render` | `campos_para_estado` | `notas` |
 | --- | --- | --- | --- | --- | --- | --- |
-| `Q1 campaign_main_doc` | `campaign` | `week_cursor`, `resource_totals`, `updated_at_utc` | N/A | `resource_totals`, `week_cursor` | `week_cursor`, `updated_at_utc` | `created_at_utc` opcional técnico |
+| `Q1 campaign_main_doc` | `campaign` | `resource_totals`, `updated_at_utc` | N/A | `resource_totals` | `updated_at_utc` | `week_cursor` solo en implementación transitoria previa a `#81` |
 | `Q2 years_list` | `year` | `year_number` | `year_number` | `year_number` | `updated_at_utc` opcional | Auditoría no es primaria de UI |
 | `Q3 weeks_selected_year_summer` | `week` | `week_number`, `status`, `notes` | `week_number` | `week_number`, `status`, `notes` | `status`, `updated_at_utc` | Parte `summer` del año |
 | `Q4 weeks_selected_year_winter` | `week` | `week_number`, `status`, `notes` | `week_number` | `week_number`, `status`, `notes` | `status`, `updated_at_utc` | Parte `winter` del año |
@@ -237,7 +237,7 @@ Estados de pantalla del MVP (canon para lecturas):
 
 ### Estado inicial de pantalla (decisión cerrada)
 
-- `selected_year` inicial = año de `current week` (`week_cursor` derivado)
+- `selected_year` inicial = año de `current week` (semana actual derivada)
 - `selected_week` inicial = `none`
 - `selected_entry` inicial = `none`
 
@@ -258,12 +258,12 @@ Notas de implementación posteriores (`#53+`):
 
 | `evento_ui_o_operacion` | `queries_a_refrescar` | `motivo` | `requiere_refresh_manual` | `notas` |
 | --- | --- | --- | --- | --- |
-| `open_main_screen` | Q1, Q2, Q3, Q4, Q6 | Estado inicial mínimo visible | No | Año inicial derivado de `week_cursor` |
+| `open_main_screen` | Q1, Q2, Q3, Q4, Q6 | Estado inicial mínimo visible | No | Año inicial derivado de la semana actual (transición: hoy puede venir de `week_cursor`) |
 | `ui.manual_refresh` | Q1, Q2, Q3, Q4, Q6 + (Q5/Q7/Q8 si hay selección/activa aplicable) | `on-demand refresh` global del contexto visible | Sí (trigger del usuario) | Sin listeners realtime (`#7`) |
 | `ui.select_year` | Q3, Q4 (resetea navegación de `Week`) | Cambia el conjunto de weeks visibles | No | Puede mantenerse una entry en visor sticky; Q5/Q8 no cargan hasta nueva selección de entry |
-| `ui.select_week` | Q5 | Cargar entries de la week seleccionada | No | No cambia `week_cursor` ni obliga a limpiar la entry en visor sticky |
+| `ui.select_week` | Q5 | Cargar entries de la week seleccionada | No | No cambia la semana actual derivada ni obliga a limpiar la entry en visor sticky |
 | `ui.select_entry` | Q8 (+ Q7 solo si sigue activo global en otra entry y la UI lo necesita) | Cargar sesiones de la entry seleccionada para el visor | No | Q5 ya aporta datos base de la entry |
-| `Week.close/reopen/reclose/update_notes` | Q1 (si cambia `week_cursor`), Q3/Q4 (año visible), Q6 (si hubo `auto-stop`) | Reflejar estado de week, cursor y sesión activa | No (post-escritura local) | Si la week afectada no está en año visible, Q3/Q4 puede diferirse a refresh manual |
+| `Week.close/reopen/reclose/update_notes` | Q1 (si cambia estado de campaña / transición temporal), Q3/Q4 (año visible), Q6 (si hubo `auto-stop`) | Reflejar estado de week, semana actual derivada y sesión activa | No (post-escritura local) | Si la week afectada no está en año visible, Q3/Q4 puede diferirse a refresh manual |
 | `Campaign.extend_years_plus_one` | Q1, Q2, Q3/Q4 si el año visible queda afectado | Reflejar nuevo año / estado de campaña | No (post-escritura local) | `+` vive en selector de año (`#9`) |
 | `Entry.create/update/delete/reorder` sobre `selected_week` | Q5 (+ Q8 si afecta la entry en visor) | Actualizar tabs/lista y panel de entry | No (post-escritura local) | `Entry.delete` puede requerir también Q6 si había activa |
 | `Entry.adjust/set/clear_resource_delta` sobre la entry en visor | Q1, Q5 | Totales globales + `resource_deltas` de entry | No (post-escritura local) | Reglas de recursos en `#15` |

--- a/docs/mvp-implementation-blocks.md
+++ b/docs/mvp-implementation-blocks.md
@@ -127,7 +127,7 @@ No incluye:
 | --- | --- | --- | --- | --- | --- | --- |
 | `I12-S1` | Inventariar operaciones por agregado (`campaign`, `week`, `entry` incl. `resource_deltas`, `session`) y casos de uso | `Codex` | `#7`, `#8`, `#9`, `#37` | Tabla de operaciones por agregado | Inventario completo y sin solapes obvios con mutabilidad vigente | `draftable` |
 | `I12-S2` | Definir contrato por agregado (precondiciones, postcondiciones, validaciones, rechazo por conflicto/transición inválida, atomicidad esperada) | `Codex` | `I12-S1` | Tabla de contrato por agregado | Cada agregado tiene contrato explícito y coherente con `#8` y `#37` | `draftable` |
-| `I12-S3` | Alinear operaciones temporales y de cursor con `#13` y `#37` (provisión/extensión/`week_cursor` derivado) | `Codex+Kiko` | `I12-S2`, `#13`, `#37` | Nota/tabla de alineación `#12` ↔ (`#13`, `#37`) | No quedan contradicciones con flujo temporal ni editabilidad | `draftable` |
+| `I12-S3` | Alinear operaciones temporales y semántica de semana actual con `#13` y `#37` (provisión/extensión/semana actual derivada; hist. `week_cursor`) | `Codex+Kiko` | `I12-S2`, `#13`, `#37` | Nota/tabla de alineación `#12` ↔ (`#13`, `#37`) | No quedan contradicciones con flujo temporal ni editabilidad | `draftable` |
 | `I12-S4` | Cerrar la decisión (revisión interactiva, trazabilidad y referencias) | `Codex+Kiko` | `I12-S3` | Documento final + registro de decisión | Aprobación explícita de Kiko y PR mergeada | `draftable` |
 
 #### Riesgos y bloqueos
@@ -199,22 +199,31 @@ No incluye:
 | --- | --- | --- | --- | --- | --- | --- |
 | `I37-S1` | Definir matriz de operaciones manuales permitidas (editabilidad "como papel") y límites | `Codex+Kiko` | `#8`, `#9`, `docs/domain-glossary.md` | Matriz de mutabilidad por agregado | Quedan cerradas operaciones manuales permitidas y su alcance MVP | `ready` |
 | `I37-S2` | Formalizar reglas de `Entry.reorder`, `Week.reopen/reclose` y correcciones manuales de `Session` | `Codex+Kiko` | `I37-S1` | Reglas por agregado e invariantes | No quedan ambigüedades funcionales sobre mutabilidad de orden/estado/sesiones | `ready` |
-| `I37-S3` | Redefinir semántica de `week_cursor` (primera `Week` abierta) y su recálculo | `Codex+Kiko` | `I37-S2`, `#13` | Reglas de cursor y alineación temporal | `week_cursor` queda coherente con temporalidad y editabilidad | `ready` |
+| `I37-S3` | Redefinir semántica de semana actual derivada (hist. `week_cursor`) y su recálculo | `Codex+Kiko` | `I37-S2`, `#13` | Reglas de semana actual y alineación temporal | La semana actual derivada queda coherente con temporalidad y editabilidad | `ready` |
 | `I37-S4` | Actualizar trazabilidad (`glossary`, conflictos, checklist/bloques) y cerrar decisión | `Codex+Kiko` | `I37-S3` | Documento final + referencias + registro de decisión | Aprobación explícita de Kiko y PR mergeada | `ready` |
 
 #### Riesgos y bloqueos
 
 - Riesgo de dejar `#12` parcialmente redactada con invariantes viejas si `#37`
   no se cierra antes.
-- Riesgo de contradicción entre semántica de `week_cursor` en temporal (#9/#13)
+- Riesgo de contradicción entre semántica de semana actual derivada (hist.
+  `week_cursor`) en temporal (#9/#13)
   y mutabilidad de estado si no se alinea explícitamente.
 
 #### Criterio de cierre de la issue
 
 - Existe una decisión marco de editabilidad manual del MVP ("como papel") que
   fija reordenación manual de `Entry` (intra-`Week`), `Week.reopen/reclose`,
-  correcciones manuales completas de `Session` y `week_cursor` como primera
-  `Week` abierta, con trazabilidad a `#12/#14/#15/#17/#19`.
+  correcciones manuales completas de `Session` y semana actual derivada (hist.
+  `week_cursor`) como primera `Week` abierta, con trazabilidad a
+  `#12/#14/#15/#17/#19`.
+
+#### Nota de transición temporal (`#76`)
+
+- Las referencias históricas a `week_cursor` en este documento se reinterpretan
+  como **semana actual derivada** (primera `Week` abierta).
+- La migración técnica para retirar la dependencia de `campaign.week_cursor` del
+  código y contratos residuales queda trazada en `#81`.
 
 #### Notas de secuencia / paralelización
 

--- a/docs/mvp-implementation-checklist.md
+++ b/docs/mvp-implementation-checklist.md
@@ -45,7 +45,7 @@ este checklist:
 - **Controles temporales de campaña** (Issue #9):
   `docs/campaign-temporal-controls.md`
   - selector temporal superior, provisión inicial de 4 años, extensión manual
-    `+1`, separación entre navegación de semana y `week_cursor`.
+    `+1`, separación entre navegación de semana y semana actual derivada.
 - **Inicialización temporal de campaña (técnica)** (Issue #13):
   `docs/campaign-temporal-initialization.md`
   - estructura temporal fija del MVP (`summer -> winter`, 10 semanas por
@@ -54,7 +54,10 @@ este checklist:
   `docs/editability-policy.md`
   - editabilidad amplia ("como papel"), reordenación manual de `Entry`,
     `Week.reopen/reclose`, correcciones manuales de `Session` y semántica
-    derivada de `week_cursor`.
+    derivada de la semana actual.
+  - Nota de transición (`#76` -> `#81`): referencias históricas a
+    `week_cursor` en este checklist deben interpretarse como **semana actual
+    derivada** (primera `Week` abierta) hasta completar la migración técnica.
 - **Modelo de recursos por `Entry` (delta neto)** (Issue #40):
   `docs/resource-delta-model.md`
   - `ResourceChange` se sustituye por `Entry.resource_deltas` (delta neto por


### PR DESCRIPTION
## Resumen

Reencuadra el modelo temporal canónico del MVP para usar **semana actual derivada** (primera week abierta) como concepto vigente, dejando `campaign.week_cursor` como detalle técnico transitorio hasta la migración de implementación.

## Qué incluye

- Reencuadre documental de `#76` (decisión + docs + trazabilidad)
- Nueva decisión `DEC-0034`
- Alineación de docs núcleo y notas de transición (`#76` -> `#81`)
- Hito `H1-03` en `docs/context-governance.md`
- Trazabilidad histórica en `#70` (bloqueo temporal superseded/reinterpretado)

## Alcance / no alcance

- No hay cambios en `src/`
- No se migra implementación ni datos en esta PR
- La migración técnica queda trazada en `#81`

Closes #76
Refs #81
Refs #70