### PR TITLE
docs: reorientar a desarrollo-first y añadir guía rápida de arranque

### DIFF
--- a/docs/context-governance.md
+++ b/docs/context-governance.md
@@ -6,8 +6,8 @@
 - `purpose`: Gobierno de contexto, gate de calidad y estado verificable.
 - `status`: active
 - `source_of_truth`: official
-- `last_updated`: 2026-02-24
-- `next_review`: 2026-03-10
+- `last_updated`: 2026-02-26
+- `next_review`: 2026-03-12
 
 ## Alcance de Fase 0
 
@@ -168,6 +168,26 @@ Se valida:
   - Desktop pequeño (`800x600`) preservado sin compactación accidental tras ajustar la heurística responsiva.
   - `portrait` queda fuera de alcance explícito de la unidad.
 
+
+
+### Hito H1-05
+
+- Fecha: 2026-02-26
+- Objetivo: reorientar la ejecución a desarrollo acelerado de la app (UI + funcionalidades) con contexto ligero reutilizable.
+- Resultado: aprobado
+- Verificación A: aprobado (nueva guía reusable publicada y trazada en mapa del sistema)
+- Verificación B: aprobado (decisión registrada y backlog de implementación actualizado con próximas issues)
+- Evidencia:
+  - `learning/personal-context-engineering-quickstart.md`
+  - `docs/system-map.md`
+  - `docs/decision-log.md` (DEC-0035)
+  - `docs/mvp-implementation-checklist.md` (nuevas issues pendientes post-#20)
+- Resumen:
+  - Se adopta modo `development_first_light_context`.
+  - La documentación pasa a criterio de soporte a implementación, no de protagonismo.
+  - Se mantiene trazabilidad mínima profesional (issue/commit/PR) para cambios no triviales.
+
+
 ## Conocimiento migrado desde legado
 
 - `important.txt`
@@ -192,8 +212,7 @@ Se valida:
 
 ## Estado actual de fase
 
-- Estado: implementation_enabled
+- Estado: development_first_light_context
 - Criterio de aceptación de Fase 0: cubierto a nivel documental y gate `#20`
   validado.
-- Siguiente paso: iniciar implementación (slice recomendado de
-  infraestructura/base app).
+- Siguiente paso: ejecutar la siguiente issue funcional prioritaria de UI/lecturas y completar el backlog corto de implementación.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -6,8 +6,8 @@
 - `purpose`: Registrar decisiones con trazabilidad y precedencia.
 - `status`: active
 - `source_of_truth`: official
-- `last_updated`: 2026-02-24
-- `next_review`: 2026-03-10
+- `last_updated`: 2026-02-26
+- `next_review`: 2026-03-12
 
 ## Formato canónico por entrada
 
@@ -791,3 +791,14 @@
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/70`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/19`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`
+
+
+### DEC-0035
+
+- `date`: 2026-02-26
+- `status`: accepted
+- `problem`: tras completar la fase fuerte de preparación de contexto, el ritmo de implementación funcional de la app quedó por debajo del objetivo personal del proyecto (uso propio y avance visible de UI/funcionalidades).
+- `decision`: cambiar el modo operativo a **desarrollo-first**: priorizar cierre de UI y funcionalidades pendientes, manteniendo documentación, issues y PR con nivel ligero y orientado a ejecución. Este cambio no elimina trazabilidad; la hace proporcional al impacto real.
+- `rationale`: maximiza valor práctico del proyecto, reduce sobrecarga documental y mantiene aprendizaje aplicable sin frenar entrega de producto.
+- `impact`: se incorpora una guía reusable de arranque de proyectos personales con ingeniería de contexto ligera; se actualiza el estado de fase para priorizar implementación acelerada; y se crea backlog inmediato de issues de desarrollo, incluyendo una de simplificación de código.
+- `references`: `AGENTS.md`, `docs/context-governance.md`, `docs/mvp-implementation-checklist.md`, `learning/personal-context-engineering-quickstart.md`

--- a/docs/mvp-implementation-checklist.md
+++ b/docs/mvp-implementation-checklist.md
@@ -241,6 +241,29 @@ Usar esta plantilla mínima en cada issue/bloque del checklist:
 - [x] Estado local de selección/navegación + visor sticky + activo mock (Issue #53)
 - [ ] Integrar lecturas mínimas read-only para arranque y navegación base (Issue #54)
 
+### Próximas issues pendientes (foco desarrollo rápido)
+
+- [ ] Issue #82 — Finalizar flujo de selección temporal y navegación semanal completa en UI (incluye estados vacíos/semana cerrada y feedback visual claro).
+- [ ] Issue #83 — Conectar acciones principales del panel central (`start`, `stop`, `add session`, `delete entry`) con handlers reales y mensajes de error básicos.
+- [ ] Issue #84 — Simplificación de código UI/estado: reducir complejidad accidental en `app_root`/`main_shell_view`/placeholders, extrayendo utilidades y eliminando duplicación innecesaria.
+- [ ] Issue #85 — Mejorar robustez móvil mínima (portrait + landscape) para barra temporal y panel central con validación visual rápida.
+- [ ] Issue #86 — Cerrar vertical read/write MVP de una operación completa (crear sesión + impacto en recursos + refresco visible en pantalla principal).
+
+#### Orden recomendado inmediato
+
+1. #54
+1. #82
+1. #84
+1. #83
+1. #85
+1. #86
+
+#### Criterio de priorización
+
+- Priorizar cambios con impacto visible en UI/flujo diario de uso.
+- Mantener issues pequeñas (1–2 sesiones de trabajo).
+- Si una issue crece demasiado, dividirla antes de implementar.
+
 ## Referencias
 
 - `AGENTS.md`

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -6,8 +6,8 @@
 - `purpose`: Mapa navegable de la documentación oficial y legado temporal.
 - `status`: active
 - `source_of_truth`: official
-- `last_updated`: 2026-02-24
-- `next_review`: 2026-03-10
+- `last_updated`: 2026-02-26
+- `next_review`: 2026-03-12
 
 ## Objetivo
 
@@ -72,6 +72,8 @@ Este documento permite que una persona o agente nuevo entienda rápidamente:
   - Flujo GitHub Flow minimalista para este proyecto.
 - `learning/handbook.md`
   - Principios transferibles de ingeniería de contexto.
+- `learning/personal-context-engineering-quickstart.md`
+  - Guía práctica para iniciar proyectos personales con contexto ligero y foco en entrega.
 - `learning/frosthaven-annex.md`
   - Casos aplicados al proyecto.
 - `learning/git-workflow-handbook.md`
@@ -128,3 +130,4 @@ Este documento permite que una persona o agente nuevo entienda rápidamente:
 - Estado de fase -> `docs/context-governance.md`
 - Pasos operativos -> `docs/context-checklists.md`
 - Material reutilizable -> `learning/handbook.md`
+- Arranque rápido de proyectos personales -> `learning/personal-context-engineering-quickstart.md`

--- a/learning/personal-context-engineering-quickstart.md
+++ b/learning/personal-context-engineering-quickstart.md
@@ -1,0 +1,176 @@
+# Guía rápida: iniciar proyectos personales con ingeniería de contexto
+
+## Metadatos
+
+- `doc_id`: LEARNING-PERSONAL-CONTEXT-QUICKSTART
+- `purpose`: Tutorial práctico para arrancar proyectos personales con buena ingeniería de contexto sin frenar la ejecución del producto.
+- `status`: active
+- `source_of_truth`: official
+- `last_updated`: 2026-02-26
+- `next_review`: 2026-03-12
+
+## Objetivo
+
+Tener un sistema ligero, reutilizable y accionable para iniciar un proyecto
+personal con ayuda de IA, evitando dos extremos:
+
+- caos sin trazabilidad;
+- burocracia que bloquea el desarrollo.
+
+Esta guía resume aciertos y errores observados en este repositorio y los
+convierte en un patrón reusable.
+
+## Principios mínimos (80/20)
+
+1. **Producto primero, contexto suficiente**
+   - El contexto debe acelerar decisiones de implementación.
+   - Si un documento no ayuda a decidir o ejecutar, no se crea todavía.
+
+1. **Fuente oficial corta y clara**
+   - Define 1 archivo de reglas operativas (`AGENTS.md`) y 3–5 documentos vivos
+     en `docs/`.
+
+1. **Trazabilidad solo donde aporta**
+   - Decision log breve para decisiones transversales.
+   - Issues/PR para unidades no triviales.
+
+1. **Iteración real de UI/funcionalidad**
+   - Cada ciclo debe mover algo visible o verificable en la app.
+
+1. **Rigor proporcional**
+   - Proyecto personal: aceptar diferidos y deuda controlada si no rompe uso
+     real.
+
+## Errores frecuentes y cómo evitarlos
+
+### Error 1: sobre-documentar antes de construir
+
+- Síntoma: muchas decisiones abstractas y poca UI funcional.
+- Corrección: imponer una regla de avance: por cada unidad documental, al menos
+  una unidad de implementación o validación visual.
+
+### Error 2: no separar decisiones de detalle vs. decisiones transversales
+
+- Síntoma: discusiones largas sobre microdetalles.
+- Corrección: solo elevar a decision log lo que impacta varias áreas.
+
+### Error 3: backlog sin orden de cierre
+
+- Síntoma: muchas tareas abiertas sin secuencia clara.
+- Corrección: mantener un backlog corto (3–7 issues activas) con prioridad
+  explícita y criterio de cierre por issue.
+
+### Error 4: falta de contrato con el agente
+
+- Síntoma: respuestas inconsistentes entre sesiones.
+- Corrección: definir en `AGENTS.md` el flujo base, formato de reportes y
+  criterio de priorización.
+
+## Kit mínimo para arrancar (plantilla)
+
+Crea esta estructura inicial:
+
+- `AGENTS.md`
+- `docs/system-map.md`
+- `docs/decision-log.md`
+- `docs/repo-workflow.md`
+- `docs/product-scope.md` (alcance MVP y no-alcance)
+- `docs/implementation-backlog.md` (issues propuestas + estado)
+- `learning/` (opcional, para lecciones transferibles)
+
+## Contenido mínimo recomendado por archivo
+
+### `AGENTS.md`
+
+Incluye solo:
+
+- objetivo del proyecto;
+- reglas operativas no negociables (máx. 10);
+- flujo de sesión (inicio, ejecución, cierre);
+- regla de priorización (`siguiente paso`);
+- política de idioma y formato;
+- regla de cierre con 3–5 próximos pasos.
+
+### `docs/product-scope.md`
+
+- problema que resuelve la app;
+- usuario objetivo;
+- alcance MVP (lista cerrada);
+- no-alcance explícito;
+- criterio de “MVP usable”.
+
+### `docs/decision-log.md`
+
+Formato corto por entrada:
+
+- `decision_id`
+- `date`
+- `problem`
+- `decision`
+- `impact`
+- `references`
+
+### `docs/implementation-backlog.md`
+
+Por cada issue propuesta:
+
+- `issue_id` (temporal si aún no existe en GitHub);
+- objetivo funcional;
+- tipo (`feat`, `refactor`, `bug`, `chore`);
+- criterio de cierre (2–4 checks);
+- prioridad (`P0/P1/P2`);
+- dependencias.
+
+## Prompt base reutilizable para arrancar con IA
+
+```text
+Quiero construir una app personal priorizando entrega funcional.
+
+Contexto operativo:
+- Usa AGENTS.md como contrato principal.
+- Mantén documentación ligera y útil para implementar.
+- Si propones documentación, debe desbloquear código o validación.
+- Para trabajo no trivial, crea issue -> rama -> PR.
+
+Objetivo actual:
+- [describe aquí 1 objetivo concreto de producto]
+
+Definición de terminado:
+- [lista breve de checks funcionales o de UI]
+
+Restricciones:
+- [stack, límites de tiempo, alcance]
+```
+
+## Flujo recomendado de una sesión (rápido)
+
+1. Leer `AGENTS.md` + backlog activo.
+1. Confirmar una sola unidad prioritaria.
+1. Ejecutar cambios.
+1. Validar (test/captura/revisión manual).
+1. Registrar solo lo necesario (decision log si aplica, update backlog).
+1. Cerrar con commit + PR + siguiente menú (3–5 pasos).
+
+## Regla práctica para no volver a la sobrecarga
+
+Antes de crear una tarea documental, responder:
+
+- ¿Desbloquea una decisión transversal real?
+- ¿Reduce retrabajo inmediato de implementación?
+- ¿Se puede cerrar en < 30 min?
+
+Si la respuesta es “no” a 2 o más preguntas, priorizar implementación.
+
+## Checklist de arranque en 20 minutos
+
+- [ ] Definir alcance MVP en 10–15 bullets.
+- [ ] Crear backlog inicial con 5–8 issues máximas.
+- [ ] Marcar una issue de simplificación/refactor temprano.
+- [ ] Dejar preparado el comando de ejecución local y validación UI.
+- [ ] Ejecutar la primera unidad funcional visible.
+
+## Adaptación explícita para este repositorio
+
+A partir de este punto, el proyecto **prioriza finalizar la app**: UI y
+funcionalidades pendientes, manteniendo documentación/Issues/PR con nivel
+ligero y orientado a ejecución.


### PR DESCRIPTION
### Motivation

- Reorientar el proyecto a un modo "development-first" para priorizar el cierre de la app (UI y funcionalidades) sin perder trazabilidad mínima. 
- Mantener la ingeniería de contexto pero reducir su peso operativo para que la documentación apoye la implementación, no la bloquee. 
- Incluir una tarea explícita de simplificación de código para reducir complejidad acumulada en la UI antes de avanzar en nuevas features.

### Description

- Añade la guía práctica `learning/personal-context-engineering-quickstart.md` con principios 80/20, kit mínimo, prompt reutilizable y checklist rápido para arrancar proyectos personales con contexto ligero. 
- Registra la decisión operacional `DEC-0035` en `docs/decision-log.md` para formalizar el cambio de rumbo a `development_first_light_context`. 
- Actualiza `docs/context-governance.md` (hito `H1-05` y estado de fase) y `docs/system-map.md` para incluir la nueva guía en la navegación oficial. 
- Amplía `docs/mvp-implementation-checklist.md` con un bloque de "Próximas issues pendientes" orientadas a ejecución rápida (issues propuestas `#82`–`#86`) incluyendo `#84` como issue de simplificación/refactor de UI/estado.

### Testing

- Ejecuté `git diff --check` para validar inconsistencias de diff y no se reportaron problemas. 
- Compilé el código Python con `python -m compileall src` y la comprobación de sintaxis finalizó correctamente sin errores de compilación.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0daf8e8c483319e468623ae5cb48b)