### PR TITLE
#86 completar feedback de navegación temporal semanal

### DIFF
--- a/docs/mvp-implementation-blocks.md
+++ b/docs/mvp-implementation-blocks.md
@@ -572,10 +572,10 @@ No incluye:
 - [x] `#52` Shell de pantalla principal (layout base Figma)
 - [x] `#53` Estado local de navegación/visor sticky/activo mock
 - [x] `#54` Integración read-only inicial (`Q1/Q2/Q3/Q4/Q6/Q7`)
+- [x] `#86` Selección temporal y feedback semanal en UI (solo tiles + feedback)
 
 ### Próxima secuencia técnica esperada (según orden actual)
 
-1. `U1-temporal-nav-ui` Finalizar flujo de selección temporal y navegación semanal completa en UI
 1. `U2-ui-state-simplification` Simplificar complejidad accidental en `app_root`/`main_shell_view`/placeholders
 1. `U3-panel-actions-real-handlers` Conectar `start`, `stop`, `add session` y `delete entry` con handlers reales
 1. `U4-mobile-robustness-min` Mejorar robustez móvil mínima (`portrait` + `landscape`) en barra temporal y panel central

--- a/docs/mvp-implementation-checklist.md
+++ b/docs/mvp-implementation-checklist.md
@@ -240,10 +240,10 @@ Usar esta plantilla mínima en cada issue/bloque del checklist:
 - [x] Shell de pantalla principal con layout base según Figma (Issue #52)
 - [x] Estado local de selección/navegación + visor sticky + activo mock (Issue #53)
 - [x] Integrar lecturas mínimas read-only para arranque y navegación base (Issue #54)
+- [x] Completar selección temporal y feedback semanal en UI (Issue #86)
 
 ### Próximas unidades propuestas (sin issue abierta)
 
-- [ ] `U1-temporal-nav-ui`: finalizar flujo de selección temporal y navegación semanal completa en UI (incluye estados vacíos/semana cerrada y feedback visual claro).
 - [ ] `U2-ui-state-simplification`: simplificar complejidad accidental en `app_root`/`main_shell_view`/placeholders, extrayendo utilidades y eliminando duplicación innecesaria.
 - [ ] `U3-panel-actions-real-handlers`: conectar acciones principales del panel central (`start`, `stop`, `add session`, `delete entry`) con handlers reales y mensajes de error básicos.
 - [ ] `U4-mobile-robustness-min`: robustez móvil mínima (`portrait` + `landscape`) para barra temporal y panel central con validación visual rápida.
@@ -253,7 +253,6 @@ Al priorizar una unidad, abrir primero su issue y sustituir el identificador `U*
 
 #### Orden recomendado inmediato
 
-1. `U1-temporal-nav-ui`
 1. `U2-ui-state-simplification`
 1. `U3-panel-actions-real-handlers`
 1. `U4-mobile-robustness-min`

--- a/src/frosthaven_campaign_journal/ui/views/main_shell_view.py
+++ b/src/frosthaven_campaign_journal/ui/views/main_shell_view.py
@@ -14,7 +14,7 @@ from frosthaven_campaign_journal.state.placeholders import (
 )
 
 
-TOP_BAR_HEIGHT = 64
+TOP_BAR_HEIGHT = 78
 ENTRY_TABS_BAR_HEIGHT = 44
 BOTTOM_BAR_HEIGHT = 96
 OUTER_PADDING = 0
@@ -43,6 +43,8 @@ COLOR_WARNING_TEXT = "#7D5700"
 COLOR_WEEK_BLOCK_SUMMER_BG = "#F2ABAB"
 COLOR_WEEK_BLOCK_WINTER_BG = "#E6B3C4"
 COLOR_WEEK_BLOCK_BORDER = "#D98787"
+COLOR_WEEK_STATUS_OPEN = "#2D8A3E"
+COLOR_WEEK_STATUS_CLOSED = "#8A5C5C"
 ENTRY_RESOURCE_KEYS = ("lumber", "metal", "hide")
 
 
@@ -119,6 +121,7 @@ def build_main_shell_view(
     )
     entry_tabs_bar = _build_entry_tabs_bar(
         state=state,
+        weeks_for_selected_year=weeks_for_selected_year,
         entries_for_selected_week=entries_for_selected_week,
         viewer_entry=viewer_entry,
         entries_panel_error_message=entries_panel_error_message,
@@ -351,19 +354,43 @@ def _build_top_temporal_bar(
         ],
     )
 
-    content = ft.Row(
-        spacing=content_row_spacing,
-        alignment=ft.MainAxisAlignment.START,
-        vertical_alignment=ft.CrossAxisAlignment.CENTER,
+    selected_week = _find_selected_week(state, weeks_for_selected_year)
+    if state.selected_week is None:
+        week_status_text = "Navegación semanal: sin week seleccionada."
+        week_status_color = COLOR_TEXT_MUTED
+    elif selected_week is None:
+        week_status_text = "La week seleccionada ya no está visible en el año actual."
+        week_status_color = COLOR_WARNING_TEXT
+    elif selected_week.is_closed:
+        week_status_text = f"Navegación semanal: Week {selected_week.week_number} cerrada."
+        week_status_color = COLOR_TEXT_DIMMED
+    else:
+        week_status_text = f"Navegación semanal: Week {selected_week.week_number} abierta."
+        week_status_color = COLOR_TEXT_PRIMARY
+
+    content = ft.Column(
+        spacing=4,
         controls=[
-            year_group,
-            ft.Container(expand=True, content=week_strip_content),
+            ft.Row(
+                spacing=content_row_spacing,
+                alignment=ft.MainAxisAlignment.START,
+                vertical_alignment=ft.CrossAxisAlignment.CENTER,
+                controls=[
+                    year_group,
+                    ft.Container(expand=True, content=week_strip_content),
+                ],
+            ),
+            ft.Text(
+                week_status_text,
+                size=11,
+                color=week_status_color,
+            ),
         ],
     )
 
     if embedded_in_appbar:
         return ft.Container(
-            padding=ft.Padding(left=12, top=10, right=12, bottom=10),
+            padding=ft.Padding(left=12, top=6, right=12, bottom=6),
             tooltip=tooltip,
             content=content,
         )
@@ -371,7 +398,7 @@ def _build_top_temporal_bar(
     return ft.Container(
         height=TOP_BAR_HEIGHT,
         bgcolor=COLOR_TOP_BAR_BG,
-        padding=ft.Padding(left=12, top=10, right=12, bottom=10),
+        padding=ft.Padding(left=12, top=6, right=12, bottom=6),
         tooltip=tooltip,
         content=content,
     )
@@ -466,22 +493,50 @@ def _build_week_tile(
     border = ft.Border.all(2, COLOR_WEEK_TILE_SELECTED_BORDER) if is_selected else None
     bgcolor = COLOR_WEEK_TILE_CLOSED_BG if week.is_closed else COLOR_WEEK_TILE_BG
     text_color = COLOR_TEXT_DIMMED if week.is_closed else COLOR_TEXT_PRIMARY
+    status_dot_color = COLOR_WEEK_STATUS_CLOSED if week.is_closed else COLOR_WEEK_STATUS_OPEN
+    status_text = "C" if week.is_closed else "A"
+    status_color = COLOR_TEXT_DIMMED if week.is_closed else COLOR_TEXT_MUTED
 
     return ft.Container(
         width=46,
-        height=42,
+        height=46,
         bgcolor=bgcolor,
         border=border,
         border_radius=2,
         alignment=ft.Alignment.CENTER,
+        tooltip=f"Week {week.week_number} {'cerrada' if week.is_closed else 'abierta'}",
         on_click=(
             None if disabled else (lambda _e, week_number=week.week_number: on_select_week(week_number))
         ),
-        content=ft.Text(
-            str(week.week_number),
-            size=13,
-            weight=ft.FontWeight.W_600,
-            color=text_color,
+        content=ft.Column(
+            spacing=2,
+            horizontal_alignment=ft.CrossAxisAlignment.CENTER,
+            controls=[
+                ft.Text(
+                    str(week.week_number),
+                    size=13,
+                    weight=ft.FontWeight.W_600,
+                    color=text_color,
+                ),
+                ft.Row(
+                    spacing=3,
+                    alignment=ft.MainAxisAlignment.CENTER,
+                    controls=[
+                        ft.Container(
+                            width=6,
+                            height=6,
+                            border_radius=999,
+                            bgcolor=status_dot_color,
+                        ),
+                        ft.Text(
+                            status_text,
+                            size=8,
+                            weight=ft.FontWeight.W_600,
+                            color=status_color,
+                        ),
+                    ],
+                ),
+            ],
         ),
     )
 
@@ -489,6 +544,7 @@ def _build_week_tile(
 def _build_entry_tabs_bar(
     *,
     state: MainScreenLocalState,
+    weeks_for_selected_year: list[MockWeek],
     entries_for_selected_week: list[MockEntry],
     viewer_entry: MockEntry | None,
     entries_panel_error_message: str | None,
@@ -520,12 +576,19 @@ def _build_entry_tabs_bar(
             ],
         )
     elif not entries_for_selected_week:
+        selected_week = _find_selected_week(state, weeks_for_selected_year)
+        if selected_week is None:
+            empty_text = "La week seleccionada ya no está visible en el año actual."
+        elif selected_week.is_closed:
+            empty_text = f"Week {selected_week.week_number} cerrada sin entries"
+        else:
+            empty_text = f"Week {selected_week.week_number} abierta sin entries"
         content = ft.Row(
             alignment=ft.MainAxisAlignment.CENTER,
             vertical_alignment=ft.CrossAxisAlignment.CENTER,
             controls=[
                 ft.Text(
-                    f"Week {state.selected_week} sin entries",
+                    empty_text,
                     size=13,
                     color=COLOR_TEXT_MUTED,
                     italic=True,
@@ -770,6 +833,13 @@ def _build_focus_week_mode(
 ) -> ft.Control:
     badge_bg = "#EDEDED" if week.is_closed else "#D9F2D9"
     badge_fg = "#6A6A6A" if week.is_closed else "#237A3B"
+    week_context_text = (
+        "Week cerrada: navegación y correcciones manuales permitidas, sin sesión activa esperada."
+        if week.is_closed
+        else "Week abierta: navegación activa y acciones de week disponibles."
+    )
+    week_context_bg = "#F4EEEE" if week.is_closed else "#EEF8EE"
+    week_context_border = "#D4B8B8" if week.is_closed else "#B7D9BF"
     action_buttons: list[ft.Control] = [
         ft.FilledButton(
             "Nueva entry",
@@ -812,7 +882,18 @@ def _build_focus_week_mode(
         )
 
     notes_controls: list[ft.Control] = [
-        ft.Row(spacing=8, wrap=True, controls=action_buttons)
+        ft.Row(spacing=8, wrap=True, controls=action_buttons),
+        ft.Container(
+            padding=ft.Padding(left=10, top=8, right=10, bottom=8),
+            bgcolor=week_context_bg,
+            border=ft.Border.all(1, week_context_border),
+            border_radius=6,
+            content=ft.Text(
+                week_context_text,
+                size=12,
+                color=COLOR_TEXT_MUTED,
+            ),
+        ),
     ]
     if week_write_pending:
         notes_controls.append(


### PR DESCRIPTION
# Resumen

Completa `U1` con mejoras de feedback temporal en UI sin añadir navegación `prev/next week`.

Cambios principales:
- Top bar con línea explícita de estado semanal (`sin week seleccionada`, `Week <n> abierta/cerrada`, `week no visible`).
- Tiles de week con marcador discreto de estado `A/C` y color (`open/closed`).
- Copy diferenciado en tabs cuando la week seleccionada no tiene entries (`abierta` vs `cerrada`).
- Aviso contextual en panel central de modo week según estado.
- Trazabilidad backlog: `U1` reflejada como `#86` cerrable y prioridad movida a `U2`.

## Issue relacionado

Closes #86

## Tipo de cambio

- [ ] Documentación
- [ ] Flujo/proceso
- [ ] Bugfix
- [x] Funcionalidad

## Checklist

- [x] El alcance está claro.
- [x] Los commits siguen Conventional Commits.
- [ ] El Markdown no tiene warnings de lint.
- [ ] Actualicé `CHANGELOG.md` si corresponde.
- [x] La trazabilidad de decisiones está actualizada.
- [x] Texto en castellano revisado (tildes/ñ/ortografía).
- [ ] Ramas mergeadas no reutilizables limpiadas (local/remoto) si aplica.

## Validación UI (Playwright)

- Estado inicial: `Año 2 Navegación semanal: sin week seleccionada`.
- Week abierta: selección de `Week 36/37` muestra `Navegación semanal: Week <n> abierta`.
- Week cerrada: selección de `Week 33` muestra `Navegación semanal: Week 33 cerrada`.
- Copy sin entries:
  - `Week 33 cerrada sin entries`.
  - `Week 37 abierta sin entries`.
- Reconciliación al cambiar año: al navegar a `Año 3` vuelve a `sin week seleccionada`.
- Smoke mobile landscape (`667x375`): selección de `Week 60` sin regresión visual del top bar.