### PR TITLE
feat(main_shell): rediseña UI tablet y retira notas de semana

### DIFF
--- a/docs/concurrency-sync-edge-case-matrix.md
+++ b/docs/concurrency-sync-edge-case-matrix.md
@@ -1,39 +1,39 @@
-# Matriz de Edge Cases de Concurrencia y Sincronización (MVP)
+﻿# Matriz de Edge Cases de Concurrencia y SincronizaciÃ³n (MVP)
 
 ## Metadatos
 
 - `doc_id`: DOC-CONCURRENCY-SYNC-EDGE-CASE-MATRIX
-- `purpose`: Definir una matriz oficial de edge cases de concurrencia/sincronización del MVP (incluyendo errores locales del mismo flujo operativo) para priorizar verificación y alimentar `#19` / `#20`.
+- `purpose`: Definir una matriz oficial de edge cases de concurrencia/sincronizaciÃ³n del MVP (incluyendo errores locales del mismo flujo operativo) para priorizar verificaciÃ³n y alimentar `#19` / `#20`.
 - `status`: active
 - `source_of_truth`: official
-- `last_updated`: 2026-02-24
+- `last_updated`: 2026-03-05
 - `next_review`: 2026-03-10
 
 ## Objetivo
 
 Cerrar una matriz documental de edge cases que traduzca los contratos y flujos
 oficiales del MVP (`#7`, `#8`, `#12`, `#14`, `#15`, `#16`, `#18`, `#37`, `#40`)
-a escenarios verificables con clasificación, recuperación esperada y prioridad.
+a escenarios verificables con clasificaciÃ³n, recuperaciÃ³n esperada y prioridad.
 
 ## Alcance y no alcance
 
 Incluye:
 
-- edge cases de concurrencia y sincronización del MVP;
+- edge cases de concurrencia y sincronizaciÃ³n del MVP;
 - `transicion_invalida` / `validacion` cuando forman parte del mismo flujo
   operativo que un caso de concurrencia;
-- operaciones compuestas con side-effects (`auto-stop`, recálculo de
-  `week_cursor`, recálculo de recursos);
-- lecturas críticas ligadas a consistencia visible (`#16` + `#18`);
-- severidad, impacto y prioridad de verificación (`P0/P1/P2`);
-- subset crítico mínimo para `#19` y `#20`.
+- operaciones compuestas con side-effects (`auto-stop`, recÃ¡lculo de
+  `week_cursor`, recÃ¡lculo de recursos);
+- lecturas crÃ­ticas ligadas a consistencia visible (`#16` + `#18`);
+- severidad, impacto y prioridad de verificaciÃ³n (`P0/P1/P2`);
+- subset crÃ­tico mÃ­nimo para `#19` y `#20`.
 
 No incluye:
 
 - plan de pruebas paso a paso (`#19`);
 - scripts, harnesses o fixtures de test;
-- implementación de pruebas en código;
-- edge cases puramente visuales/UI sin impacto de sincronización/consistencia;
+- implementaciÃ³n de pruebas en cÃ³digo;
+- edge cases puramente visuales/UI sin impacto de sincronizaciÃ³n/consistencia;
 - reapertura de decisiones de dominio ya cerradas.
 
 ## Entradas y prerrequisitos
@@ -57,108 +57,107 @@ No incluye:
    documenta edge cases igualmente porque:
    - pueden ocurrir escrituras desde otro dispositivo;
    - puede existir estado local obsoleto;
-   - los side-effects compuestos requieren expectativas explícitas.
+   - los side-effects compuestos requieren expectativas explÃ­citas.
 1. Las escrituras son `online-only` (`#7`).
-1. No hay listeners realtime; la reconciliación visible depende de
+1. No hay listeners realtime; la reconciliaciÃ³n visible depende de
    `on-demand refresh` (`#7`, `#16`).
-1. La política de conflictos es estricta (`#8`): rechazo + `refrescar` +
+1. La polÃ­tica de conflictos es estricta (`#8`): rechazo + `refrescar` +
    `reintentar`.
 1. La matriz no redefine contratos; los traduce a escenarios verificables.
 
-## Taxonomía de edge cases (familias y criterios)
+## TaxonomÃ­a de edge cases (familias y criterios)
 
-### Criterios de inclusión
+### Criterios de inclusiÃ³n
 
-1. El caso afecta invariantes, consistencia visible, recuperación de usuario o
+1. El caso afecta invariantes, consistencia visible, recuperaciÃ³n de usuario o
    integridad de datos del MVP.
 1. El caso tiene expectativa verificable derivable de docs oficiales.
-1. Si el caso es solo UI/visual y no afecta sincronización/consistencia, queda
-   fuera de `#17` (pasa a `#19` o a diseño/UI).
+1. Si el caso es solo UI/visual y no afecta sincronizaciÃ³n/consistencia, queda
+   fuera de `#17` (pasa a `#19` o a diseÃ±o/UI).
 
-### Tabla 1 — Taxonomía de casos (`I17-S1`)
+### Tabla 1 â€” TaxonomÃ­a de casos (`I17-S1`)
 
 | `family_id` | `familia` | `descripcion` | `fuentes_principales` | `incluye_categorias_rechazo` | `notas` |
 | --- | --- | --- | --- | --- | --- |
-| `session_flow` | Flujo de sesiones y sesión activa global | Casos de `Session.*`, unicidad `0..1` activa global y side-effects `auto-stop` | `#12`, `#14`, `#8` | `conflicto`, `transicion_invalida`, `validacion` | Incluye coexistencia con `Session.manual_*` |
-| `week_state_cursor` | Estado de week + `week_cursor` | Transiciones `Week.close/reopen/reclose`, cursor derivado y límite de weeks abiertas | `#12`, `#37`, `#9`, `#13`, `#8` | `conflicto`, `transicion_invalida`, `validacion` | `closed` no bloquea mutaciones por sí mismo |
-| `entry_lifecycle_order` | Ciclo de vida y orden de entries | `Entry.create/update/delete/reorder` y consistencia de `order_index` | `#12`, `#14`, `#18` | `conflicto`, `transicion_invalida`, `validacion` | Incluye auto-normalización de orden |
-| `resource_totals_deltas` | Recursos por `Entry` + totales campaña | `Entry.adjust/set/clear_resource_delta` y recálculo/validación de totales | `#15`, `#12`, `#40`, `#8` | `conflicto`, `transicion_invalida`, `validacion` | `drift` => `conflicto`; no-ops idempotentes documentados |
-| `temporal_provision_extension` | Provisión/extensión temporal | `Campaign.provision_initial_years` y `extend_years_plus_one` con estructura/cursor derivados | `#12`, `#13`, `#37`, `#8` | `conflicto`, `validacion` | Sin reabrir mecánica técnica Firestore |
-| `critical_reads_refresh_order` | Lecturas críticas / refresh / orden | Casos de `#16` + `#18` que afectan consistencia visible bajo refresh manual | `#16`, `#18`, `#14`, `#7` | `conflicto`, `validacion` (poco frecuente), `mixta` | Solo lecturas críticas; no UX genérica |
+| `session_flow` | Flujo de sesiones y sesiÃ³n activa global | Casos de `Session.*`, unicidad `0..1` activa global y side-effects `auto-stop` | `#12`, `#14`, `#8` | `conflicto`, `transicion_invalida`, `validacion` | Incluye coexistencia con `Session.manual_*` |
+| `week_state_cursor` | Estado de week + `week_cursor` | Transiciones `Week.close/reopen/reclose`, cursor derivado y lÃ­mite de weeks abiertas | `#12`, `#37`, `#9`, `#13`, `#8` | `conflicto`, `transicion_invalida`, `validacion` | `closed` no bloquea mutaciones por sÃ­ mismo |
+| `entry_lifecycle_order` | Ciclo de vida y orden de entries | `Entry.create/update/delete/reorder` y consistencia de `order_index` | `#12`, `#14`, `#18` | `conflicto`, `transicion_invalida`, `validacion` | Incluye auto-normalizaciÃ³n de orden |
+| `resource_totals_deltas` | Recursos por `Entry` + totales campaÃ±a | `Entry.adjust/set/clear_resource_delta` y recÃ¡lculo/validaciÃ³n de totales | `#15`, `#12`, `#40`, `#8` | `conflicto`, `transicion_invalida`, `validacion` | `drift` => `conflicto`; no-ops idempotentes documentados |
+| `temporal_provision_extension` | ProvisiÃ³n/extensiÃ³n temporal | `Campaign.provision_initial_years` y `extend_years_plus_one` con estructura/cursor derivados | `#12`, `#13`, `#37`, `#8` | `conflicto`, `validacion` | Sin reabrir mecÃ¡nica tÃ©cnica Firestore |
+| `critical_reads_refresh_order` | Lecturas crÃ­ticas / refresh / orden | Casos de `#16` + `#18` que afectan consistencia visible bajo refresh manual | `#16`, `#18`, `#14`, `#7` | `conflicto`, `validacion` (poco frecuente), `mixta` | Solo lecturas crÃ­ticas; no UX genÃ©rica |
 
-## Matriz principal de escenarios canónicos
+## Matriz principal de escenarios canÃ³nicos
 
 ### Convenciones
 
 1. `categoria_esperada = mixta` se usa solo cuando el escenario base agrupa
-   variantes cuya clasificación final depende de la operación exacta.
-1. `recuperacion_esperada` reutiliza la semántica de `#8`, `#12`, `#14`, `#15`.
-1. `docs_referencia` enumera las fuentes mínimas para validar el escenario.
+   variantes cuya clasificaciÃ³n final depende de la operaciÃ³n exacta.
+1. `recuperacion_esperada` reutiliza la semÃ¡ntica de `#8`, `#12`, `#14`, `#15`.
+1. `docs_referencia` enumera las fuentes mÃ­nimas para validar el escenario.
 
-### Tabla 2 — Matriz principal (escenarios canónicos) (`I17-S2A`)
+### Tabla 2 â€” Matriz principal (escenarios canÃ³nicos) (`I17-S2A`)
 
 | `edge_case_id` | `family_id` | `escenario_canonico` | `precondicion_resumida` | `trigger` | `sintoma_observable` | `resultado_esperado` | `categoria_esperada` | `recuperacion_esperada` | `severidad` | `impacto` | `prioridad_verificacion` | `docs_referencia` | `notas` |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `EC-SESSION-01` | `session_flow` | `start` con base obsoleta y posible `auto-stop + start` en conflicto | Existe sesión activa previa o estado leído obsoleto | `Session.start` | Error al iniciar / activa final distinta de la esperada | Rechazo por conflicto; no doble activa; sin estado parcial confirmado por cliente | `conflicto` | `refresh` manual + reintentar | `critical` | invariante de sesión activa global | `P0` | `#12`, `#14`, `#8` | Operación compuesta |
-| `EC-SESSION-02` | `session_flow` | `stop` sobre sesión cambiada concurrentemente | Sesión parecía activa al cliente | `Session.stop` | Stop falla porque la base ya cambió | Rechazo por conflicto; no asumir cierre local como definitivo | `conflicto` | `refresh` manual + reintentar | `high` | flujo principal de sesión | `P1` | `#12`, `#14`, `#8` | Distinguir de sesión ya cerrada |
-| `EC-SESSION-03` | `session_flow` | `start` sobre entry ya activa | `selected_entry` coincide con `active_entry` | `ui.session_start_on_selected_entry` / `Session.start` | Usuario pulsa `Iniciar` sobre entry ya activa | Error local; no crea nueva sesión; no `auto-stop` | `transicion_invalida` | error local (sin refresh por defecto) | `medium` | flujo principal de sesión | `P1` | `#14`, `#12` | Caso de UX/flujo crítico |
-| `EC-SESSION-04` | `session_flow` | `stop` sobre sesión ya no activa | UI desfasada o acción repetida | `ui.session_stop_on_selected_entry` / `Session.stop` | `Stop` no aplica a la sesión actual | Error local; estado activo no cambia | `transicion_invalida` | error local (refresh opcional si sospecha obsolescencia) | `medium` | flujo principal de sesión | `P2` | `#14`, `#12`, `#8` | Sin auto-refresh |
-| `EC-SESSION-05` | `session_flow` | `Session.manual_update` rompe unicidad de activa global | Corrección manual sobre timestamps puede convertir sesión a activa | `Session.manual_update` | Riesgo de >1 sesión activa global | Operación rechazada o conflicto según base; unicidad preservada | `mixta` | error local si validación; `refresh + retry` si conflicto | `high` | invariante de sesión activa global | `P1` | `#12`, `#37`, `#14`, `#8` | Clasificación final por variante |
-| `EC-SESSION-06` | `session_flow` | `Entry.delete` activa / `Week.close\|reclose` con `auto-stop` embebido en conflicto compuesto | Sesión activa en la entry/week afectada | `Entry.delete` / `Week.close` / `Week.reclose` | Operación compuesta falla o queda en estado ambiguo al usuario | Rechazo de la operación compuesta; no dejar estado parcial asumido por cliente | `conflicto` | `refresh` manual + reintentar operación padre | `critical` | invariante + flujo principal + recuperación | `P0` | `#12`, `#14`, `#8` | Compuesto con side-effects |
-| `EC-WEEK-01` | `week_state_cursor` | Transición inválida de `Week` | Estado real no coincide con transición solicitada | `Week.close` / `Week.reopen` / `Week.reclose` | Acción sobre week ya en ese estado / no aplicable | Error local por transición inválida; no `refresh` por defecto | `transicion_invalida` | error local | `medium` | flujo temporal y estado | `P1` | `#12`, `#8`, `#14` | Distinguir de conflicto |
-| `EC-WEEK-02` | `week_state_cursor` | Conflicto en cambio de estado de week con recálculo de `week_cursor` | Week/cursor leídos obsoletos | `Week.close` / `Week.reopen` / `Week.reclose` | Acción de week falla por base obsoleta; marcador `current week` puede quedar viejo | Rechazo por conflicto; `week_cursor` visible se corrige tras refresh | `conflicto` | `refresh` manual + reintentar | `critical` | temporal + consistencia visible | `P0` | `#12`, `#37`, `#9`, `#14`, `#8` | Incluye recálculo derivado de cursor |
-| `EC-WEEK-03` | `week_state_cursor` | Cierre/recierre dejaría `0` weeks abiertas | Week objetivo es la última abierta | `Week.close` / `Week.reclose` | Acción rechazada aunque la week exista y transición parezca válida | Validación rechaza; invariante de weeks abiertas preservada | `validacion` | error local; corregir acción | `critical` | invariante temporal | `P0` | `#12`, `#37`, `#13` | Bloquea comportamiento inválido del cursor |
-| `EC-ENTRY-01` | `entry_lifecycle_order` | `reorder` con base de orden obsoleta | Orden de entries cambió concurrentemente | `Entry.reorder_within_week` | Reordenación falla / orden visible desfasado | Rechazo por conflicto; orden se restablece tras refresh | `conflicto` | `refresh` manual + reintentar | `high` | consistencia visual + flujo principal | `P1` | `#12`, `#18`, `#8` | Resecuencia densa `1..N` |
-| `EC-ENTRY-02` | `entry_lifecycle_order` | `Entry.update/delete` sobre entry obsoleta o ya borrada | Cliente opera sobre entry ya modificada/eliminada | `Entry.update` / `Entry.delete` | Acción falla; tabs/panel pueden quedar desfasados | Conflicto o transición inválida según caso; no estado parcial | `mixta` | error local (`not found`) o `refresh + retry` (conflicto) | `high` | flujo principal + consistencia visible | `P1` | `#12`, `#14`, `#16`, `#8` | Clasificación final por variante |
-| `EC-ENTRY-03` | `entry_lifecycle_order` | Secuencia inconsistente de `order_index` y auto-normalización | Secuencia previa con huecos/duplicados | `Entry.create` (y/o inserción con normalización) | Orden previo inconsistente detectado | Se auto-normaliza la secuencia y la operación puede continuar sin error | `validacion` | no aplica; comportamiento controlado | `low` | orden de entries / robustez | `P2` | `#12` | Edge local controlado (no fallo) |
-| `EC-RESOURCE-01` | `resource_totals_deltas` | Total final negativo | Delta propuesto haría `campaign_after < 0` | `Entry.adjust/set/clear_resource_delta` | Operación rechazada por total inválido | Validación rechaza; totales no negativos preservados | `validacion` | error local; corregir delta | `high` | integridad de totales de recursos | `P1` | `#15`, `#12` | `clear` puede revelar drift si base mala |
-| `EC-RESOURCE-02` | `resource_totals_deltas` | Base obsoleta en deltas/totales | `Entry` o `campaign.resource_totals` cambió | `Entry.adjust/set/clear_resource_delta` | Error al persistir ajuste de recursos | Rechazo por conflicto; no aplicar delta sobre base obsoleta | `conflicto` | `refresh` manual + reintentar | `critical` | integridad de datos/recursos | `P0` | `#15`, `#12`, `#8`, `#40` | Caso central de concurrencia en recursos |
-| `EC-RESOURCE-03` | `resource_totals_deltas` | Drift/inconsistencia detectada de totales | Cálculo local detecta preestado imposible | Cualquier operación de recursos (o `Entry.delete` con impacto recursos) | Estado de recursos no cuadra con deltas/totales | Clasificar como conflicto y forzar refresh; escalar si persiste | `conflicto` | `refresh` y reintentar; escalar si persiste | `critical` | integridad de datos/recursos | `P0` | `#15`, `#8`, `#12` | Decisión explícita: drift => conflicto |
-| `EC-RESOURCE-04` | `resource_totals_deltas` | No-ops idempotentes sin error | `adjust=0`, `set` mismo valor, `clear` inexistente | `Entry.adjust/set/clear_resource_delta` | Acción no cambia estado pero puede ejecutarse | No error; estado final permanece igual; contrato idempotente | `validacion` | no aplica; seguir flujo normal | `low` | robustez / UX tolerante | `P2` | `#15`, `#12`, `#40` | `clear` inexistente es idempotente |
-| `EC-TEMPORAL-01` | `temporal_provision_extension` | `extend_years_plus_one` con base obsoleta/duplicado | Estructura temporal cambió / año ya existe | `Campaign.extend_years_plus_one` | Extensión falla por base obsoleta o duplicados | Rechazo por conflicto o validación; no crear año parcial | `mixta` | error local (duplicado/estructura) o `refresh + retry` (conflicto) | `critical` | temporal + integridad estructural | `P0` | `#12`, `#13`, `#37`, `#8` | Año completo o fallo completo |
-| `EC-TEMPORAL-02` | `temporal_provision_extension` | Provisión inicial/reprovisión parcial inválida | Duplicados o continuidad `week_number` rota | `Campaign.provision_initial_years` | Falla la provisión inicial / reprovisión accidental | Rechazo por validación o conflicto; no estructura temporal parcial | `mixta` | error local o `refresh + retry` según base | `high` | temporal + integridad estructural | `P1` | `#12`, `#13`, `#8` | Incluye idempotencia/rechazo de reprovisión |
-| `EC-READ-01` | `critical_reads_refresh_order` | `ui.manual_refresh` reconcilia conflicto y normaliza estado visible | Estado visible potencialmente obsoleto tras error | `ui.manual_refresh` | UI desincronizada tras conflicto | Refresco on-demand recarga queries visibles y restablece consistencia | `conflicto` | `refresh` manual (acción del usuario) | `critical` | recuperación MVP | `P0` | `#7`, `#16`, `#14`, `#18` | Sin realtime listeners |
-| `EC-READ-02` | `critical_reads_refresh_order` | `Q8` con `serverTimestamp` pendiente produce orden provisional | Sesiones recién escritas con timestamps pendientes | `Q8 sessions_selected_entry_combined` | Orden temporalmente provisional en lista de sesiones | Orden final solo garantizado tras `refresh`; no prometer estabilidad antes | `validacion` | refresh manual cuando se requiera orden final | `medium` | consistencia visual / orden | `P1` | `#18`, `#16` | No es conflicto de escritura |
-| `EC-READ-03` | `critical_reads_refresh_order` | Activo global en otra entry (`Q6+Q7`) vs selección/foco | Existe sesión activa global y `selected_entry != active_entry` | `Q6` + `Q7` + estado UI (`#14`) | UI puede mostrar foco y activo distintos | UI distingue foco vs activo; label del activo se resuelve vía Q7 si aplica | `conflicto` | refresh manual si Q6/Q7 quedan obsoletos | `critical` | consistencia visual de foco vs activo | `P0` | `#14`, `#16`, `#18` | Caso crítico de lectura + flujo |
-| `EC-READ-04` | `critical_reads_refresh_order` | Arranque sin selección + cargas diferidas correctas | Apertura de pantalla principal sin selección | `open_main_screen` | Carga excesiva o carga prematura de queries de entry | Cargar solo Q1/Q2/Q3/Q4/Q6; no Q5/Q7/Q8 hasta selección | `validacion` | corregir trigger/carga; no requiere refresh | `medium` | coste/latencia y consistencia de arranque | `P1` | `#16`, `#9`, `#14`, `#7` | Caso de lecturas mínimas correctas |
-| `EC-READ-05` | `critical_reads_refresh_order` | Cambio de año / merge `Q3+Q4` mantiene orden de weeks | Cambio de año o refresh del año visible | `ui.select_year` / refresh Q3+Q4 | Weeks mezcladas fuera de orden canónico | Merge cliente conserva orden por `week_number ASC` | `validacion` | corregir orden local / refresh si base obsoleta | `medium` | consistencia visual temporal | `P1` | `#16`, `#18`, `#13` | `summer+winter` se ordenan por `week_number` |
+| `EC-SESSION-01` | `session_flow` | `start` con base obsoleta y posible `auto-stop + start` en conflicto | Existe sesiÃ³n activa previa o estado leÃ­do obsoleto | `Session.start` | Error al iniciar / activa final distinta de la esperada | Rechazo por conflicto; no doble activa; sin estado parcial confirmado por cliente | `conflicto` | `refresh` manual + reintentar | `critical` | invariante de sesiÃ³n activa global | `P0` | `#12`, `#14`, `#8` | OperaciÃ³n compuesta |
+| `EC-SESSION-02` | `session_flow` | `stop` sobre sesiÃ³n cambiada concurrentemente | SesiÃ³n parecÃ­a activa al cliente | `Session.stop` | Stop falla porque la base ya cambiÃ³ | Rechazo por conflicto; no asumir cierre local como definitivo | `conflicto` | `refresh` manual + reintentar | `high` | flujo principal de sesiÃ³n | `P1` | `#12`, `#14`, `#8` | Distinguir de sesiÃ³n ya cerrada |
+| `EC-SESSION-03` | `session_flow` | `start` sobre entry ya activa | `selected_entry` coincide con `active_entry` | `ui.session_start_on_selected_entry` / `Session.start` | Usuario pulsa `Iniciar` sobre entry ya activa | Error local; no crea nueva sesiÃ³n; no `auto-stop` | `transicion_invalida` | error local (sin refresh por defecto) | `medium` | flujo principal de sesiÃ³n | `P1` | `#14`, `#12` | Caso de UX/flujo crÃ­tico |
+| `EC-SESSION-04` | `session_flow` | `stop` sobre sesiÃ³n ya no activa | UI desfasada o acciÃ³n repetida | `ui.session_stop_on_selected_entry` / `Session.stop` | `Stop` no aplica a la sesiÃ³n actual | Error local; estado activo no cambia | `transicion_invalida` | error local (refresh opcional si sospecha obsolescencia) | `medium` | flujo principal de sesiÃ³n | `P2` | `#14`, `#12`, `#8` | Sin auto-refresh |
+| `EC-SESSION-05` | `session_flow` | `Session.manual_update` rompe unicidad de activa global | CorrecciÃ³n manual sobre timestamps puede convertir sesiÃ³n a activa | `Session.manual_update` | Riesgo de >1 sesiÃ³n activa global | OperaciÃ³n rechazada o conflicto segÃºn base; unicidad preservada | `mixta` | error local si validaciÃ³n; `refresh + retry` si conflicto | `high` | invariante de sesiÃ³n activa global | `P1` | `#12`, `#37`, `#14`, `#8` | ClasificaciÃ³n final por variante |
+| `EC-SESSION-06` | `session_flow` | `Entry.delete` activa / `Week.close\|reclose` con `auto-stop` embebido en conflicto compuesto | SesiÃ³n activa en la entry/week afectada | `Entry.delete` / `Week.close` / `Week.reclose` | OperaciÃ³n compuesta falla o queda en estado ambiguo al usuario | Rechazo de la operaciÃ³n compuesta; no dejar estado parcial asumido por cliente | `conflicto` | `refresh` manual + reintentar operaciÃ³n padre | `critical` | invariante + flujo principal + recuperaciÃ³n | `P0` | `#12`, `#14`, `#8` | Compuesto con side-effects |
+| `EC-WEEK-01` | `week_state_cursor` | TransiciÃ³n invÃ¡lida de `Week` | Estado real no coincide con transiciÃ³n solicitada | `Week.close` / `Week.reopen` / `Week.reclose` | AcciÃ³n sobre week ya en ese estado / no aplicable | Error local por transiciÃ³n invÃ¡lida; no `refresh` por defecto | `transicion_invalida` | error local | `medium` | flujo temporal y estado | `P1` | `#12`, `#8`, `#14` | Distinguir de conflicto |
+| `EC-WEEK-02` | `week_state_cursor` | Conflicto en cambio de estado de week con recÃ¡lculo de `week_cursor` | Week/cursor leÃ­dos obsoletos | `Week.close` / `Week.reopen` / `Week.reclose` | AcciÃ³n de week falla por base obsoleta; marcador `current week` puede quedar viejo | Rechazo por conflicto; `week_cursor` visible se corrige tras refresh | `conflicto` | `refresh` manual + reintentar | `critical` | temporal + consistencia visible | `P0` | `#12`, `#37`, `#9`, `#14`, `#8` | Incluye recÃ¡lculo derivado de cursor |
+| `EC-WEEK-03` | `week_state_cursor` | Cierre/recierre dejarÃ­a `0` weeks abiertas | Week objetivo es la Ãºltima abierta | `Week.close` / `Week.reclose` | AcciÃ³n rechazada aunque la week exista y transiciÃ³n parezca vÃ¡lida | ValidaciÃ³n rechaza; invariante de weeks abiertas preservada | `validacion` | error local; corregir acciÃ³n | `critical` | invariante temporal | `P0` | `#12`, `#37`, `#13` | Bloquea comportamiento invÃ¡lido del cursor |
+| `EC-ENTRY-01` | `entry_lifecycle_order` | `reorder` con base de orden obsoleta | Orden de entries cambiÃ³ concurrentemente | `Entry.reorder_within_week` | ReordenaciÃ³n falla / orden visible desfasado | Rechazo por conflicto; orden se restablece tras refresh | `conflicto` | `refresh` manual + reintentar | `high` | consistencia visual + flujo principal | `P1` | `#12`, `#18`, `#8` | Resecuencia densa `1..N` |
+| `EC-ENTRY-02` | `entry_lifecycle_order` | `Entry.update/delete` sobre entry obsoleta o ya borrada | Cliente opera sobre entry ya modificada/eliminada | `Entry.update` / `Entry.delete` | AcciÃ³n falla; tabs/panel pueden quedar desfasados | Conflicto o transiciÃ³n invÃ¡lida segÃºn caso; no estado parcial | `mixta` | error local (`not found`) o `refresh + retry` (conflicto) | `high` | flujo principal + consistencia visible | `P1` | `#12`, `#14`, `#16`, `#8` | ClasificaciÃ³n final por variante |
+| `EC-ENTRY-03` | `entry_lifecycle_order` | Secuencia inconsistente de `order_index` y auto-normalizaciÃ³n | Secuencia previa con huecos/duplicados | `Entry.create` (y/o inserciÃ³n con normalizaciÃ³n) | Orden previo inconsistente detectado | Se auto-normaliza la secuencia y la operaciÃ³n puede continuar sin error | `validacion` | no aplica; comportamiento controlado | `low` | orden de entries / robustez | `P2` | `#12` | Edge local controlado (no fallo) |
+| `EC-RESOURCE-01` | `resource_totals_deltas` | Total final negativo | Delta propuesto harÃ­a `campaign_after < 0` | `Entry.adjust/set/clear_resource_delta` | OperaciÃ³n rechazada por total invÃ¡lido | ValidaciÃ³n rechaza; totales no negativos preservados | `validacion` | error local; corregir delta | `high` | integridad de totales de recursos | `P1` | `#15`, `#12` | `clear` puede revelar drift si base mala |
+| `EC-RESOURCE-02` | `resource_totals_deltas` | Base obsoleta en deltas/totales | `Entry` o `campaign.resource_totals` cambiÃ³ | `Entry.adjust/set/clear_resource_delta` | Error al persistir ajuste de recursos | Rechazo por conflicto; no aplicar delta sobre base obsoleta | `conflicto` | `refresh` manual + reintentar | `critical` | integridad de datos/recursos | `P0` | `#15`, `#12`, `#8`, `#40` | Caso central de concurrencia en recursos |
+| `EC-RESOURCE-03` | `resource_totals_deltas` | Drift/inconsistencia detectada de totales | CÃ¡lculo local detecta preestado imposible | Cualquier operaciÃ³n de recursos (o `Entry.delete` con impacto recursos) | Estado de recursos no cuadra con deltas/totales | Clasificar como conflicto y forzar refresh; escalar si persiste | `conflicto` | `refresh` y reintentar; escalar si persiste | `critical` | integridad de datos/recursos | `P0` | `#15`, `#8`, `#12` | DecisiÃ³n explÃ­cita: drift => conflicto |
+| `EC-RESOURCE-04` | `resource_totals_deltas` | No-ops idempotentes sin error | `adjust=0`, `set` mismo valor, `clear` inexistente | `Entry.adjust/set/clear_resource_delta` | AcciÃ³n no cambia estado pero puede ejecutarse | No error; estado final permanece igual; contrato idempotente | `validacion` | no aplica; seguir flujo normal | `low` | robustez / UX tolerante | `P2` | `#15`, `#12`, `#40` | `clear` inexistente es idempotente |
+| `EC-TEMPORAL-01` | `temporal_provision_extension` | `extend_years_plus_one` con base obsoleta/duplicado | Estructura temporal cambiÃ³ / aÃ±o ya existe | `Campaign.extend_years_plus_one` | ExtensiÃ³n falla por base obsoleta o duplicados | Rechazo por conflicto o validaciÃ³n; no crear aÃ±o parcial | `mixta` | error local (duplicado/estructura) o `refresh + retry` (conflicto) | `critical` | temporal + integridad estructural | `P0` | `#12`, `#13`, `#37`, `#8` | AÃ±o completo o fallo completo |
+| `EC-TEMPORAL-02` | `temporal_provision_extension` | ProvisiÃ³n inicial/reprovisiÃ³n parcial invÃ¡lida | Duplicados o continuidad `week_number` rota | `Campaign.provision_initial_years` | Falla la provisiÃ³n inicial / reprovisiÃ³n accidental | Rechazo por validaciÃ³n o conflicto; no estructura temporal parcial | `mixta` | error local o `refresh + retry` segÃºn base | `high` | temporal + integridad estructural | `P1` | `#12`, `#13`, `#8` | Incluye idempotencia/rechazo de reprovisiÃ³n |
+| `EC-READ-01` | `critical_reads_refresh_order` | `ui.manual_refresh` reconcilia conflicto y normaliza estado visible | Estado visible potencialmente obsoleto tras error | `ui.manual_refresh` | UI desincronizada tras conflicto | Refresco on-demand recarga queries visibles y restablece consistencia | `conflicto` | `refresh` manual (acciÃ³n del usuario) | `critical` | recuperaciÃ³n MVP | `P0` | `#7`, `#16`, `#14`, `#18` | Sin realtime listeners |
+| `EC-READ-02` | `critical_reads_refresh_order` | `Q8` con `serverTimestamp` pendiente produce orden provisional | Sesiones reciÃ©n escritas con timestamps pendientes | `Q8 sessions_selected_entry_combined` | Orden temporalmente provisional en lista de sesiones | Orden final solo garantizado tras `refresh`; no prometer estabilidad antes | `validacion` | refresh manual cuando se requiera orden final | `medium` | consistencia visual / orden | `P1` | `#18`, `#16` | No es conflicto de escritura |
+| `EC-READ-03` | `critical_reads_refresh_order` | Activo global en otra entry (`Q6+Q7`) vs selecciÃ³n/foco | Existe sesiÃ³n activa global y `selected_entry != active_entry` | `Q6` + `Q7` + estado UI (`#14`) | UI puede mostrar foco y activo distintos | UI distingue foco vs activo; label del activo se resuelve vÃ­a Q7 si aplica | `conflicto` | refresh manual si Q6/Q7 quedan obsoletos | `critical` | consistencia visual de foco vs activo | `P0` | `#14`, `#16`, `#18` | Caso crÃ­tico de lectura + flujo |
+| `EC-READ-04` | `critical_reads_refresh_order` | Arranque sin selecciÃ³n + cargas diferidas correctas | Apertura de pantalla principal sin selecciÃ³n | `open_main_screen` | Carga excesiva o carga prematura de queries de entry | Cargar solo Q1/Q2/Q3/Q4/Q6; no Q5/Q7/Q8 hasta selecciÃ³n | `validacion` | corregir trigger/carga; no requiere refresh | `medium` | coste/latencia y consistencia de arranque | `P1` | `#16`, `#9`, `#14`, `#7` | Caso de lecturas mÃ­nimas correctas |
+| `EC-READ-05` | `critical_reads_refresh_order` | Cambio de aÃ±o / merge `Q3+Q4` mantiene orden de weeks | Cambio de aÃ±o o refresh del aÃ±o visible | `ui.select_year` / refresh Q3+Q4 | Weeks mezcladas fuera de orden canÃ³nico | Merge cliente conserva orden por `week_number ASC` | `validacion` | corregir orden local / refresh si base obsoleta | `medium` | consistencia visual temporal | `P1` | `#16`, `#18`, `#13` | `summer+winter` se ordenan por `week_number` |
 
-## Variantes por familia y operación (capa 2)
+## Variantes por familia y operaciÃ³n (capa 2)
 
 ### Regla de uso
 
-1. Esta tabla evita multiplicar filas canónicas.
-1. Cada operación/evento obligatorio aparece al menos una vez.
-1. Si no aporta edge case nuevo, se marca “sin variante crítica adicional” y se
-   referencia el escenario canónico más cercano.
+1. Esta tabla evita multiplicar filas canÃ³nicas.
+1. Cada operaciÃ³n/evento obligatorio aparece al menos una vez.
+1. Si no aporta edge case nuevo, se marca â€œsin variante crÃ­tica adicionalâ€ y se
+   referencia el escenario canÃ³nico mÃ¡s cercano.
 
-### Tabla 3 — Variantes por operación (capa 2) (`I17-S2B`)
+### Tabla 3 â€” Variantes por operaciÃ³n (capa 2) (`I17-S2B`)
 
 | `variant_id` | `operation_or_event` | `edge_case_id_base` | `delta_especifico` | `clasificacion_final_esperada` | `recuperacion_final` | `notas` |
 | --- | --- | --- | --- | --- | --- | --- |
-| `V-001` | `Campaign.provision_initial_years` | `EC-TEMPORAL-02` | Duplicados/continuidad inválida al reprovisionar o base obsoleta | `validacion` / `conflicto` | error local o `refresh + retry` | Crear 4 años o fallar completo |
-| `V-002` | `Campaign.extend_years_plus_one` | `EC-TEMPORAL-01` | Duplicado de año / base obsoleta / continuidad inválida | `validacion` / `conflicto` | error local o `refresh + retry` | Caso P0 |
-| `V-003` | `Week.close` | `EC-WEEK-02` | Puede incluir `auto-stop` embebido + recálculo de cursor | `conflicto` / `transicion_invalida` / `validacion` | error local o `refresh + retry` | Ver `EC-WEEK-03` y `EC-SESSION-06` |
-| `V-004` | `Week.reopen` | `EC-WEEK-01` | Transición `closed -> open`; cursor derivado | `transicion_invalida` / `conflicto` | error local o `refresh + retry` | Sin caso de `0 weeks abiertas` |
+| `V-001` | `Campaign.provision_initial_years` | `EC-TEMPORAL-02` | Duplicados/continuidad invÃ¡lida al reprovisionar o base obsoleta | `validacion` / `conflicto` | error local o `refresh + retry` | Crear 4 aÃ±os o fallar completo |
+| `V-002` | `Campaign.extend_years_plus_one` | `EC-TEMPORAL-01` | Duplicado de aÃ±o / base obsoleta / continuidad invÃ¡lida | `validacion` / `conflicto` | error local o `refresh + retry` | Caso P0 |
+| `V-003` | `Week.close` | `EC-WEEK-02` | Puede incluir `auto-stop` embebido + recÃ¡lculo de cursor | `conflicto` / `transicion_invalida` / `validacion` | error local o `refresh + retry` | Ver `EC-WEEK-03` y `EC-SESSION-06` |
+| `V-004` | `Week.reopen` | `EC-WEEK-01` | TransiciÃ³n `closed -> open`; cursor derivado | `transicion_invalida` / `conflicto` | error local o `refresh + retry` | Sin caso de `0 weeks abiertas` |
 | `V-005` | `Week.reclose` | `EC-WEEK-03` | Puede disparar `auto-stop` y validar `0 weeks abiertas` | `validacion` / `transicion_invalida` / `conflicto` | error local o `refresh + retry` | Compuesto cuando hay activa |
-| `V-006` | `Week.update_notes` | `EC-WEEK-02` | No cambia estado/cursor, pero puede fallar por base obsoleta | `conflicto` / `validacion` | error local o `refresh + reingresar cambios` | Sin LWW |
-| `V-007` | `Entry.create` | `EC-ENTRY-03` | Auto-normalización de `order_index` y posible conflicto de base | `validacion` / `conflicto` | no-op/normalización o `refresh + retry` | Edge local controlado + conflicto posible |
-| `V-008` | `Entry.update` | `EC-ENTRY-02` | Entry obsoleta / intento inválido (ej. mover de week) | `conflicto` / `validacion` | error local o `refresh + retry` | `transicion_invalida` suele aplicar más a delete |
-| `V-009` | `Entry.delete` | `EC-SESSION-06` | Si entry activa: `auto-stop` embebido; si ya no existe: not found | `conflicto` / `transicion_invalida` | error local o `refresh + retry` | También impacta recursos (`EC-RESOURCE-03`) |
+| `V-007` | `Entry.create` | `EC-ENTRY-03` | Auto-normalizaciÃ³n de `order_index` y posible conflicto de base | `validacion` / `conflicto` | no-op/normalizaciÃ³n o `refresh + retry` | Edge local controlado + conflicto posible |
+| `V-008` | `Entry.update` | `EC-ENTRY-02` | Entry obsoleta / intento invÃ¡lido (ej. mover de week) | `conflicto` / `validacion` | error local o `refresh + retry` | `transicion_invalida` suele aplicar mÃ¡s a delete |
+| `V-009` | `Entry.delete` | `EC-SESSION-06` | Si entry activa: `auto-stop` embebido; si ya no existe: not found | `conflicto` / `transicion_invalida` | error local o `refresh + retry` | TambiÃ©n impacta recursos (`EC-RESOURCE-03`) |
 | `V-010` | `Entry.reorder_within_week` | `EC-ENTRY-01` | Base de orden obsoleta o pertenencia incoherente | `conflicto` / `validacion` | error local o `refresh + retry` | Resecuencia densa `1..N` |
 | `V-011` | `Entry.adjust_resource_delta` | `EC-RESOURCE-02` | Base obsoleta; no-op si `adjust=0`; total negativo | `conflicto` / `validacion` | error local o `refresh + retry` | Ver `EC-RESOURCE-04` |
 | `V-012` | `Entry.set_resource_delta` | `EC-RESOURCE-02` | Base obsoleta; set mismo valor (no-op); total negativo | `conflicto` / `validacion` | error local o `refresh + retry` | Ver `EC-RESOURCE-04` |
 | `V-013` | `Entry.clear_resource_delta` | `EC-RESOURCE-03` | Drift detectado o clave inexistente idempotente | `conflicto` / `validacion` | `refresh + retry` o no-op | `clear` inexistente sin error |
-| `V-014` | `Session.start` | `EC-SESSION-01` | Puede derivar a `EC-SESSION-03` si entry ya activa | `conflicto` / `transicion_invalida` / `validacion` | error local o `refresh + retry` | Compuesto si había activa previa |
-| `V-015` | `Session.stop` | `EC-SESSION-02` | Si ya no activa -> `EC-SESSION-04` | `conflicto` / `transicion_invalida` | error local o `refresh + retry` | Distinguir conflicto de acción repetida |
-| `V-016` | `Session.auto_stop` | `EC-SESSION-06` | Side-effect heredado del padre (`start`, `week close`, `entry delete`) | `conflicto` / `transicion_invalida` | heredada de la operación padre | No acción manual principal |
+| `V-014` | `Session.start` | `EC-SESSION-01` | Puede derivar a `EC-SESSION-03` si entry ya activa | `conflicto` / `transicion_invalida` / `validacion` | error local o `refresh + retry` | Compuesto si habÃ­a activa previa |
+| `V-015` | `Session.stop` | `EC-SESSION-02` | Si ya no activa -> `EC-SESSION-04` | `conflicto` / `transicion_invalida` | error local o `refresh + retry` | Distinguir conflicto de acciÃ³n repetida |
+| `V-016` | `Session.auto_stop` | `EC-SESSION-06` | Side-effect heredado del padre (`start`, `week close`, `entry delete`) | `conflicto` / `transicion_invalida` | heredada de la operaciÃ³n padre | No acciÃ³n manual principal |
 | `V-017` | `Session.manual_create` | `EC-SESSION-05` | Crear activa manual puede violar unicidad | `validacion` / `conflicto` | error local o `refresh + retry` | Weeks `open\|closed` permitidas |
 | `V-018` | `Session.manual_update` | `EC-SESSION-05` | `ended_at_utc null <-> valor`; riesgo unicidad activa | `validacion` / `conflicto` | error local o `refresh + retry` | Sin reparenting |
-| `V-019` | `Session.manual_delete` | `EC-ENTRY-02` | Sesión ya borrada vs base obsoleta | `transicion_invalida` / `conflicto` | error local o `refresh + retry` | Puede afectar lectura Q8 |
-| `V-020` | `open_main_screen` | `EC-READ-04` | Arranque sin selección; cargas diferidas obligatorias | `validacion` | corregir triggers de carga | No es conflicto, sí edge de sync/coste |
-| `V-021` | `ui.manual_refresh` | `EC-READ-01` | Reconciliación de estado visible tras error/conflicto | `conflicto` | `refresh` manual ejecutado por usuario | Núcleo del MVP sin realtime |
-| `V-022` | `ui.select_year` | `EC-READ-05` | Merge Q3+Q4 por `week_number`; limpiar selección local | `validacion` / `conflicto` | corregir orden o `refresh` | Q5/Q8 no cargan hasta nueva selección |
-| `V-023` | `ui.select_week` | `EC-READ-04` | No debe cargar sesiones (Q8) todavía | `validacion` | corregir triggers de lectura | Carga Q5 solamente |
+| `V-019` | `Session.manual_delete` | `EC-ENTRY-02` | SesiÃ³n ya borrada vs base obsoleta | `transicion_invalida` / `conflicto` | error local o `refresh + retry` | Puede afectar lectura Q8 |
+| `V-020` | `open_main_screen` | `EC-READ-04` | Arranque sin selecciÃ³n; cargas diferidas obligatorias | `validacion` | corregir triggers de carga | No es conflicto, sÃ­ edge de sync/coste |
+| `V-021` | `ui.manual_refresh` | `EC-READ-01` | ReconciliaciÃ³n de estado visible tras error/conflicto | `conflicto` | `refresh` manual ejecutado por usuario | NÃºcleo del MVP sin realtime |
+| `V-022` | `ui.select_year` | `EC-READ-05` | Merge Q3+Q4 por `week_number`; limpiar selecciÃ³n local | `validacion` / `conflicto` | corregir orden o `refresh` | Q5/Q8 no cargan hasta nueva selecciÃ³n |
+| `V-023` | `ui.select_week` | `EC-READ-04` | No debe cargar sesiones (Q8) todavÃ­a | `validacion` | corregir triggers de lectura | Carga Q5 solamente |
 | `V-024` | `ui.select_entry` | `EC-READ-03` | Carga Q8 y coexistencia con activa global en otra entry | `conflicto` / `validacion` | `refresh` si base obsoleta; si no, flujo normal | Foco vs activo |
 | `V-025` | `Q6 active_session_global` | `EC-READ-03` | Activa global obsoleta / ausente / distinta de foco | `conflicto` | `refresh` manual | `ended_at_utc == null`, `limit 1` |
 | `V-026` | `Q7 active_entry_doc_if_needed` | `EC-READ-03` | Label del activo externo no resoluble por doc obsoleto | `conflicto` / `validacion` | `refresh` manual; fallback de UI | Condicional |
@@ -168,118 +167,118 @@ No incluye:
 
 ### `severidad` (4 niveles)
 
-- `critical`: rompe invariantes centrales o puede ocultar corrupción/estado
-  engañoso severo.
+- `critical`: rompe invariantes centrales o puede ocultar corrupciÃ³n/estado
+  engaÃ±oso severo.
 - `high`: comportamiento incorrecto relevante del flujo principal con alta
-  fricción/riesgo.
+  fricciÃ³n/riesgo.
 - `medium`: inconsistencia recuperable con impacto acotado o caso menos
   frecuente.
-- `low`: edge case controlado/no-op/recuperación clara con impacto menor.
+- `low`: edge case controlado/no-op/recuperaciÃ³n clara con impacto menor.
 
 ### `impacto` (texto corto obligatorio)
 
-Usar una línea breve y concreta, por ejemplo:
+Usar una lÃ­nea breve y concreta, por ejemplo:
 
-- `invariante de sesión activa global`
+- `invariante de sesiÃ³n activa global`
 - `consistencia visual de foco vs activo`
 - `integridad de totales de recursos`
 - `temporal + cursor derivado`
-- `recuperación on-demand refresh`
+- `recuperaciÃ³n on-demand refresh`
 
 ### `prioridad_verificacion`
 
-- `P0`: crítico para MVP; debe aparecer en `#19`; su ausencia de cobertura
+- `P0`: crÃ­tico para MVP; debe aparecer en `#19`; su ausencia de cobertura
   bloquea `#20`.
-- `P1`: importante antes del gate, pero no bloquea por sí solo si el conjunto
-  crítico está cubierto.
-- `P2`: cobertura recomendada / regresión posterior.
+- `P1`: importante antes del gate, pero no bloquea por sÃ­ solo si el conjunto
+  crÃ­tico estÃ¡ cubierto.
+- `P2`: cobertura recomendada / regresiÃ³n posterior.
 
-## Casos críticos mínimos a verificar en el MVP
+## Casos crÃ­ticos mÃ­nimos a verificar en el MVP
 
-### Regla de selección (`I17-S3`)
+### Regla de selecciÃ³n (`I17-S3`)
 
 1. Incluir **todos los `P0`** de la matriz principal.
-1. Si una familia no tiene `P0`, añadir al menos un `P1` representativo.
-1. Mapear explícitamente cada caso crítico a `#19` como insumo de pruebas.
+1. Si una familia no tiene `P0`, aÃ±adir al menos un `P1` representativo.
+1. Mapear explÃ­citamente cada caso crÃ­tico a `#19` como insumo de pruebas.
 
-### Tabla 4 — Casos críticos MVP (`I17-S3`)
+### Tabla 4 â€” Casos crÃ­ticos MVP (`I17-S3`)
 
 | `edge_case_id` | `motivo_criticidad` | `prioridad_verificacion` | `bloquea_#20` | `relacion_con_#19` | `notas` |
 | --- | --- | --- | --- | --- | --- |
-| `EC-SESSION-01` | Conflicto en `start` compuesto (`auto-stop + start`) con riesgo sobre unicidad de sesión activa | `P0` | Sí | Debe convertirse en caso de prueba de operación compuesta y recuperación | Flujo principal |
-| `EC-SESSION-06` | Side-effects `auto-stop` embebidos en operaciones compuestas (`Entry.delete` / `Week.close\|reclose`) | `P0` | Sí | Requiere pruebas de conflicto en compuestos con efecto observable | Cruza `#12` y `#14` |
-| `EC-WEEK-02` | Cambio de estado de week + recálculo de `week_cursor` bajo conflicto | `P0` | Sí | Caso de prueba de consistencia temporal y refresh | Afecta `current week` |
-| `EC-WEEK-03` | Invariante crítica: no dejar `0` weeks abiertas | `P0` | Sí | Debe probarse como validación bloqueante | Temporal/cursor |
-| `EC-RESOURCE-02` | Conflicto sobre deltas/totales de recursos con riesgo de pérdida de consistencia | `P0` | Sí | Caso de prueba de recursos con base obsoleta | `Entry.resource_deltas` + `campaign.resource_totals` |
-| `EC-RESOURCE-03` | Drift/inconsistencia detectada y clasificación correcta como conflicto | `P0` | Sí | Caso de integridad y recuperación `refresh` | Si persiste tras refresh, escalar |
-| `EC-TEMPORAL-01` | Extensión de año con duplicados/base obsoleta; riesgo estructural alto | `P0` | Sí | Caso de temporal estructural y atomicidad observable | `+1` año |
-| `EC-READ-01` | `ui.manual_refresh` como mecanismo central de reconciliación MVP | `P0` | Sí | Caso de recuperación transversal post-conflicto | Sin realtime |
-| `EC-READ-03` | Coherencia foco vs activo (Q6/Q7 + selección) en flujo principal | `P0` | Sí | Caso de consistencia visible cruzando `#14` + `#16` | Activo en otra entry |
+| `EC-SESSION-01` | Conflicto en `start` compuesto (`auto-stop + start`) con riesgo sobre unicidad de sesiÃ³n activa | `P0` | SÃ­ | Debe convertirse en caso de prueba de operaciÃ³n compuesta y recuperaciÃ³n | Flujo principal |
+| `EC-SESSION-06` | Side-effects `auto-stop` embebidos en operaciones compuestas (`Entry.delete` / `Week.close\|reclose`) | `P0` | SÃ­ | Requiere pruebas de conflicto en compuestos con efecto observable | Cruza `#12` y `#14` |
+| `EC-WEEK-02` | Cambio de estado de week + recÃ¡lculo de `week_cursor` bajo conflicto | `P0` | SÃ­ | Caso de prueba de consistencia temporal y refresh | Afecta `current week` |
+| `EC-WEEK-03` | Invariante crÃ­tica: no dejar `0` weeks abiertas | `P0` | SÃ­ | Debe probarse como validaciÃ³n bloqueante | Temporal/cursor |
+| `EC-RESOURCE-02` | Conflicto sobre deltas/totales de recursos con riesgo de pÃ©rdida de consistencia | `P0` | SÃ­ | Caso de prueba de recursos con base obsoleta | `Entry.resource_deltas` + `campaign.resource_totals` |
+| `EC-RESOURCE-03` | Drift/inconsistencia detectada y clasificaciÃ³n correcta como conflicto | `P0` | SÃ­ | Caso de integridad y recuperaciÃ³n `refresh` | Si persiste tras refresh, escalar |
+| `EC-TEMPORAL-01` | ExtensiÃ³n de aÃ±o con duplicados/base obsoleta; riesgo estructural alto | `P0` | SÃ­ | Caso de temporal estructural y atomicidad observable | `+1` aÃ±o |
+| `EC-READ-01` | `ui.manual_refresh` como mecanismo central de reconciliaciÃ³n MVP | `P0` | SÃ­ | Caso de recuperaciÃ³n transversal post-conflicto | Sin realtime |
+| `EC-READ-03` | Coherencia foco vs activo (Q6/Q7 + selecciÃ³n) en flujo principal | `P0` | SÃ­ | Caso de consistencia visible cruzando `#14` + `#16` | Activo en otra entry |
 | `EC-READ-02` | Orden provisional/final de sesiones con timestamps pendientes (`Q8`) | `P1` | No | Incluir como cobertura de orden estable en `#19` | Cubre `#18` en lecturas |
-| `EC-ENTRY-01` | Reordenación con base de orden obsoleta | `P1` | No (si hay cobertura alternativa de flujo) | Caso de concurrencia de orden en entries | Recomendada antes de `#20` |
-| `EC-ENTRY-02` | `Entry.update/delete` sobre entry obsoleta o inexistente | `P1` | No | Caso de clasificación conflicto vs transición inválida | Cobertura de lifecycle |
+| `EC-ENTRY-01` | ReordenaciÃ³n con base de orden obsoleta | `P1` | No (si hay cobertura alternativa de flujo) | Caso de concurrencia de orden en entries | Recomendada antes de `#20` |
+| `EC-ENTRY-02` | `Entry.update/delete` sobre entry obsoleta o inexistente | `P1` | No | Caso de clasificaciÃ³n conflicto vs transiciÃ³n invÃ¡lida | Cobertura de lifecycle |
 
-## Alineación con `#12`, `#14`, `#15`, `#16`, `#18`
+## AlineaciÃ³n con `#12`, `#14`, `#15`, `#16`, `#18`
 
-### `#12` — Contrato de operaciones Firestore por agregado
+### `#12` â€” Contrato de operaciones Firestore por agregado
 
 1. `#17` no redefine pre/postcondiciones ni atomicidad de comportamiento.
 1. `#17` traduce ese contrato a escenarios verificables (incluyendo compuestos).
-1. La tabla de variantes referencia operaciones de `#12` como cobertura mínima.
+1. La tabla de variantes referencia operaciones de `#12` como cobertura mÃ­nima.
 
-### `#14` — Flujo de sesión activa y `auto-stop`
+### `#14` â€” Flujo de sesiÃ³n activa y `auto-stop`
 
 1. `#17` reutiliza el modelo de estados/errores del flujo (`conflicto`,
    `transicion_invalida`, `validacion`).
 1. Los casos `session_flow` y `critical_reads_refresh_order` deben respetar la
-   separación foco vs activo y la recuperación `refresh` manual + reintentar.
+   separaciÃ³n foco vs activo y la recuperaciÃ³n `refresh` manual + reintentar.
 
-### `#15` — Validación y recálculo de recursos
+### `#15` â€” ValidaciÃ³n y recÃ¡lculo de recursos
 
-1. `#17` reutiliza la clasificación de recursos:
+1. `#17` reutiliza la clasificaciÃ³n de recursos:
    - total negativo => `validacion`
    - base obsoleta => `conflicto`
    - drift => `conflicto`
    - no-ops idempotentes => sin error
 1. No se reabre el modelo de recursos de `#40`.
 
-### `#16` — Consultas mínimas de pantalla principal
+### `#16` â€” Consultas mÃ­nimas de pantalla principal
 
-1. `#17` cubre solo lecturas críticas ligadas a sincronización/consistencia.
+1. `#17` cubre solo lecturas crÃ­ticas ligadas a sincronizaciÃ³n/consistencia.
 1. `#17` no reactiva `timeline_entries_flat`; se mantiene fuera del MVP actual.
 1. `#17` usa Q1..Q8 y triggers de `#16` como base para los casos de lectura.
 
-### `#18` — Timestamps y orden estable
+### `#18` â€” Timestamps y orden estable
 
-1. `#17` no redefine tuplas canónicas de orden.
+1. `#17` no redefine tuplas canÃ³nicas de orden.
 1. `#17` solo verifica edge cases derivados:
    - orden provisional por `serverTimestamp` pendiente;
-   - estabilización tras refresh;
-   - consistencia visible de listas críticas.
+   - estabilizaciÃ³n tras refresh;
+   - consistencia visible de listas crÃ­ticas.
 
-## Casos de aceptación / verificación documental
+## Casos de aceptaciÃ³n / verificaciÃ³n documental
 
 1. La matriz final incluye las 6 familias obligatorias y cubre sesiones,
-   entries, recursos, temporal y lecturas críticas.
-1. La matriz principal contiene al menos los 23 escenarios canónicos con IDs
+   entries, recursos, temporal y lecturas crÃ­ticas.
+1. La matriz principal contiene al menos los 23 escenarios canÃ³nicos con IDs
    `EC-*` fijados.
-1. Cada escenario tiene expectativa verificable, clasificación y recuperación
+1. Cada escenario tiene expectativa verificable, clasificaciÃ³n y recuperaciÃ³n
    esperada.
 1. La tabla de variantes cubre todas las operaciones/eventos obligatorios.
-1. El subset crítico incluye todos los `P0` y mapea insumos hacia `#19`.
+1. El subset crÃ­tico incluye todos los `P0` y mapea insumos hacia `#19`.
 1. `#17` no contradice `#12/#14/#15/#16/#18/#37/#40`.
 1. `timeline_entries_flat` solo aparece, si se menciona, como no activado en el
    MVP actual de `#16`.
 
-## Riesgos, límites y decisiones diferidas
+## Riesgos, lÃ­mites y decisiones diferidas
 
-- La matriz documenta escenarios y expectativas, pero no sustituye el diseño de
+- La matriz documenta escenarios y expectativas, pero no sustituye el diseÃ±o de
   pruebas detallado de `#19`.
-- Algunas clasificaciones canónicas se marcan como `mixta` para evitar explotar
-  filas; la clasificación final se cierra en la tabla de variantes.
+- Algunas clasificaciones canÃ³nicas se marcan como `mixta` para evitar explotar
+  filas; la clasificaciÃ³n final se cierra en la tabla de variantes.
 - El comportamiento exacto de mensajes UI (toast/inline/modal) sigue fuera de
-  alcance; aquí se fija recuperación, no diseño visual.
-- Si el MVP amplía lecturas o reactiva `timeline_entries_flat`, `#17` deberá
+  alcance; aquÃ­ se fija recuperaciÃ³n, no diseÃ±o visual.
+- Si el MVP amplÃ­a lecturas o reactiva `timeline_entries_flat`, `#17` deberÃ¡
   extender la familia `critical_reads_refresh_order`.
 
 ## Referencias
@@ -303,3 +302,4 @@ Usar una línea breve y concreta, por ejemplo:
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/17`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/19`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/20`
+

--- a/docs/conflict-policy.md
+++ b/docs/conflict-policy.md
@@ -6,7 +6,7 @@
 - `purpose`: Definir la polÃ­tica de resoluciÃ³n de conflictos concurrentes del MVP.
 - `status`: active
 - `source_of_truth`: official
-- `last_updated`: 2026-02-24
+- `last_updated`: 2026-03-05
 - `next_review`: 2026-03-10
 
 ## Objetivo
@@ -57,7 +57,6 @@ No incluye:
 | `Entry.reorder_within_week` | `week` + `entry` | Medio/Alto | `rechazar` | `refrescar` + `reintentar` | Resecuencia densa `1..N`; detalle contractual en #12 |
 | `Session.manual_create/update/delete` | `session` + `campaign` | Alto | `rechazar` | `refrescar` + `reintentar` | Mantener `0..1` sesiÃ³n activa global; detalle contractual en #12 |
 | Borrado de `Entry` activa (con cascada) | `entry` + `session` + `campaign` | Alto | `rechazar` | `refrescar` + `reintentar` | Incluye auto-stop; borra `sessions` y elimina `resource_deltas` embebidos con la `Entry`; contrato tÃ©cnico en #12 |
-| EdiciÃ³n de `Week.notes` | `week` | Medio | `rechazar` | `refrescar` + reingresar cambios | No usar `last-write-wins` en MVP |
 | `Entry.adjust_resource_delta` | `entry` (+ totales derivados) | Medio/Alto | `rechazar` | `refrescar` + `reintentar` | Ajusta delta neto en `Entry.resource_deltas`; valida totales finales no negativos |
 | `Entry.set_resource_delta` | `entry` (+ totales derivados) | Alto | `rechazar` | `refrescar` + `reintentar` | EdiciÃ³n manual directa del delta neto; opera sobre `Entry` y totales |
 | `Entry.clear_resource_delta` | `entry` (+ totales derivados) | Medio/Alto | `rechazar` | `refrescar` + `reintentar` | Elimina clave del mapa (`delta -> 0`); rechazar si base estÃ¡ obsoleta |
@@ -106,9 +105,6 @@ No incluye:
 - Dos dispositivos intentan iniciar sesiÃ³n activa casi a la vez.
   - Resultado MVP: uno de los intentos puede quedar invÃ¡lido tras refresco;
     conflicto se resuelve por rechazo y reintento.
-- Un dispositivo cierra una `Week` mientras otro edita `Week.notes`.
-  - Resultado MVP: la ediciÃ³n depende del estado actual; si el estado cambiÃ³ de
-    forma incompatible, se rechaza y se refresca.
 - Un dispositivo reabre una `Week` mientras otro la re-cierra o cierra una week
   distinta que afecta al `week_cursor`.
   - Resultado MVP: una de las operaciones puede quedar obsoleta; se rechaza y
@@ -166,4 +162,6 @@ No incluye:
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/15`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/18`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/17`
+
+
 

--- a/docs/context-governance.md
+++ b/docs/context-governance.md
@@ -6,7 +6,7 @@
 - `purpose`: Gobierno de contexto, gate de calidad y estado verificable.
 - `status`: active
 - `source_of_truth`: official
-- `last_updated`: 2026-03-02
+- `last_updated`: 2026-03-05
 - `next_review`: 2026-03-13
 
 ## Alcance de Fase 0
@@ -212,6 +212,48 @@ Se valida:
   - Cada tile expone `subir/bajar/eliminar/editar notas` por icono.
   - Se añade persistencia de `Entry.notes` y `Entry.scenario_outcome` (read-only en UI para outcome).
   - Se elimina selector externo de entries y comportamiento sticky al cambiar semana/año.
+
+### Hito H1-07
+
+- Fecha: 2026-03-05
+- Objetivo: adaptar la shell principal a tablet (compactación visual, acciones
+  flotantes y barra inferior solo de recursos) y retirar `Week.update_notes` de
+  runtime + documentación activa.
+- Resultado: completado
+- Verificación A: aprobado (estructura de código/documentación actualizada en
+  UI, estado, lecturas y writes)
+- Verificación B: aprobado (compilación completa de `src` y búsqueda sin
+  referencias activas a `Week.update_notes`/`Week.notes` en contratos MVP)
+- Evidencia:
+  - `src/frosthaven_campaign_journal/ui/main_shell/view/temporal_bar.py`
+  - `src/frosthaven_campaign_journal/ui/main_shell/view/shell_view.py`
+  - `src/frosthaven_campaign_journal/ui/main_shell/view/center_focus.py`
+  - `src/frosthaven_campaign_journal/ui/main_shell/view/center_panel.py`
+  - `src/frosthaven_campaign_journal/ui/main_shell/view/status_bar.py`
+  - `src/frosthaven_campaign_journal/ui/common/resources/groups.py`
+  - `src/frosthaven_campaign_journal/ui/common/resources/resource_total_row.py`
+  - `src/frosthaven_campaign_journal/models/__init__.py`
+  - `src/frosthaven_campaign_journal/data/main_screen_reads.py`
+  - `src/frosthaven_campaign_journal/data/week_writes.py`
+  - `docs/firestore-operation-contract.md`
+  - `docs/conflict-policy.md`
+  - `docs/editability-policy.md`
+  - `docs/minimal-read-queries.md`
+  - `docs/timestamp-order-policy.md`
+  - `docs/concurrency-sync-edge-case-matrix.md`
+  - `docs/ui-main-shell-architecture-mvs.md`
+  - `docs/resource-ui-catalog.md`
+  - `docs/decision-log.md` (DEC-0045)
+- Resumen:
+  - Barra superior con fondo visible y controles temporales compactados.
+  - Acciones semanales movidas a menú flotante contextual con `Crear`,
+    `Cerrar/Reabrir/Recerrar` y `Refrescar`.
+  - Cabecera de semana eliminada del visor y metadatos redundantes retirados en
+    tarjetas de entry.
+  - Barra inferior simplificada a recursos totales (sin estado textual),
+    incluyendo orden visual `Otros -> Materiales -> Plantas`.
+  - Soporte de notas de semana eliminado de modelos, estado, writes y contratos
+    activos del MVP.
 
 
 ## Conocimiento migrado desde legado

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -6,7 +6,7 @@
 - `purpose`: Registrar decisiones con trazabilidad y precedencia.
 - `status`: active
 - `source_of_truth`: official
-- `last_updated`: 2026-03-04
+- `last_updated`: 2026-03-05
 - `next_review`: 2026-03-12
 
 ## Formato canónico por entrada
@@ -1019,3 +1019,43 @@
   `assets/resource-icons/`,
   `docs/resource-ui-catalog.md`,
   `docs/domain-glossary.md`
+
+### DEC-0045
+
+- `date`: 2026-03-05
+- `status`: accepted
+- `problem`: la UI del shell principal en tablet no mantenía densidad útil
+  (barra superior y visor central), el bloque de estado inferior ocupaba espacio
+  crítico y el soporte de notas de semana dejó de ser necesario para el flujo
+  objetivo.
+- `decision`: rediseñar la shell para tablet con acciones contextuales en botón
+  flotante (`+`), eliminar la cabecera de semana y metadatos redundantes por
+  entry, mantener solo recursos totales en barra inferior (orden visual:
+  `Otros -> Materiales -> Plantas`) y retirar por completo `Week.update_notes`
+  del runtime y de los contratos activos del MVP.
+- `rationale`: prioriza legibilidad y acciones frecuentes en viewport reducido,
+  simplifica el modelo operativo semanal y elimina una vía de edición que ya no
+  aporta valor al flujo de juego.
+- `impact`: se compacta la barra temporal superior, se sustituye la fila de
+  refresco por menú flotante contextual, se simplifica el visor semanal,
+  desaparece el estado textual de la barra inferior, se actualiza el modelo
+  (`WeekRead`/`WeekSummary`) sin notas de semana y se alinea la documentación
+  oficial eliminando referencias activas a `Week.update_notes`.
+- `references`: `src/frosthaven_campaign_journal/ui/main_shell/view/temporal_bar.py`,
+  `src/frosthaven_campaign_journal/ui/main_shell/view/shell_view.py`,
+  `src/frosthaven_campaign_journal/ui/main_shell/view/center_focus.py`,
+  `src/frosthaven_campaign_journal/ui/main_shell/view/center_panel.py`,
+  `src/frosthaven_campaign_journal/ui/main_shell/view/status_bar.py`,
+  `src/frosthaven_campaign_journal/ui/common/resources/groups.py`,
+  `src/frosthaven_campaign_journal/ui/common/resources/resource_total_row.py`,
+  `src/frosthaven_campaign_journal/models/__init__.py`,
+  `src/frosthaven_campaign_journal/data/main_screen_reads.py`,
+  `src/frosthaven_campaign_journal/data/week_writes.py`,
+  `docs/firestore-operation-contract.md`,
+  `docs/conflict-policy.md`,
+  `docs/editability-policy.md`,
+  `docs/minimal-read-queries.md`,
+  `docs/timestamp-order-policy.md`,
+  `docs/concurrency-sync-edge-case-matrix.md`,
+  `docs/resource-ui-catalog.md`,
+  `docs/ui-main-shell-architecture-mvs.md`

--- a/docs/editability-policy.md
+++ b/docs/editability-policy.md
@@ -1,51 +1,51 @@
-# Política de Editabilidad Manual y Correcciones (MVP)
+﻿# PolÃ­tica de Editabilidad Manual y Correcciones (MVP)
 
 ## Metadatos
 
 - `doc_id`: DOC-EDITABILITY-POLICY
-- `purpose`: Definir la política de editabilidad manual del MVP ("como papel") y las correcciones de orden, estado y sesiones que actualizan invariantes del dominio antes del contrato Firestore por agregado.
+- `purpose`: Definir la polÃ­tica de editabilidad manual del MVP ("como papel") y las correcciones de orden, estado y sesiones que actualizan invariantes del dominio antes del contrato Firestore por agregado.
 - `status`: active
 - `source_of_truth`: official
-- `last_updated`: 2026-02-24
+- `last_updated`: 2026-03-05
 - `next_review`: 2026-03-10
 
 ## Objetivo
 
-Cerrar una decisión marco de dominio para el MVP que permita correcciones
-manuales amplias ("como papel"), manteniendo consistencia explícita en
-invariantes críticos y dejando trazado el impacto sobre las Issues `#12`, `#14`,
+Cerrar una decisiÃ³n marco de dominio para el MVP que permita correcciones
+manuales amplias ("como papel"), manteniendo consistencia explÃ­cita en
+invariantes crÃ­ticos y dejando trazado el impacto sobre las Issues `#12`, `#14`,
 `#15`, `#17` y `#19`.
 
 ## Alcance y no alcance
 
 Incluye:
 
-- reordenación manual de `Entry` dentro de una misma `Week`;
-- corrección manual de `Week.status` (`reopen`/`reclose`);
+- reordenaciÃ³n manual de `Entry` dentro de una misma `Week`;
+- correcciÃ³n manual de `Week.status` (`reopen`/`reclose`);
 - correcciones manuales completas de `Session` (crear/editar/borrar,
   incluyendo timestamps);
-- política derivada de semana actual (primera `Week` abierta) como concepto no persistido;
-- matriz de operaciones manuales permitidas y sus límites;
-- impacto documental sobre dominio, conflictos y orden técnico downstream.
+- polÃ­tica derivada de semana actual (primera `Week` abierta) como concepto no persistido;
+- matriz de operaciones manuales permitidas y sus lÃ­mites;
+- impacto documental sobre dominio, conflictos y orden tÃ©cnico downstream.
 
 No incluye:
 
 - contrato Firestore por agregado (Issue `#12`);
-- política de timestamps y desempates (Issue `#18`);
-- diseño de UI detallado de flujos y pantallas (Issues `#14`, `#16`);
-- implementación de código de app.
+- polÃ­tica de timestamps y desempates (Issue `#18`);
+- diseÃ±o de UI detallado de flujos y pantallas (Issues `#14`, `#16`);
+- implementaciÃ³n de cÃ³digo de app.
 
 ## Entradas y prerrequisitos
 
 - `docs/domain-glossary.md` (modelo de dominio e invariantes actuales)
-- `docs/conflict-policy.md` (política de conflictos concurrentes MVP)
-- `docs/campaign-temporal-controls.md` (controles temporales y semántica temporal)
-- `docs/campaign-temporal-initialization.md` (estructura temporal y provisión)
+- `docs/conflict-policy.md` (polÃ­tica de conflictos concurrentes MVP)
+- `docs/campaign-temporal-controls.md` (controles temporales y semÃ¡ntica temporal)
+- `docs/campaign-temporal-initialization.md` (estructura temporal y provisiÃ³n)
 - Decisiones de Kiko para esta issue marco:
-  - reordenación manual de `Entry`: sí, con operación "mover una entry";
-  - alcance de reordenación: solo dentro de la misma `Week`;
+  - reordenaciÃ³n manual de `Entry`: sÃ­, con operaciÃ³n "mover una entry";
+  - alcance de reordenaciÃ³n: solo dentro de la misma `Week`;
   - `order_index`: secuencia densa `1..N`;
-  - `Week.reopen/reclose`: sí;
+  - `Week.reopen/reclose`: sÃ­;
   - correcciones manuales de `Session`: completo (crear/editar/borrar, con timestamps);
   - semana actual derivada: primera `Week` abierta (menor `week_number` entre abiertas);
   - borrado para `#12`: hard delete real (insumo downstream);
@@ -56,67 +56,65 @@ No incluye:
 
 1. El MVP prioriza permitir correcciones manuales amplias para trabajar "como en
    papel", pero con mayor orden y trazabilidad.
-1. La editabilidad amplia no elimina invariantes críticos; los redefine de
-   forma explícita cuando sea necesario.
+1. La editabilidad amplia no elimina invariantes crÃ­ticos; los redefine de
+   forma explÃ­cita cuando sea necesario.
 1. Las correcciones manuales se documentan primero a nivel de dominio; el
-   contrato Firestore por agregado se define después en la Issue `#12`.
-1. La política de conflictos concurrentes del MVP sigue siendo de rechazo con
-   `refresco` y `reintento`; esta decisión actualiza qué operaciones existen y
-   qué precondiciones funcionales aplican.
+   contrato Firestore por agregado se define despuÃ©s en la Issue `#12`.
+1. La polÃ­tica de conflictos concurrentes del MVP sigue siendo de rechazo con
+   `refresco` y `reintento`; esta decisiÃ³n actualiza quÃ© operaciones existen y
+   quÃ© precondiciones funcionales aplican.
 
 ## Matriz de operaciones manuales permitidas (MVP)
 
-| Operación manual | Agregado principal | Permitida en MVP | Alcance | Notas |
+| OperaciÃ³n manual | Agregado principal | Permitida en MVP | Alcance | Notas |
 | --- | --- | --- | --- | --- |
-| `Entry.reorder_within_week` | `week` + `entry` | Sí | Mover una `Entry` dentro de la misma `Week` | Resecuencia `order_index` densa `1..N` |
-| `Entry.update` | `entry` | Sí | Amplio (campos funcionales de `Entry`) | Contrato detallado en `#12`; no cambia de `Week` aquí |
-| `Week.update_notes` | `week` | Sí | Weeks abiertas o cerradas | Editabilidad de contenido amplia |
-| `Week.reopen` | `week` + `campaign` | Sí | `closed -> open` | Recalcula la semana actual derivada |
-| `Week.reclose` | `week` + `campaign` | Sí | `open -> closed` | Recalcula la semana actual derivada |
-| `Session.manual_create` | `session` + `campaign` | Sí | Histórica o activa | Preserva `0..1` sesión activa global |
-| `Session.manual_update` | `session` + `campaign` | Sí | Corrección de timestamps y estado | Preserva `0..1` sesión activa global |
-| `Session.manual_delete` | `session` + `campaign` | Sí | Borrado real | Preserva `0..1` sesión activa global |
-| `Entry.adjust/set/clear_resource_delta` | `entry` | Sí | Weeks abiertas o cerradas | Edita `Entry.resource_deltas` (delta neto por recurso) con validación de totales no negativos |
+| `Entry.reorder_within_week` | `week` + `entry` | SÃ­ | Mover una `Entry` dentro de la misma `Week` | Resecuencia `order_index` densa `1..N` |
+| `Entry.update` | `entry` | SÃ­ | Amplio (campos funcionales de `Entry`) | Contrato detallado en `#12`; no cambia de `Week` aquÃ­ |
+| `Week.reopen` | `week` + `campaign` | SÃ­ | `closed -> open` | Recalcula la semana actual derivada |
+| `Week.reclose` | `week` + `campaign` | SÃ­ | `open -> closed` | Recalcula la semana actual derivada |
+| `Session.manual_create` | `session` + `campaign` | SÃ­ | HistÃ³rica o activa | Preserva `0..1` sesiÃ³n activa global |
+| `Session.manual_update` | `session` + `campaign` | SÃ­ | CorrecciÃ³n de timestamps y estado | Preserva `0..1` sesiÃ³n activa global |
+| `Session.manual_delete` | `session` + `campaign` | SÃ­ | Borrado real | Preserva `0..1` sesiÃ³n activa global |
+| `Entry.adjust/set/clear_resource_delta` | `entry` | SÃ­ | Weeks abiertas o cerradas | Edita `Entry.resource_deltas` (delta neto por recurso) con validaciÃ³n de totales no negativos |
 
 ## Reglas por agregado
 
 ### `Entry` / orden del timeline
 
-1. Se permite reordenación manual de `Entry` en el MVP.
-1. La operación funcional documentada es **mover una `Entry`** a una nueva
-   posición dentro de la **misma `Week`**.
-1. No se permite mover `Entry` entre weeks en esta decisión.
-1. Tras una reordenación válida, `order_index` se recalcula a secuencia **densa
+1. Se permite reordenaciÃ³n manual de `Entry` en el MVP.
+1. La operaciÃ³n funcional documentada es **mover una `Entry`** a una nueva
+   posiciÃ³n dentro de la **misma `Week`**.
+1. No se permite mover `Entry` entre weeks en esta decisiÃ³n.
+1. Tras una reordenaciÃ³n vÃ¡lida, `order_index` se recalcula a secuencia **densa
    `1..N`** dentro de la `Week`.
 1. Rechazos esperados a nivel funcional:
    - `Entry` inexistente o ya borrada;
    - `Week` de referencia inconsistente;
-   - colisión o resecuenciación imposible por estado obsoleto concurrente.
+   - colisiÃ³n o resecuenciaciÃ³n imposible por estado obsoleto concurrente.
 
-### `Week` / estado y notas
+### `Week` / estado
 
-1. `Week.notes` es editable tanto en `open` como en `closed`.
-1. Se permite corrección manual de `Week.status`:
+1. Se permite correcciÃ³n manual de `Week.status`:
    - `Week.reopen`: `closed -> open`
    - `Week.reclose`: `open -> closed`
 1. Las operaciones de estado (`reopen/reclose`) son correcciones manuales
-   explícitas y no equivalen a navegación temporal.
+   explÃ­citas y no equivalen a navegaciÃ³n temporal.
 1. Las operaciones que dependan de `Week.status=open` deben declararlo
-   explícitamente en sus contratos (`#12`, `#14`, `#15`).
+   explÃ­citamente en sus contratos (`#12`, `#14`, `#15`).
 
 ### `Session`
 
 1. Se permiten correcciones manuales completas:
-   - crear sesión manualmente;
-   - editar sesión manualmente;
-   - borrar sesión manualmente.
-1. La edición manual incluye, como mínimo, corrección de timestamps
+   - crear sesiÃ³n manualmente;
+   - editar sesiÃ³n manualmente;
+   - borrar sesiÃ³n manualmente.
+1. La ediciÃ³n manual incluye, como mÃ­nimo, correcciÃ³n de timestamps
    (`started_at_utc`, `ended_at_utc`).
-1. Se mantiene la invariante de `0..1` `Session` activa global en la campaña.
-1. Si una corrección manual produciría más de una sesión activa global, la
-   operación debe rechazarse.
+1. Se mantiene la invariante de `0..1` `Session` activa global en la campaÃ±a.
+1. Si una correcciÃ³n manual producirÃ­a mÃ¡s de una sesiÃ³n activa global, la
+   operaciÃ³n debe rechazarse.
 1. `auto-stop` sigue existiendo como comportamiento de `Session.start` (flujo
-   normal), pero las correcciones manuales no deben introducir cambios implícitos
+   normal), pero las correcciones manuales no deben introducir cambios implÃ­citos
    opacos; el contrato detallado se fija en `#12` y el flujo en `#14`.
 
 ### Recursos en `Entry` (`resource_deltas`)
@@ -124,30 +122,30 @@ No incluye:
 1. La editabilidad de recursos se mantiene en el MVP, pero se expresa sobre
    `Entry.resource_deltas` (delta neto por `resource_key`), no mediante una
    entidad `ResourceChange`.
-1. Se permiten ajustes incrementales (`+/-`), edición manual directa del delta
+1. Se permiten ajustes incrementales (`+/-`), ediciÃ³n manual directa del delta
    neto y limpieza de clave cuando el resultado es `0`.
-1. La política de editabilidad amplia no elimina la validación de totales
+1. La polÃ­tica de editabilidad amplia no elimina la validaciÃ³n de totales
    finales no negativos.
 1. El modelo detallado se define en `docs/resource-delta-model.md` y el
-   contrato de pre/postcondiciones/rechazos en `#12` (parcheado por supersesión
+   contrato de pre/postcondiciones/rechazos en `#12` (parcheado por supersesiÃ³n
    parcial de recursos).
 
 ## Reglas de estado y semana actual derivada (`Week.status`, concepto derivado)
 
-### Política global de semana actual derivada
+### PolÃ­tica global de semana actual derivada
 
 1. La **semana actual** del MVP se define como la **primera `Week` abierta**,
    es decir, la `Week` abierta con **menor `week_number`** entre las weeks
    provisionadas.
-1. Navegar o seleccionar una `Week` para foco/edición no cambia automáticamente
+1. Navegar o seleccionar una `Week` para foco/ediciÃ³n no cambia automÃ¡ticamente
    la semana actual derivada.
 1. La semana actual se trata como un valor derivado de la estructura de weeks
-   abiertas y sus estados, en lugar de una selección manual libre.
-1. **Nota de transición (`#76`)**: la implementación actual todavía
-   persiste/consume `campaign.week_cursor` en código como mecanismo transitorio;
-   la migración técnica para retirarlo se sigue en `#81`.
+   abiertas y sus estados, en lugar de una selecciÃ³n manual libre.
+1. **Nota de transiciÃ³n (`#76`)**: la implementaciÃ³n actual todavÃ­a
+   persiste/consume `campaign.week_cursor` en cÃ³digo como mecanismo transitorio;
+   la migraciÃ³n tÃ©cnica para retirarlo se sigue en `#81`.
 
-### Reglas de recálculo
+### Reglas de recÃ¡lculo
 
 La semana actual derivada se recalcula tras operaciones que puedan cambiar la
 primera week abierta:
@@ -155,14 +153,14 @@ primera week abierta:
 - `Week.close`
 - `Week.reopen`
 - `Week.reclose`
-- provisión inicial / extensión temporal
+- provisiÃ³n inicial / extensiÃ³n temporal
 
-### Relación con el ajuste manual previo de `week_cursor`
+### RelaciÃ³n con el ajuste manual previo de `week_cursor`
 
-1. La semántica de `Campaign.set_week_cursor` como ajuste manual explícito (Issue
-   `#9`) queda **sustituida** en MVP por la política derivada de cursor de esta
-   decisión (`#37`).
-1. El detalle de la transición contractual se alinea en:
+1. La semÃ¡ntica de `Campaign.set_week_cursor` como ajuste manual explÃ­cito (Issue
+   `#9`) queda **sustituida** en MVP por la polÃ­tica derivada de cursor de esta
+   decisiÃ³n (`#37`).
+1. El detalle de la transiciÃ³n contractual se alinea en:
    - `docs/campaign-temporal-controls.md`
    - `docs/campaign-temporal-initialization.md`
    - `#12` (contrato por agregado)
@@ -170,50 +168,50 @@ primera week abierta:
 ### Invariante de existencia de week abierta (soporte de la semana actual)
 
 1. Debe existir al menos una `Week` abierta provisionada para mantener
-   una semana actual derivada válida.
-1. Si una operación (`Week.close`/`Week.reclose`) dejara **0 weeks abiertas**,
-   la operación se rechaza.
+   una semana actual derivada vÃ¡lida.
+1. Si una operaciÃ³n (`Week.close`/`Week.reclose`) dejara **0 weeks abiertas**,
+   la operaciÃ³n se rechaza.
 
 ## Reglas para sesiones manuales
 
 ### `Session.manual_create`
 
-1. Puede crear una sesión histórica (con `ended_at_utc` definido) o activa
+1. Puede crear una sesiÃ³n histÃ³rica (con `ended_at_utc` definido) o activa
    (`ended_at_utc=null`).
-1. Si crea una sesión activa, debe validarse que no exista otra sesión activa
-   global en la campaña.
+1. Si crea una sesiÃ³n activa, debe validarse que no exista otra sesiÃ³n activa
+   global en la campaÃ±a.
 
 ### `Session.manual_update`
 
-1. Permite corregir timestamps de una sesión existente.
-1. Si la corrección cambia el estado a activa (`ended_at_utc=null`), debe
-   validarse la unicidad de sesión activa global.
-1. Si la corrección cambia una sesión activa a cerrada, la sesión deja de contar
+1. Permite corregir timestamps de una sesiÃ³n existente.
+1. Si la correcciÃ³n cambia el estado a activa (`ended_at_utc=null`), debe
+   validarse la unicidad de sesiÃ³n activa global.
+1. Si la correcciÃ³n cambia una sesiÃ³n activa a cerrada, la sesiÃ³n deja de contar
    como activa sin requerir `auto-stop`.
 
 ### `Session.manual_delete`
 
-1. Permite borrar manualmente una sesión histórica o activa.
-1. Si se borra una sesión activa, el resultado debe mantener `0..1` sesiones
+1. Permite borrar manualmente una sesiÃ³n histÃ³rica o activa.
+1. Si se borra una sesiÃ³n activa, el resultado debe mantener `0..1` sesiones
    activas globales (normalmente `0`).
 
 ## Invariantes preservadas y modificadas
 
 ### Invariantes preservadas
 
-- `0..1` `Session` activa global en la campaña.
+- `0..1` `Session` activa global en la campaÃ±a.
 - `week_number` global inmutable.
-- Validación de totales finales no negativos en recursos.
-- Jerarquía temporal `campaign > year > season > week > entry`.
+- ValidaciÃ³n de totales finales no negativos en recursos.
+- JerarquÃ­a temporal `campaign > year > season > week > entry`.
 
 ### Invariantes modificadas / ampliadas
 
-- Se sustituye “sin reordenación manual de `Entry` en MVP” por:
-  - reordenación manual permitida dentro de la misma `Week` con secuencia densa
+- Se sustituye â€œsin reordenaciÃ³n manual de `Entry` en MVPâ€ por:
+  - reordenaciÃ³n manual permitida dentro de la misma `Week` con secuencia densa
     `1..N`.
-- Se amplía la mutabilidad de `Week.status`:
+- Se amplÃ­a la mutabilidad de `Week.status`:
   - se permiten `reopen` y `reclose`.
-- Se amplía la mutabilidad de `Session`:
+- Se amplÃ­a la mutabilidad de `Session`:
   - correcciones manuales completas (crear/editar/borrar).
 - Se redefine la semana actual:
   - pasa a ser la primera `Week` abierta (menor `week_number` abierta).
@@ -222,33 +220,33 @@ primera week abierta:
 
 ### Impacto sobre `docs/conflict-policy.md` / Issue `#8`
 
-- Se añaden/ajustan operaciones concurrentes de:
+- Se aÃ±aden/ajustan operaciones concurrentes de:
   - `Week.reopen`
   - `Week.reclose`
   - correcciones manuales de `Session`
-  - reordenación manual de `Entry`
-- Se mantiene la política de rechazo con `refresco` y `reintento`.
+  - reordenaciÃ³n manual de `Entry`
+- Se mantiene la polÃ­tica de rechazo con `refresco` y `reintento`.
 
 ### Impacto sobre `#12` (contrato Firestore por agregado)
 
-- Añade operaciones y precondiciones nuevas a documentar.
+- AÃ±ade operaciones y precondiciones nuevas a documentar.
 - Debe alinearse con:
   - hard delete real (input ya acordado)
   - `Entry.update` amplio (input ya acordado)
-  - atomicidad descrita como comportamiento (sin técnica obligatoria)
+  - atomicidad descrita como comportamiento (sin tÃ©cnica obligatoria)
 
 ### Impacto sobre `#14`, `#15`, `#17`, `#19`
 
-- `#14`: flujo de sesión activa / `auto-stop` debe coexistir con correcciones
-  manuales de sesión y `Week.reopen/reclose`.
+- `#14`: flujo de sesiÃ³n activa / `auto-stop` debe coexistir con correcciones
+  manuales de sesiÃ³n y `Week.reopen/reclose`.
 - `#15`: reglas de recursos deben considerar editabilidad en weeks cerradas y
   correcciones amplias sobre `Entry.resource_deltas`.
-- `#17`: matriz de edge cases debe incorporar reordenación, reopen/reclose y
-  correcciones manuales de sesión.
+- `#17`: matriz de edge cases debe incorporar reordenaciÃ³n, reopen/reclose y
+  correcciones manuales de sesiÃ³n.
 - `#19`: el plan de pruebas de invariantes debe incluir los nuevos casos de
   cursor derivado y mutabilidad ampliada.
 
-## Casos de aceptación / verificación documental
+## Casos de aceptaciÃ³n / verificaciÃ³n documental
 
 1. **Mover `Entry` dentro de una `Week`**
    - `order_index` queda denso `1..N`.
@@ -259,24 +257,24 @@ primera week abierta:
 1. **Re-cerrar una `Week` reabierta**
    - `Week.status` vuelve a `closed`.
    - la semana actual derivada se recalcula con la misma regla global.
-1. **Corrección manual completa de `Session`**
+1. **CorrecciÃ³n manual completa de `Session`**
    - Se permiten create/edit/delete con timestamps.
-   - No se rompe la invariante `0..1` sesión activa global.
-1. **Límite de cursor válido**
-   - Se rechaza una operación que deje `0` weeks abiertas provisionadas.
-1. **Alineación con conflictos**
+   - No se rompe la invariante `0..1` sesiÃ³n activa global.
+1. **LÃ­mite de cursor vÃ¡lido**
+   - Se rechaza una operaciÃ³n que deje `0` weeks abiertas provisionadas.
+1. **AlineaciÃ³n con conflictos**
    - `docs/conflict-policy.md` queda coherente con la nueva editabilidad.
 1. **Desbloqueo de `#12`**
-   - `#12` puede redactarse con dominio actualizado y trazabilidad explícita.
+   - `#12` puede redactarse con dominio actualizado y trazabilidad explÃ­cita.
 
-## Riesgos y límites
+## Riesgos y lÃ­mites
 
 - Riesgo de ampliar demasiado el alcance de `#12` si no se separa claramente
-  esta decisión de dominio del contrato Firestore.
-- Riesgo de contradicción temporal si no se alinean `#9`, `#13` y esta decisión
-  respecto a la semana actual derivada (históricamente `week_cursor`).
-- Riesgo de aumentar edge cases concurrentes; se asume mitigación mediante la
-  política de rechazo ya vigente en `#8`.
+  esta decisiÃ³n de dominio del contrato Firestore.
+- Riesgo de contradicciÃ³n temporal si no se alinean `#9`, `#13` y esta decisiÃ³n
+  respecto a la semana actual derivada (histÃ³ricamente `week_cursor`).
+- Riesgo de aumentar edge cases concurrentes; se asume mitigaciÃ³n mediante la
+  polÃ­tica de rechazo ya vigente en `#8`.
 
 ## Referencias
 
@@ -295,3 +293,4 @@ primera week abierta:
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/15`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/40`
+

--- a/docs/firestore-operation-contract.md
+++ b/docs/firestore-operation-contract.md
@@ -1,20 +1,20 @@
-# Contrato de Operaciones Firestore por Agregado (MVP)
+﻿# Contrato de Operaciones Firestore por Agregado (MVP)
 
 ## Metadatos
 
 - `doc_id`: DOC-FIRESTORE-OPERATION-CONTRACT
-- `purpose`: Definir el contrato documental de operaciones de escritura por agregado del MVP (precondiciones, validaciones, rechazos y postcondiciones), alineado con sincronización, conflictos, temporalidad y editabilidad.
+- `purpose`: Definir el contrato documental de operaciones de escritura por agregado del MVP (precondiciones, validaciones, rechazos y postcondiciones), alineado con sincronizaciÃ³n, conflictos, temporalidad y editabilidad.
 - `status`: active
 - `source_of_truth`: official
-- `last_updated`: 2026-03-02
+- `last_updated`: 2026-03-05
 - `next_review`: 2026-03-16
 
 ## Objetivo
 
-Cerrar la especificación contractual de operaciones Firestore por agregado para
+Cerrar la especificaciÃ³n contractual de operaciones Firestore por agregado para
 el MVP, de forma que futuras implementaciones tengan reglas claras de dominio,
 rechazo y atomicidad esperada (a nivel de comportamiento) sin adelantar la
-técnica concreta de Firestore.
+tÃ©cnica concreta de Firestore.
 
 ## Alcance y no alcance
 
@@ -24,46 +24,46 @@ Incluye:
   `entry` incluidas mutaciones de `resource_deltas`, `session`);
 - precondiciones, validaciones, postcondiciones y rechazos esperados;
 - operaciones compuestas y atomicidad esperada de comportamiento;
-- alineación explícita con `#13` (temporal) y `#37` (editabilidad);
-- diferenciación entre `conflicto`, `transicion_invalida` y `validacion`.
+- alineaciÃ³n explÃ­cita con `#13` (temporal) y `#37` (editabilidad);
+- diferenciaciÃ³n entre `conflicto`, `transicion_invalida` y `validacion`.
 
 No incluye:
 
-- implementación concreta en Firestore (transacciones, batch, técnica de
+- implementaciÃ³n concreta en Firestore (transacciones, batch, tÃ©cnica de
   precondiciones);
 - consultas/lecturas (`#16`);
 - timestamps/desempates de orden estable (se definen en
   `docs/timestamp-order-policy.md`, Issue `#18`);
-- diseño de UI o flujos de pantalla (`#14`, `#16`);
-- código de app.
+- diseÃ±o de UI o flujos de pantalla (`#14`, `#16`);
+- cÃ³digo de app.
 
 ## Entradas y prerrequisitos
 
 - `docs/sync-strategy.md` (Issue `#7`)
 - `docs/conflict-policy.md` (Issue `#8`)
-- `docs/campaign-temporal-controls.md` (Issue `#9`, con actualización por `#37`)
+- `docs/campaign-temporal-controls.md` (Issue `#9`, con actualizaciÃ³n por `#37`)
 - `docs/campaign-temporal-initialization.md` (Issue `#13`)
 - `docs/editability-policy.md` (Issue `#37`)
-- `docs/resource-delta-model.md` (Issue `#40`, supersesión parcial de recursos)
-- `docs/resource-validation-recalculation.md` (Issue `#15`, detalle de validación y recálculo de recursos)
+- `docs/resource-delta-model.md` (Issue `#40`, supersesiÃ³n parcial de recursos)
+- `docs/resource-validation-recalculation.md` (Issue `#15`, detalle de validaciÃ³n y recÃ¡lculo de recursos)
 - `docs/timestamp-order-policy.md` (Issue `#18`)
 - `docs/domain-glossary.md`
 
 ## Convenciones del contrato
 
-1. Este documento define **comportamiento esperado**, no técnica Firestore.
+1. Este documento define **comportamiento esperado**, no tÃ©cnica Firestore.
 1. `respuesta_cliente_recomendada` distingue:
    - `refrescar + reintentar` para conflictos concurrentes;
-   - error local (sin refresh por defecto) para transiciones inválidas;
-   - corrección de datos/entrada para rechazos de validación.
+   - error local (sin refresh por defecto) para transiciones invÃ¡lidas;
+   - correcciÃ³n de datos/entrada para rechazos de validaciÃ³n.
 1. La **semana actual derivada** (primera `Week` abierta) se expresa como
-   **postcondición derivada** en operaciones que cambian estado de `Week` o
+   **postcondiciÃ³n derivada** en operaciones que cambian estado de `Week` o
    estructura temporal.
-1. **Nota de transición (`#76`)**: la implementación actual todavía persiste/
-   consume `campaign.week_cursor` como mecanismo técnico transitorio; este
-   documento lo trata como detalle de implementación a retirar en `#81`, no
-   como contrato canónico.
-1. `Session` no usa un campo `state`; una sesión activa se define por
+1. **Nota de transiciÃ³n (`#76`)**: la implementaciÃ³n actual todavÃ­a persiste/
+   consume `campaign.week_cursor` como mecanismo tÃ©cnico transitorio; este
+   documento lo trata como detalle de implementaciÃ³n a retirar en `#81`, no
+   como contrato canÃ³nico.
+1. `Session` no usa un campo `state`; una sesiÃ³n activa se define por
    `ended_at_utc = null`.
 1. Ownership de `Session` se deriva de la ruta; no se redefine por campos.
 1. Los cambios de recursos del MVP se modelan como `Entry.resource_deltas`
@@ -78,7 +78,6 @@ No incluye:
   - `Week.close`
   - `Week.reopen`
   - `Week.reclose`
-  - `Week.update_notes`
 - `entry`
   - `Entry.create`
   - `Entry.update`
@@ -99,7 +98,7 @@ No incluye:
 
 - `Campaign.set_week_cursor_manual`
   - estado: **excluida**
-  - motivo: la semántica previa de ajuste manual fue sustituida por la política
+  - motivo: la semÃ¡ntica previa de ajuste manual fue sustituida por la polÃ­tica
     derivada de `week_cursor` definida en `docs/editability-policy.md` (Issue
     `#37`) y alineada en `docs/campaign-temporal-controls.md`.
 
@@ -107,156 +106,154 @@ No incluye:
 
 | operation_id | agregado_principal | agregados_afectados | tipo | disparador | estado_mvp | dependencias_documentales | notas |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `Campaign.provision_initial_years` | `campaign` | `campaign`, `year`, `season`, `week` | `compuesta` | creación/provisión inicial de campaña | `activa` | `#9`, `#13`, `#37` | semana actual derivada como postcondición |
-| `Campaign.extend_years_plus_one` | `campaign` | `campaign`, `year`, `season`, `week` | `compuesta` | acción `+` de año (UI) | `activa` | `#9`, `#13`, `#37` | crea 1 año completo; cursor derivado |
-| `Campaign.set_week_cursor_manual` | `campaign` | `campaign` | `simple` | ajuste manual (semántica histórica) | `excluida` | `#9`, `#37` | semántica sustituida en MVP |
-| `Week.close` | `week` | `week`, `campaign`, `session` | `compuesta` | cierre normal de semana | `activa` | `#8`, `#37` | auto-stop si hay sesión activa |
-| `Week.reopen` | `week` | `week`, `campaign` | `compuesta` | corrección manual de estado | `activa` | `#8`, `#37` | recálculo de semana actual derivada |
-| `Week.reclose` | `week` | `week`, `campaign`, `session` | `compuesta` | corrección manual de estado | `activa` | `#8`, `#37` | auto-stop si hay sesión activa |
-| `Week.update_notes` | `week` | `week` | `simple` | edición de notas | `activa` | `#8`, `#37` | permitido en `open|closed` |
-| `Entry.create` | `entry` | `entry`, `week` | `compuesta` | creación manual de entry | `activa` | `#37`, glosario | auto-normaliza `order_index` si detecta secuencia inconsistente |
-| `Entry.update` | `entry` | `entry` | `simple` | edición manual de entry | `activa` | `#37`, glosario | alcance amplio; sin mover de `Week` |
-| `Entry.update_notes` | `entry` | `entry` | `simple` | edición rápida de notas de entry | `activa` | `#37`, glosario | permitido en `open|closed`; no cambia tipo/orden |
+| `Campaign.provision_initial_years` | `campaign` | `campaign`, `year`, `season`, `week` | `compuesta` | creaciÃ³n/provisiÃ³n inicial de campaÃ±a | `activa` | `#9`, `#13`, `#37` | semana actual derivada como postcondiciÃ³n |
+| `Campaign.extend_years_plus_one` | `campaign` | `campaign`, `year`, `season`, `week` | `compuesta` | acciÃ³n `+` de aÃ±o (UI) | `activa` | `#9`, `#13`, `#37` | crea 1 aÃ±o completo; cursor derivado |
+| `Campaign.set_week_cursor_manual` | `campaign` | `campaign` | `simple` | ajuste manual (semÃ¡ntica histÃ³rica) | `excluida` | `#9`, `#37` | semÃ¡ntica sustituida en MVP |
+| `Week.close` | `week` | `week`, `campaign`, `session` | `compuesta` | cierre normal de semana | `activa` | `#8`, `#37` | auto-stop si hay sesiÃ³n activa |
+| `Week.reopen` | `week` | `week`, `campaign` | `compuesta` | correcciÃ³n manual de estado | `activa` | `#8`, `#37` | recÃ¡lculo de semana actual derivada |
+| `Week.reclose` | `week` | `week`, `campaign`, `session` | `compuesta` | correcciÃ³n manual de estado | `activa` | `#8`, `#37` | auto-stop si hay sesiÃ³n activa |
+| `Entry.create` | `entry` | `entry`, `week` | `compuesta` | creaciÃ³n manual de entry | `activa` | `#37`, glosario | auto-normaliza `order_index` si detecta secuencia inconsistente |
+| `Entry.update` | `entry` | `entry` | `simple` | ediciÃ³n manual de entry | `activa` | `#37`, glosario | alcance amplio; sin mover de `Week` |
+| `Entry.update_notes` | `entry` | `entry` | `simple` | ediciÃ³n rÃ¡pida de notas de entry | `activa` | `#37`, glosario | permitido en `open|closed`; no cambia tipo/orden |
 | `Entry.delete` | `entry` | `entry`, `session`, `campaign` | `compuesta` | borrado manual de entry | `activa` | glosario, `#37`, `#40` | hard delete real; auto-stop si entry activa; elimina `resource_deltas` con la entry |
 | `Entry.reorder_within_week` | `entry` | `entry`, `week` | `compuesta` | mover una entry en la misma week | `activa` | `#8`, `#37` | resecuencia densa `1..N` |
 | `Entry.adjust_resource_delta` | `entry` | `entry`, `campaign` | `compuesta` | tap `+/-` de recurso en una entry | `activa` | `#8`, `#37`, `#40`, glosario | ajusta delta neto en `Entry.resource_deltas` y valida totales |
-| `Entry.set_resource_delta` | `entry` | `entry`, `campaign` | `compuesta` | edición manual de delta neto | `activa` | `#8`, `#37`, `#40`, glosario | reemplaza delta neto; elimina clave si queda en `0` |
-| `Entry.clear_resource_delta` | `entry` | `entry`, `campaign` | `compuesta` | limpieza explícita de recurso en la entry | `activa` | `#8`, `#37`, `#40`, glosario | elimina clave de `resource_deltas`; valida totales |
-| `Session.start` | `session` | `campaign`, `entry`, `session` | `compuesta` | iniciar sesión de juego | `activa` | `#8`, glosario | permitido en week `open|closed`; auto-stop si hay activa |
-| `Session.stop` | `session` | `campaign`, `entry`, `session` | `simple` | detener sesión activa | `activa` | `#8`, glosario | inválida si la sesión ya no está activa |
-| `Session.auto_stop` | `session` | `campaign`, `entry`, `session` | `derivada` | `start`, `Week.close/reclose`, `Entry.delete` | `activa` | glosario, `#37` | no es acción manual principal |
-| `Session.manual_create` | `session` | `campaign`, `entry`, `session` | `simple` | corrección manual | `activa` | `#37`, glosario | histórica o activa; permitido en week `open|closed` |
-| `Session.manual_update` | `session` | `campaign`, `entry`, `session` | `simple` | corrección manual | `activa` | `#37`, glosario | corrige timestamps; `null <-> valor`; sin reparenting |
-| `Session.manual_delete` | `session` | `campaign`, `entry`, `session` | `simple` | corrección manual | `activa` | `#37`, glosario | hard delete; permitido en week `open|closed` |
+| `Entry.set_resource_delta` | `entry` | `entry`, `campaign` | `compuesta` | ediciÃ³n manual de delta neto | `activa` | `#8`, `#37`, `#40`, glosario | reemplaza delta neto; elimina clave si queda en `0` |
+| `Entry.clear_resource_delta` | `entry` | `entry`, `campaign` | `compuesta` | limpieza explÃ­cita de recurso en la entry | `activa` | `#8`, `#37`, `#40`, glosario | elimina clave de `resource_deltas`; valida totales |
+| `Session.start` | `session` | `campaign`, `entry`, `session` | `compuesta` | iniciar sesiÃ³n de juego | `activa` | `#8`, glosario | permitido en week `open|closed`; auto-stop si hay activa |
+| `Session.stop` | `session` | `campaign`, `entry`, `session` | `simple` | detener sesiÃ³n activa | `activa` | `#8`, glosario | invÃ¡lida si la sesiÃ³n ya no estÃ¡ activa |
+| `Session.auto_stop` | `session` | `campaign`, `entry`, `session` | `derivada` | `start`, `Week.close/reclose`, `Entry.delete` | `activa` | glosario, `#37` | no es acciÃ³n manual principal |
+| `Session.manual_create` | `session` | `campaign`, `entry`, `session` | `simple` | correcciÃ³n manual | `activa` | `#37`, glosario | histÃ³rica o activa; permitido en week `open|closed` |
+| `Session.manual_update` | `session` | `campaign`, `entry`, `session` | `simple` | correcciÃ³n manual | `activa` | `#37`, glosario | corrige timestamps; `null <-> valor`; sin reparenting |
+| `Session.manual_delete` | `session` | `campaign`, `entry`, `session` | `simple` | correcciÃ³n manual | `activa` | `#37`, glosario | hard delete; permitido en week `open|closed` |
 
-## Contrato por operación
+## Contrato por operaciÃ³n
 
-| operation_id | precondiciones_dominio | precondiciones_conflicto | validaciones | postcondiciones | rechazos_esperados | categoria_rechazo | atomicidad_esperada_comportamiento | respuesta_cliente_recomendada | notas_de_implementación |
+| operation_id | precondiciones_dominio | precondiciones_conflicto | validaciones | postcondiciones | rechazos_esperados | categoria_rechazo | atomicidad_esperada_comportamiento | respuesta_cliente_recomendada | notas_de_implementaciÃ³n |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `Campaign.provision_initial_years` | campaña existe y está provisionable | base de campaña no obsoleta | crea 4 años; `summer->winter`; 10 semanas/estación; no duplicados (`year/season/week`) | estructura temporal inicial completa; semana actual derivada apunta a primera week abierta | duplicados, base obsoleta | `validacion` / `conflicto` | todo el bloque temporal se crea o falla completo | `refrescar + reintentar` si conflicto; error local si duplicado/estado inválido | no fija técnica Firestore |
-| `Campaign.extend_years_plus_one` | campaña ya provisionada; último año identificable | base de campaña/estructura temporal no obsoleta | crea exactamente 1 año; continuidad `year_number` y `week_number`; no duplicados | nuevo año completo añadido; semana actual derivada válida | duplicados; continuidad inválida; base obsoleta | `validacion` / `conflicto` | se añade el año completo o falla completo | `refrescar + reintentar` si conflicto; error local si estructura inválida | disparo UI desde `+` de año |
-| `Week.close` | week existe; transición `open -> closed`; week abierta provisionada no quedará en 0 tras operación | base de `week.status` y sesión activa relevante no obsoletas | si hay sesión activa en la week, ejecutar `Session.auto_stop`; validar recálculo de la semana actual derivada | week queda `closed`; sesión activa de esa week queda cerrada si existía; semana actual derivada recalculada | transición ya cerrada; dejaría 0 weeks abiertas; base obsoleta | `transicion_invalida` / `validacion` / `conflicto` | auto-stop + cierre + recálculo se consideran una sola operación lógica | error local (transición/validación); `refrescar + reintentar` si conflicto | `closed` no bloquea mutaciones por sí mismo |
-| `Week.reopen` | week existe; transición `closed -> open` | base de `week.status` no obsoleta | transición válida; recálculo de la semana actual derivada | week queda `open`; semana actual derivada recalculada | transición ya abierta; base obsoleta | `transicion_invalida` / `conflicto` | cambio de estado + recálculo como operación lógica única | error local si transición inválida; `refrescar + reintentar` si conflicto | corrección manual explícita |
-| `Week.reclose` | week existe; transición `open -> closed`; no dejar 0 weeks abiertas | base de `week.status` y sesión activa relevante no obsoletas | si hay sesión activa en la week, `auto-stop`; validar recálculo de cursor | week queda `closed`; cursor derivado válido | transición ya cerrada; dejaría 0 weeks abiertas; base obsoleta | `transicion_invalida` / `validacion` / `conflicto` | auto-stop + cambio de estado + recálculo como operación lógica única | error local (transición/validación); `refrescar + reintentar` si conflicto | corrección manual de estado |
-| `Week.update_notes` | week existe | base de `updated_at_utc`/versión no obsoleta | edición de texto válida; permitido en `open|closed` | `notes` actualizadas | base obsoleta; payload inválido | `conflicto` / `validacion` | una actualización simple | `refrescar + reingresar cambios` si conflicto; error local si payload inválido | sin LWW |
-| `Entry.create` | week existe; ownership por ruta válido | base de orden (`entries` de la week) no obsoleta para inserción | `Entry.type` válido; `scenario_ref` obligatorio si `scenario`; si secuencia `order_index` inconsistente, auto-normalizar denso `1..N` antes/asociado a inserción | nueva entry creada con `order_index` válido y secuencia consistente | payload inválido; week inexistente; base obsoleta no resoluble | `validacion` / `conflicto` | normalización de orden + creación forman operación lógica única | error local si payload inválido; `refrescar + reintentar` si conflicto | permitido en week `open|closed` |
-| `Entry.update` | entry existe | base de entry no obsoleta | edición amplia de campos funcionales; `scenario_ref` consistente; no cambiar de `Week` | entry actualizada en la misma week | payload inválido; intento de mover de week; base obsoleta | `validacion` / `conflicto` | actualización simple | error local si validación; `refrescar + reintentar` si conflicto | sin reparenting |
-| `Entry.update_notes` | entry existe | base de entry no obsoleta | `notes` es string; permitido en `open|closed` | notas de entry actualizadas sin modificar tipo/orden | payload inválido; base obsoleta | `validacion` / `conflicto` | actualización simple | error local si validación; `refrescar + reintentar` si conflicto | operación enfocada para edición rápida en listado semanal |
-| `Entry.delete` | entry existe | base de entry e hijos relevantes no obsoletas | hard delete; si entry activa, `auto-stop`; borrado de `sessions`; eliminación implícita de `resource_deltas` con la `Entry` | entry eliminada con sus `sessions` y `resource_deltas`; no queda sesión activa asociada a esa entry | entry ya borrada; base obsoleta; cascada inválida por conflicto | `transicion_invalida` / `conflicto` | auto-stop + borrado de hijos + borrado de entry se tratan como operación lógica única | error local si ya no existe; `refrescar + reintentar` si conflicto | hard delete real (sin soft delete funcional) |
-| `Entry.reorder_within_week` | entry existe y pertenece a la week objetivo; misma week | base del orden de la week no obsoleta | posición destino válida; resecuencia densa `1..N`; no mover entre weeks | orden de entries de la week queda consistente | entry inexistente; week inconsistente; base obsoleta | `validacion` / `conflicto` | mover + resecuencia como operación lógica única | error local si validación; `refrescar + reintentar` si conflicto | permitido en week `open|closed` |
-| `Entry.adjust_resource_delta` | entry existe; `resource_key` pertenece al catálogo MVP | base de entry y `resource_totals` relevantes no obsoletas | ajuste entero firmado; cálculo de delta neto; eliminar clave si resultado `0`; totales finales no negativos | `Entry.resource_deltas` actualizado (neto); `campaign.resource_totals` consistente | `resource_key` inválida; payload inválido; totales negativos; base obsoleta | `validacion` / `conflicto` | recálculo de totales + actualización de `Entry.resource_deltas` como operación lógica única | error local si validación; `refrescar + reintentar` si conflicto | permitido en week `open|closed`; no crea log incremental |
-| `Entry.set_resource_delta` | entry existe; `resource_key` válida | base de entry y totales relevantes no obsoletas | delta entero firmado; si delta final `0`, eliminar clave; totales finales no negativos | delta neto fijado (o clave eliminada) y totales consistentes | `resource_key` inválida; payload inválido; totales negativos; base obsoleta | `validacion` / `conflicto` | recálculo de totales + escritura del mapa como operación lógica única | error local si validación; `refrescar + reintentar` si conflicto | edición manual directa del delta neto |
-| `Entry.clear_resource_delta` | entry existe | base de entry y totales relevantes no obsoletas | `resource_key` válida; recálculo mantiene totales no negativos | clave eliminada de `resource_deltas` (o permanece ausente si se trata como idempotente) y totales consistentes | `resource_key` inválida; totales negativos; base obsoleta | `validacion` / `conflicto` | recálculo de totales + limpieza de clave como operación lógica única | error local si validación; `refrescar + reintentar` si conflicto | limpiar clave inexistente puede tratarse como idempotente (sin error) |
-| `Session.start` | entry existe; sesión activa global puede ser 0..1; week `open|closed` permitida | base de sesión activa global no obsoleta | si ya hay sesión activa, `auto-stop` previo; garantizar unicidad `0..1` activa | nueva sesión activa (o transición equivalente) creada; unicidad preservada | unicidad violada; entry inválida; base obsoleta | `validacion` / `conflicto` | `auto-stop + start` (si aplica) como operación lógica única | error local si validación; `refrescar + reintentar` si conflicto | actividad derivada por `ended_at_utc=null` |
-| `Session.stop` | sesión objetivo existe y está activa (`ended_at_utc=null`) | base de sesión no obsoleta | sesión sigue activa al momento de aplicar stop | sesión queda cerrada (`ended_at_utc` definido) | sesión ya cerrada/no activa; base obsoleta | `transicion_invalida` / `conflicto` | actualización simple | error local si transición inválida; `refrescar + reintentar` si conflicto | distingue conflicto de transición inválida |
-| `Session.auto_stop` | sesión activa previa existe | base de sesión activa no obsoleta | trigger válido (`start`, `Week.close/reclose`, `Entry.delete`) | sesión activa previa queda cerrada | sesión ya no activa; base obsoleta | `transicion_invalida` / `conflicto` | se evalúa dentro de la operación compuesta disparadora | heredada de la operación padre | no se expone como acción manual principal |
-| `Session.manual_create` | entry existe; ownership por ruta válido | base de sesión activa global no obsoleta si crea una activa | timestamps válidos; histórica o activa; unicidad `0..1` activa global | sesión manual creada | timestamps inválidos; unicidad violada; base obsoleta | `validacion` / `conflicto` | creación simple | error local si validación; `refrescar + reintentar` si conflicto | permitido en week `open|closed` |
-| `Session.manual_update` | sesión existe; ownership por ruta inmutable | base de la sesión y de unicidad global no obsoletas | corrige `started_at_utc`/`ended_at_utc`; permite `null <-> valor`; sin reparenting; unicidad de activa global | sesión corregida; unicidad preservada | timestamps inválidos; reparenting intentado; unicidad violada; base obsoleta | `validacion` / `conflicto` | actualización simple | error local si validación; `refrescar + reintentar` si conflicto | no existe campo `state` separado |
-| `Session.manual_delete` | sesión existe | base de sesión no obsoleta | hard delete; preservar `0..1` activa global | sesión eliminada | sesión ya borrada; base obsoleta | `transicion_invalida` / `conflicto` | borrado simple | error local si transición inválida; `refrescar + reintentar` si conflicto | permitido en week `open|closed` |
+| `Campaign.provision_initial_years` | campaÃ±a existe y estÃ¡ provisionable | base de campaÃ±a no obsoleta | crea 4 aÃ±os; `summer->winter`; 10 semanas/estaciÃ³n; no duplicados (`year/season/week`) | estructura temporal inicial completa; semana actual derivada apunta a primera week abierta | duplicados, base obsoleta | `validacion` / `conflicto` | todo el bloque temporal se crea o falla completo | `refrescar + reintentar` si conflicto; error local si duplicado/estado invÃ¡lido | no fija tÃ©cnica Firestore |
+| `Campaign.extend_years_plus_one` | campaÃ±a ya provisionada; Ãºltimo aÃ±o identificable | base de campaÃ±a/estructura temporal no obsoleta | crea exactamente 1 aÃ±o; continuidad `year_number` y `week_number`; no duplicados | nuevo aÃ±o completo aÃ±adido; semana actual derivada vÃ¡lida | duplicados; continuidad invÃ¡lida; base obsoleta | `validacion` / `conflicto` | se aÃ±ade el aÃ±o completo o falla completo | `refrescar + reintentar` si conflicto; error local si estructura invÃ¡lida | disparo UI desde `+` de aÃ±o |
+| `Week.close` | week existe; transiciÃ³n `open -> closed`; week abierta provisionada no quedarÃ¡ en 0 tras operaciÃ³n | base de `week.status` y sesiÃ³n activa relevante no obsoletas | si hay sesiÃ³n activa en la week, ejecutar `Session.auto_stop`; validar recÃ¡lculo de la semana actual derivada | week queda `closed`; sesiÃ³n activa de esa week queda cerrada si existÃ­a; semana actual derivada recalculada | transiciÃ³n ya cerrada; dejarÃ­a 0 weeks abiertas; base obsoleta | `transicion_invalida` / `validacion` / `conflicto` | auto-stop + cierre + recÃ¡lculo se consideran una sola operaciÃ³n lÃ³gica | error local (transiciÃ³n/validaciÃ³n); `refrescar + reintentar` si conflicto | `closed` no bloquea mutaciones por sÃ­ mismo |
+| `Week.reopen` | week existe; transiciÃ³n `closed -> open` | base de `week.status` no obsoleta | transiciÃ³n vÃ¡lida; recÃ¡lculo de la semana actual derivada | week queda `open`; semana actual derivada recalculada | transiciÃ³n ya abierta; base obsoleta | `transicion_invalida` / `conflicto` | cambio de estado + recÃ¡lculo como operaciÃ³n lÃ³gica Ãºnica | error local si transiciÃ³n invÃ¡lida; `refrescar + reintentar` si conflicto | correcciÃ³n manual explÃ­cita |
+| `Week.reclose` | week existe; transiciÃ³n `open -> closed`; no dejar 0 weeks abiertas | base de `week.status` y sesiÃ³n activa relevante no obsoletas | si hay sesiÃ³n activa en la week, `auto-stop`; validar recÃ¡lculo de cursor | week queda `closed`; cursor derivado vÃ¡lido | transiciÃ³n ya cerrada; dejarÃ­a 0 weeks abiertas; base obsoleta | `transicion_invalida` / `validacion` / `conflicto` | auto-stop + cambio de estado + recÃ¡lculo como operaciÃ³n lÃ³gica Ãºnica | error local (transiciÃ³n/validaciÃ³n); `refrescar + reintentar` si conflicto | correcciÃ³n manual de estado |
+| `Entry.create` | week existe; ownership por ruta vÃ¡lido | base de orden (`entries` de la week) no obsoleta para inserciÃ³n | `Entry.type` vÃ¡lido; `scenario_ref` obligatorio si `scenario`; si secuencia `order_index` inconsistente, auto-normalizar denso `1..N` antes/asociado a inserciÃ³n | nueva entry creada con `order_index` vÃ¡lido y secuencia consistente | payload invÃ¡lido; week inexistente; base obsoleta no resoluble | `validacion` / `conflicto` | normalizaciÃ³n de orden + creaciÃ³n forman operaciÃ³n lÃ³gica Ãºnica | error local si payload invÃ¡lido; `refrescar + reintentar` si conflicto | permitido en week `open|closed` |
+| `Entry.update` | entry existe | base de entry no obsoleta | ediciÃ³n amplia de campos funcionales; `scenario_ref` consistente; no cambiar de `Week` | entry actualizada en la misma week | payload invÃ¡lido; intento de mover de week; base obsoleta | `validacion` / `conflicto` | actualizaciÃ³n simple | error local si validaciÃ³n; `refrescar + reintentar` si conflicto | sin reparenting |
+| `Entry.update_notes` | entry existe | base de entry no obsoleta | `notes` es string; permitido en `open|closed` | notas de entry actualizadas sin modificar tipo/orden | payload invÃ¡lido; base obsoleta | `validacion` / `conflicto` | actualizaciÃ³n simple | error local si validaciÃ³n; `refrescar + reintentar` si conflicto | operaciÃ³n enfocada para ediciÃ³n rÃ¡pida en listado semanal |
+| `Entry.delete` | entry existe | base de entry e hijos relevantes no obsoletas | hard delete; si entry activa, `auto-stop`; borrado de `sessions`; eliminaciÃ³n implÃ­cita de `resource_deltas` con la `Entry` | entry eliminada con sus `sessions` y `resource_deltas`; no queda sesiÃ³n activa asociada a esa entry | entry ya borrada; base obsoleta; cascada invÃ¡lida por conflicto | `transicion_invalida` / `conflicto` | auto-stop + borrado de hijos + borrado de entry se tratan como operaciÃ³n lÃ³gica Ãºnica | error local si ya no existe; `refrescar + reintentar` si conflicto | hard delete real (sin soft delete funcional) |
+| `Entry.reorder_within_week` | entry existe y pertenece a la week objetivo; misma week | base del orden de la week no obsoleta | posiciÃ³n destino vÃ¡lida; resecuencia densa `1..N`; no mover entre weeks | orden de entries de la week queda consistente | entry inexistente; week inconsistente; base obsoleta | `validacion` / `conflicto` | mover + resecuencia como operaciÃ³n lÃ³gica Ãºnica | error local si validaciÃ³n; `refrescar + reintentar` si conflicto | permitido en week `open|closed` |
+| `Entry.adjust_resource_delta` | entry existe; `resource_key` pertenece al catÃ¡logo MVP | base de entry y `resource_totals` relevantes no obsoletas | ajuste entero firmado; cÃ¡lculo de delta neto; eliminar clave si resultado `0`; totales finales no negativos | `Entry.resource_deltas` actualizado (neto); `campaign.resource_totals` consistente | `resource_key` invÃ¡lida; payload invÃ¡lido; totales negativos; base obsoleta | `validacion` / `conflicto` | recÃ¡lculo de totales + actualizaciÃ³n de `Entry.resource_deltas` como operaciÃ³n lÃ³gica Ãºnica | error local si validaciÃ³n; `refrescar + reintentar` si conflicto | permitido en week `open|closed`; no crea log incremental |
+| `Entry.set_resource_delta` | entry existe; `resource_key` vÃ¡lida | base de entry y totales relevantes no obsoletas | delta entero firmado; si delta final `0`, eliminar clave; totales finales no negativos | delta neto fijado (o clave eliminada) y totales consistentes | `resource_key` invÃ¡lida; payload invÃ¡lido; totales negativos; base obsoleta | `validacion` / `conflicto` | recÃ¡lculo de totales + escritura del mapa como operaciÃ³n lÃ³gica Ãºnica | error local si validaciÃ³n; `refrescar + reintentar` si conflicto | ediciÃ³n manual directa del delta neto |
+| `Entry.clear_resource_delta` | entry existe | base de entry y totales relevantes no obsoletas | `resource_key` vÃ¡lida; recÃ¡lculo mantiene totales no negativos | clave eliminada de `resource_deltas` (o permanece ausente si se trata como idempotente) y totales consistentes | `resource_key` invÃ¡lida; totales negativos; base obsoleta | `validacion` / `conflicto` | recÃ¡lculo de totales + limpieza de clave como operaciÃ³n lÃ³gica Ãºnica | error local si validaciÃ³n; `refrescar + reintentar` si conflicto | limpiar clave inexistente puede tratarse como idempotente (sin error) |
+| `Session.start` | entry existe; sesiÃ³n activa global puede ser 0..1; week `open|closed` permitida | base de sesiÃ³n activa global no obsoleta | si ya hay sesiÃ³n activa, `auto-stop` previo; garantizar unicidad `0..1` activa | nueva sesiÃ³n activa (o transiciÃ³n equivalente) creada; unicidad preservada | unicidad violada; entry invÃ¡lida; base obsoleta | `validacion` / `conflicto` | `auto-stop + start` (si aplica) como operaciÃ³n lÃ³gica Ãºnica | error local si validaciÃ³n; `refrescar + reintentar` si conflicto | actividad derivada por `ended_at_utc=null` |
+| `Session.stop` | sesiÃ³n objetivo existe y estÃ¡ activa (`ended_at_utc=null`) | base de sesiÃ³n no obsoleta | sesiÃ³n sigue activa al momento de aplicar stop | sesiÃ³n queda cerrada (`ended_at_utc` definido) | sesiÃ³n ya cerrada/no activa; base obsoleta | `transicion_invalida` / `conflicto` | actualizaciÃ³n simple | error local si transiciÃ³n invÃ¡lida; `refrescar + reintentar` si conflicto | distingue conflicto de transiciÃ³n invÃ¡lida |
+| `Session.auto_stop` | sesiÃ³n activa previa existe | base de sesiÃ³n activa no obsoleta | trigger vÃ¡lido (`start`, `Week.close/reclose`, `Entry.delete`) | sesiÃ³n activa previa queda cerrada | sesiÃ³n ya no activa; base obsoleta | `transicion_invalida` / `conflicto` | se evalÃºa dentro de la operaciÃ³n compuesta disparadora | heredada de la operaciÃ³n padre | no se expone como acciÃ³n manual principal |
+| `Session.manual_create` | entry existe; ownership por ruta vÃ¡lido | base de sesiÃ³n activa global no obsoleta si crea una activa | timestamps vÃ¡lidos; histÃ³rica o activa; unicidad `0..1` activa global | sesiÃ³n manual creada | timestamps invÃ¡lidos; unicidad violada; base obsoleta | `validacion` / `conflicto` | creaciÃ³n simple | error local si validaciÃ³n; `refrescar + reintentar` si conflicto | permitido en week `open|closed` |
+| `Session.manual_update` | sesiÃ³n existe; ownership por ruta inmutable | base de la sesiÃ³n y de unicidad global no obsoletas | corrige `started_at_utc`/`ended_at_utc`; permite `null <-> valor`; sin reparenting; unicidad de activa global | sesiÃ³n corregida; unicidad preservada | timestamps invÃ¡lidos; reparenting intentado; unicidad violada; base obsoleta | `validacion` / `conflicto` | actualizaciÃ³n simple | error local si validaciÃ³n; `refrescar + reintentar` si conflicto | no existe campo `state` separado |
+| `Session.manual_delete` | sesiÃ³n existe | base de sesiÃ³n no obsoleta | hard delete; preservar `0..1` activa global | sesiÃ³n eliminada | sesiÃ³n ya borrada; base obsoleta | `transicion_invalida` / `conflicto` | borrado simple | error local si transiciÃ³n invÃ¡lida; `refrescar + reintentar` si conflicto | permitido en week `open|closed` |
 ## Operaciones compuestas y atomicidad esperada (comportamiento)
 
-Este documento exige atomicidad a nivel de **resultado observable** (éxito
-completo o fallo completo), sin fijar si la implementación usa transacción,
-batch o combinación de mecanismos Firestore.
+Este documento exige atomicidad a nivel de **resultado observable** (Ã©xito
+completo o fallo completo), sin fijar si la implementaciÃ³n usa transacciÃ³n,
+batch o combinaciÃ³n de mecanismos Firestore.
 
-Operaciones compuestas mínimas:
+Operaciones compuestas mÃ­nimas:
 
-1. `Session.start` con `auto-stop` previo cuando ya existe sesión activa.
-1. `Week.close` / `Week.reclose` con `auto-stop` + recálculo de la semana actual derivada.
-1. `Entry.delete` activa con `auto-stop` + borrado de `sessions` (y eliminación
-   implícita de `resource_deltas` al borrar la `Entry`).
-1. `Entry.create` con auto-normalización de `order_index` cuando la secuencia de
+1. `Session.start` con `auto-stop` previo cuando ya existe sesiÃ³n activa.
+1. `Week.close` / `Week.reclose` con `auto-stop` + recÃ¡lculo de la semana actual derivada.
+1. `Entry.delete` activa con `auto-stop` + borrado de `sessions` (y eliminaciÃ³n
+   implÃ­cita de `resource_deltas` al borrar la `Entry`).
+1. `Entry.create` con auto-normalizaciÃ³n de `order_index` cuando la secuencia de
    la week llega inconsistente.
 1. `Entry.adjust_resource_delta`, `Entry.set_resource_delta` y
-   `Entry.clear_resource_delta` con recálculo de `campaign.resource_totals`.
+   `Entry.clear_resource_delta` con recÃ¡lculo de `campaign.resource_totals`.
 1. `Campaign.provision_initial_years` y `Campaign.extend_years_plus_one` con
-   estructura temporal completa + semana actual derivada válida.
+   estructura temporal completa + semana actual derivada vÃ¡lida.
 
-## Alineación temporal con #13
+## AlineaciÃ³n temporal con #13
 
 | operacion | insumo_#13 | insumo_#37 | regla_en_#12 | no_definido_en_#12 | riesgo_si_se_viola |
 | --- | --- | --- | --- | --- | --- |
-| `Campaign.provision_initial_years` | 4 años iniciales, `summer->winter`, 10 semanas/estación, `week_number` correlativo | semana actual derivada; no dejar 0 abiertas | creación completa con duplicados rechazados y semana actual derivada válida | técnica Firestore | estructura temporal inconsistente / semana actual inválida |
-| `Campaign.extend_years_plus_one` | +1 año, continuidad `year_number`/`week_number` | semana actual derivada | extensión exacta de 1 año; sin reprovisión; sin duplicados | técnica Firestore | numeración rota o duplicados |
-| `Week.close/reopen/reclose` | coherencia `week_number`/jerarquía | recálculo de semana actual derivada; transición manual | cambio de estado + postcondición de semana actual derivada | timestamp/desempate | semana actual incoherente o estado inválido |
-| `Entry`/`Session` (incluyendo `Entry.resource_deltas`) sobre weeks históricas | weeks siguen existiendo y `week_number` no cambia | editabilidad amplia en `open|closed` | operaciones permitidas en weeks `closed` salvo validación específica | política UI | bloqueos artificiales o contradicción con `#37` |
+| `Campaign.provision_initial_years` | 4 aÃ±os iniciales, `summer->winter`, 10 semanas/estaciÃ³n, `week_number` correlativo | semana actual derivada; no dejar 0 abiertas | creaciÃ³n completa con duplicados rechazados y semana actual derivada vÃ¡lida | tÃ©cnica Firestore | estructura temporal inconsistente / semana actual invÃ¡lida |
+| `Campaign.extend_years_plus_one` | +1 aÃ±o, continuidad `year_number`/`week_number` | semana actual derivada | extensiÃ³n exacta de 1 aÃ±o; sin reprovisiÃ³n; sin duplicados | tÃ©cnica Firestore | numeraciÃ³n rota o duplicados |
+| `Week.close/reopen/reclose` | coherencia `week_number`/jerarquÃ­a | recÃ¡lculo de semana actual derivada; transiciÃ³n manual | cambio de estado + postcondiciÃ³n de semana actual derivada | timestamp/desempate | semana actual incoherente o estado invÃ¡lido |
+| `Entry`/`Session` (incluyendo `Entry.resource_deltas`) sobre weeks histÃ³ricas | weeks siguen existiendo y `week_number` no cambia | editabilidad amplia en `open|closed` | operaciones permitidas en weeks `closed` salvo validaciÃ³n especÃ­fica | polÃ­tica UI | bloqueos artificiales o contradicciÃ³n con `#37` |
 
-## Alineación de editabilidad e invariantes con #37
+## AlineaciÃ³n de editabilidad e invariantes con #37
 
-1. `Campaign.set_week_cursor_manual` se documenta como exclusión activa del MVP.
-1. La semana actual derivada (históricamente implementada como `week_cursor`) es postcondición y nunca selección manual libre.
-1. `Week.status=closed` es marcador informativo; no bloquea por sí mismo
+1. `Campaign.set_week_cursor_manual` se documenta como exclusiÃ³n activa del MVP.
+1. La semana actual derivada (histÃ³ricamente implementada como `week_cursor`) es postcondiciÃ³n y nunca selecciÃ³n manual libre.
+1. `Week.status=closed` es marcador informativo; no bloquea por sÃ­ mismo
    mutaciones de `Entry` (incluyendo `resource_deltas`) ni `Session`.
-1. `Entry.reorder_within_week` está limitado a la misma `Week` y resecuencia
+1. `Entry.reorder_within_week` estÃ¡ limitado a la misma `Week` y resecuencia
    densa `1..N`.
 1. `Session.manual_update` no cambia ownership por ruta y puede corregir
    `ended_at_utc` en ambos sentidos.
-1. Debe preservarse `0..1` sesión activa global.
+1. Debe preservarse `0..1` sesiÃ³n activa global.
 1. Debe preservarse la existencia de al menos una `Week` abierta provisionada.
 
-## Rechazos por conflicto, validación y transición inválida
+## Rechazos por conflicto, validaciÃ³n y transiciÃ³n invÃ¡lida
 
 ### `conflicto`
 
-- La base relevante cambió concurrentemente respecto a la lectura del cliente.
+- La base relevante cambiÃ³ concurrentemente respecto a la lectura del cliente.
 - Respuesta cliente recomendada: `refrescar + reintentar`.
 
 ### `validacion`
 
 - La entrada o el resultado violan invariantes (por ejemplo, `scenario_ref`
-  ausente, totales negativos, dejar 0 weeks abiertas, posición inválida).
-- Respuesta cliente recomendada: error local y corrección de la acción/entrada.
+  ausente, totales negativos, dejar 0 weeks abiertas, posiciÃ³n invÃ¡lida).
+- Respuesta cliente recomendada: error local y correcciÃ³n de la acciÃ³n/entrada.
 
 ### `transicion_invalida`
 
-- La entidad ya no está en el estado requerido para la transición pedida (por
-  ejemplo, `Week.close` sobre `closed`, `Session.stop` sobre sesión no activa).
+- La entidad ya no estÃ¡ en el estado requerido para la transiciÃ³n pedida (por
+  ejemplo, `Week.close` sobre `closed`, `Session.stop` sobre sesiÃ³n no activa).
 - Respuesta cliente recomendada: error local (sin refresh por defecto), salvo
   que la UI detecte otros indicios de estado obsoleto.
 
-## Casos de aceptación / verificación documental
+## Casos de aceptaciÃ³n / verificaciÃ³n documental
 
-1. `Campaign.extend_years_plus_one` crea exactamente 1 año y mantiene
+1. `Campaign.extend_years_plus_one` crea exactamente 1 aÃ±o y mantiene
    continuidad temporal de `#13`.
-1. `Week.close` con sesión activa define `auto-stop + cerrar` y recálculo de la
-   semana actual derivada como operación compuesta.
+1. `Week.close` con sesiÃ³n activa define `auto-stop + cerrar` y recÃ¡lculo de la
+   semana actual derivada como operaciÃ³n compuesta.
 1. `Week.close` sobre week ya `closed` se clasifica como `transicion_invalida`
    con error local.
 1. `Week.reclose` rechaza operaciones que dejen `0` weeks abiertas.
 1. `Session.start` queda permitido en week `open` o `closed`.
-1. `Session.stop` inválido se clasifica como `transicion_invalida`.
+1. `Session.stop` invÃ¡lido se clasifica como `transicion_invalida`.
 1. `Session.manual_update` permite `ended_at_utc: valor -> null` y `null -> valor`
-   preservando unicidad de sesión activa global.
+   preservando unicidad de sesiÃ³n activa global.
 1. `Session.manual_update` no permite reparenting.
 1. `Entry.create` auto-normaliza `order_index` cuando detecta secuencia
    inconsistente.
 1. `Entry.update_notes` permite editar notas de `Entry` sin cambiar
    `type/scenario_ref/order_index`.
-1. `Entry.reorder_within_week` funciona también en weeks `closed` y resecuencia
+1. `Entry.reorder_within_week` funciona tambiÃ©n en weeks `closed` y resecuencia
    a `1..N`.
 1. Las operaciones de recursos del contrato se expresan sobre
    `Entry.resource_deltas` (`adjust/set/clear`) y no sobre `ResourceChange`.
-1. `Campaign.set_week_cursor_manual` aparece como exclusión activa del contrato
+1. `Campaign.set_week_cursor_manual` aparece como exclusiÃ³n activa del contrato
    MVP.
 
-## Riesgos, límites y decisiones diferidas
+## Riesgos, lÃ­mites y decisiones diferidas
 
-- La técnica exacta para garantizar atomicidad en Firestore queda diferida a la
-  implementación.
-- La política de timestamps y desempate estable se define en
+- La tÃ©cnica exacta para garantizar atomicidad en Firestore queda diferida a la
+  implementaciÃ³n.
+- La polÃ­tica de timestamps y desempate estable se define en
   `docs/timestamp-order-policy.md` (Issue `#18`) y este contrato no la
   reespecifica.
 - El contrato no define lecturas ni consultas (`#16`).
 - La parte de recursos de este contrato fue parcialmente supersedida por
   `docs/resource-delta-model.md` (Issue `#40`) y parcheada con operaciones
-  sobre `Entry.resource_deltas`; el detalle de validación y recálculo de
+  sobre `Entry.resource_deltas`; el detalle de validaciÃ³n y recÃ¡lculo de
   recursos se especifica en `docs/resource-validation-recalculation.md`
   (Issue `#15`).
-- La UX exacta para errores de conflicto vs transición inválida se concreta en
+- La UX exacta para errores de conflicto vs transiciÃ³n invÃ¡lida se concreta en
   issues de flujo (`#14`) y UI.
-- La matriz transversal de edge cases de concurrencia/sincronización se
+- La matriz transversal de edge cases de concurrencia/sincronizaciÃ³n se
   documenta en `docs/concurrency-sync-edge-case-matrix.md` (Issue `#17`) como
-  traducción verificable de este contrato y otras políticas.
+  traducciÃ³n verificable de este contrato y otras polÃ­ticas.
 
 ## Referencias
 
@@ -280,3 +277,4 @@ Operaciones compuestas mínimas:
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/15`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/18`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/17`
+

--- a/docs/minimal-read-queries.md
+++ b/docs/minimal-read-queries.md
@@ -6,7 +6,7 @@
 - `purpose`: Definir el inventario mÃ­nimo de lecturas/consultas para la pantalla principal del MVP (superficies visibles, triggers, orden y lÃ­mites de carga).
 - `status`: active
 - `source_of_truth`: official
-- `last_updated`: 2026-02-24
+- `last_updated`: 2026-03-05
 - `next_review`: 2026-03-10
 
 ## Objetivo
@@ -93,7 +93,7 @@ No incluye:
 | `top_year_selector` | Barra superior con aÃ±o actual seleccionado, navegaciÃ³n prev/next y `+` de extensiÃ³n | Todos | aÃ±os provisionados, aÃ±o seleccionado, condiciÃ³n de Ãºltimo aÃ±o | `+` depende del Ãºltimo aÃ±o provisionado (`#9`) |
 | `top_week_selector` | Tira de semanas del aÃ±o seleccionado (navegaciÃ³n/foco temporal) | Todos | weeks del aÃ±o seleccionado (`week_number`, `status`), marcador `current week` (semana actual derivada) | Seleccionar week no cambia la semana actual derivada (`#9`) |
 | `top_entry_selector_tabs` | Selector de `Entry` de la week seleccionada (tabs) | `week_selected_no_entry`, `entry_selected_*` | entries de la week seleccionada ordenadas | Puede mostrar estado vacÃ­o/acciÃ³n de creaciÃ³n si no hay entries |
-| `focus_panel_week_state` | Panel central en modo `Week` (semana seleccionada, notas, estado) | `week_selected_no_entry` | `Week` seleccionada (`status`, `notes`) | Consume datos ya presentes en lecturas de weeks |
+| `focus_panel_week_state` | Panel central en modo `Week` (semana seleccionada y estado) | `week_selected_no_entry` | `Week` seleccionada (`status`) | Consume datos ya presentes en lecturas de weeks |
 | `focus_panel_entry_state` | Panel central en modo `Entry` (datos de entry, recursos, bloque sesiÃ³n) | `entry_selected_*` | `Entry` seleccionada + sesiones de esa entry | `total jugado` y desplegable de sesiones dependen de lectura de `sessions` |
 | `bottom_totals_bar` | Barra inferior con totales globales y resumen de activo | Todos | `campaign.resource_totals`, resumen de sesiÃ³n activa, label del activo si aplica | El detalle visual no cambia las lecturas mÃ­nimas |
 | `active_session_indicator_summary` | Indicadores de foco vs activo / estado de sesiÃ³n global | Todos (condicional si hay activa) | sesiÃ³n activa global + owner (`Entry`) si no coincide con la seleccionada | Alineado con separaciÃ³n foco/activo de `#14` |
@@ -148,7 +148,6 @@ Estados de pantalla del MVP (canon para lecturas):
 - **Campos lÃ³gicos mÃ­nimos**:
   - `week_number`
   - `status`
-  - `notes`
   - `updated_at_utc` (opcional tÃ©cnico)
 - **Uso**:
   - tira de weeks del aÃ±o seleccionado
@@ -211,8 +210,8 @@ Estados de pantalla del MVP (canon para lecturas):
 | --- | --- | --- | --- | --- | --- | --- |
 | `Q1 campaign_main_doc` | `campaign` | `resource_totals`, `updated_at_utc` | N/A | `resource_totals` | `updated_at_utc` | `week_cursor` solo en implementaciÃ³n transitoria previa a `#81` |
 | `Q2 years_list` | `year` | `year_number` | `year_number` | `year_number` | `updated_at_utc` opcional | AuditorÃ­a no es primaria de UI |
-| `Q3 weeks_selected_year_summer` | `week` | `week_number`, `status`, `notes` | `week_number` | `week_number`, `status`, `notes` | `status`, `updated_at_utc` | Parte `summer` del aÃ±o |
-| `Q4 weeks_selected_year_winter` | `week` | `week_number`, `status`, `notes` | `week_number` | `week_number`, `status`, `notes` | `status`, `updated_at_utc` | Parte `winter` del aÃ±o |
+| `Q3 weeks_selected_year_summer` | `week` | `week_number`, `status` | `week_number` | `week_number`, `status` | `status`, `updated_at_utc` | Parte `summer` del aÃ±o |
+| `Q4 weeks_selected_year_winter` | `week` | `week_number`, `status` | `week_number` | `week_number`, `status` | `status`, `updated_at_utc` | Parte `winter` del aÃ±o |
 | `Q5 entries_selected_week` | `entry` | `type`, `scenario_ref`, `order_index`, `resource_deltas`, `created_at_utc`, `updated_at_utc` | `order_index`, `created_at_utc`, `entry_id` | `type`, `scenario_ref`, `resource_deltas` | `updated_at_utc`, `order_index` | `entry_id` viene del doc id |
 | `Q6 active_session_global` | `session` | `started_at_utc`, `ended_at_utc`, `created_at_utc`, `updated_at_utc` + ruta | `N/A (single)` | `started_at_utc`, `ended_at_utc` | `ended_at_utc`, `updated_at_utc` | `limit 1` por invariante |
 | `Q7 active_entry_doc_if_needed` | `entry` | `type`, `scenario_ref` | N/A | `type`, `scenario_ref` | `updated_at_utc` opcional | Solo si activa != seleccionada |
@@ -263,7 +262,7 @@ Notas de implementaciÃ³n posteriores (`#53+`):
 | `ui.select_year` | Q3, Q4 (resetea navegaciÃ³n de `Week`) | Cambia el conjunto de weeks visibles | No | Puede mantenerse una entry en visor sticky; Q5/Q8 no cargan hasta nueva selecciÃ³n de entry |
 | `ui.select_week` | Q5 | Cargar entries de la week seleccionada | No | No cambia la semana actual derivada ni obliga a limpiar la entry en visor sticky |
 | `ui.select_entry` | Q8 (+ Q7 solo si sigue activo global en otra entry y la UI lo necesita) | Cargar sesiones de la entry seleccionada para el visor | No | Q5 ya aporta datos base de la entry |
-| `Week.close/reopen/reclose/update_notes` | Q1 (si cambia estado de campaÃ±a / transiciÃ³n temporal), Q3/Q4 (aÃ±o visible), Q6 (si hubo `auto-stop`) | Reflejar estado de week, semana actual derivada y sesiÃ³n activa | No (post-escritura local) | Si la week afectada no estÃ¡ en aÃ±o visible, Q3/Q4 puede diferirse a refresh manual |
+| `Week.close/reopen/reclose` | Q1 (si cambia estado de campaÃ±a / transiciÃ³n temporal), Q3/Q4 (aÃ±o visible), Q6 (si hubo `auto-stop`) | Reflejar estado de week, semana actual derivada y sesiÃ³n activa | No (post-escritura local) | Si la week afectada no estÃ¡ en aÃ±o visible, Q3/Q4 puede diferirse a refresh manual |
 | `Campaign.extend_years_plus_one` | Q1, Q2, Q3/Q4 si el aÃ±o visible queda afectado | Reflejar nuevo aÃ±o / estado de campaÃ±a | No (post-escritura local) | `+` vive en selector de aÃ±o (`#9`) |
 | `Entry.create/update/delete/reorder` sobre `selected_week` | Q5 (+ Q8 si afecta la entry en visor) | Actualizar tabs/lista y panel de entry | No (post-escritura local) | `Entry.delete` puede requerir tambiÃ©n Q6 si habÃ­a activa |
 | `Entry.adjust/set/clear_resource_delta` sobre la entry en visor | Q1, Q5 | Totales globales + `resource_deltas` de entry | No (post-escritura local) | Reglas de recursos en `#15` |
@@ -308,8 +307,8 @@ se tratarÃ¡ como ampliaciÃ³n posterior (no bloquea `#16`).
    - Riesgo: degradar UX si se recarga toda la pantalla tras cada operaciÃ³n.
    - MitigaciÃ³n: refresco por Ã¡mbito (tabla 4) y refresh manual para conflictos.
 
-1. **Q3+Q4 incluyen `notes`**
-   - Riesgo: cargar campos de week que no siempre se muestran.
+1. **Q3+Q4 incluyen solo estado (`status`)**
+   - Riesgo: bajo; se mantiene lectura mínima de week para selector temporal.
    - MitigaciÃ³n: aceptar el coste por simplicidad del MVP; evita query extra
      para panel `Week`.
 
@@ -327,7 +326,7 @@ se tratarÃ¡ como ampliaciÃ³n posterior (no bloquea `#16`).
 ### Supuestos de lectura por superficies incompletas (obligatorios)
 
 1. **Bloque central**
-   - modo `Week`: consume `status` + `notes` desde Q3/Q4 (sin query extra)
+   - modo `Week`: consume `status` desde Q3/Q4 (sin query extra)
    - modo `Entry`: consume `Entry` desde Q5 y sesiones desde Q8
 1. **Barra inferior**
    - requiere Q1 (`resource_totals`) + Q6 (activo global) + Q7 (label del
@@ -398,4 +397,6 @@ se tratarÃ¡ como ampliaciÃ³n posterior (no bloquea `#16`).
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/17`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/37`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/40`
+
+
 

--- a/docs/resource-ui-catalog.md
+++ b/docs/resource-ui-catalog.md
@@ -6,8 +6,8 @@
 - `purpose`: Definir catálogo UI único de recursos (claves internas, etiquetas, grupos, orden e iconos) para edición de deltas y visualización de totales.
 - `status`: active
 - `source_of_truth`: official
-- `last_updated`: 2026-03-04
-- `next_review`: 2026-03-18
+- `last_updated`: 2026-03-05
+- `next_review`: 2026-03-19
 
 ## Objetivo
 
@@ -22,6 +22,10 @@ Este documento alinea implementación UI con el glosario de dominio vigente (`do
 
 ## Orden canónico y agrupación
 
+1. Otros:
+   - `inspiration`
+   - `morale`
+   - `soldiers`
 1. Materiales:
    - `lumber`
    - `metal`
@@ -34,12 +38,11 @@ Este documento alinea implementación UI con el glosario de dominio vigente (`do
    - `flamefruit`
    - `rockroot`
    - `snowthistle`
-1. Otros:
-   - `inspiration`
-   - `morale`
-   - `soldiers`
 
 ## Mapeo UI (EN -> ES) y assets
+
+Nota de orden visual activo en runtime: `Otros -> Materiales -> Plantas` (las
+dos columnas de plantas se renderizan como un único bloque `Plantas`).
 
 | resource_key | etiqueta_ui_es | grupo_ui | icon_filename_png |
 | --- | --- | --- | --- |

--- a/docs/timestamp-order-policy.md
+++ b/docs/timestamp-order-policy.md
@@ -1,37 +1,37 @@
-# Política de Timestamps y Orden Estable entre Dispositivos (MVP)
+﻿# PolÃ­tica de Timestamps y Orden Estable entre Dispositivos (MVP)
 
 ## Metadatos
 
 - `doc_id`: DOC-TIMESTAMP-ORDER-POLICY
-- `purpose`: Definir la política MVP de auditoría temporal y orden estable entre dispositivos (timestamps server-only, reglas de escritura y tuplas canónicas por lista).
+- `purpose`: Definir la polÃ­tica MVP de auditorÃ­a temporal y orden estable entre dispositivos (timestamps server-only, reglas de escritura y tuplas canÃ³nicas por lista).
 - `status`: active
 - `source_of_truth`: official
-- `last_updated`: 2026-02-24
+- `last_updated`: 2026-03-05
 - `next_review`: 2026-03-10
 
 ## Objetivo
 
-Cerrar una decisión documental oficial para la auditoría temporal del MVP y el
-orden estable entre dispositivos, de forma compatible con sincronización,
+Cerrar una decisiÃ³n documental oficial para la auditorÃ­a temporal del MVP y el
+orden estable entre dispositivos, de forma compatible con sincronizaciÃ³n,
 conflictos, contrato de operaciones por agregado y modelo de recursos vigente.
 
 ## Alcance y no alcance
 
 Incluye:
 
-- política de `created_at_utc` / `updated_at_utc` (server-only);
+- polÃ­tica de `created_at_utc` / `updated_at_utc` (server-only);
 - reglas de escritura de timestamps en create/update/side-effects/hard delete;
-- matriz explícita de orden canónico por lista (alcance UI + consultas mínimas
+- matriz explÃ­cita de orden canÃ³nico por lista (alcance UI + consultas mÃ­nimas
   de `#16`);
 - manejo de timestamps pendientes (`serverTimestamp` no confirmado);
-- alineación con `#12`, `#16`, `#40` y `docs/domain-glossary.md`.
+- alineaciÃ³n con `#12`, `#16`, `#40` y `docs/domain-glossary.md`.
 
 No incluye:
 
-- técnica Firestore exacta para materializar `serverTimestamp`;
-- diseño de queries finales de `#16` (solo reglas de orden y prefijos);
+- tÃ©cnica Firestore exacta para materializar `serverTimestamp`;
+- diseÃ±o de queries finales de `#16` (solo reglas de orden y prefijos);
 - UX detallada de indicadores de estado provisional;
-- código de app.
+- cÃ³digo de app.
 
 ## Entradas y prerrequisitos
 
@@ -48,40 +48,40 @@ No incluye:
 
 ## Decisiones cerradas de esta issue
 
-1. Alcance de matriz de orden: listas visibles del MVP + consultas mínimas de
+1. Alcance de matriz de orden: listas visibles del MVP + consultas mÃ­nimas de
    `#16`.
-1. Auditoría temporal: `server-only`.
+1. AuditorÃ­a temporal: `server-only`.
 1. `deleted_at_utc`: fuera del MVP.
-1. Matriz de orden estable explícita por lista.
-1. Orden canónico: prefijo de query + normalización final en cliente.
-1. Último desempate global: `document_id` lexicográfico ascendente.
+1. Matriz de orden estable explÃ­cita por lista.
+1. Orden canÃ³nico: prefijo de query + normalizaciÃ³n final en cliente.
+1. Ãšltimo desempate global: `document_id` lexicogrÃ¡fico ascendente.
 1. Sesiones en listas combinadas: activa primero.
-1. Histórico de sesiones: `started_at_utc` descendente.
+1. HistÃ³rico de sesiones: `started_at_utc` descendente.
 1. Timeline: orden de dominio (`week_number`, `order_index`) primero; timestamps
    solo como fallback/desempate.
-1. Timestamps pendientes: orden canónico final solo garantizado tras `refresh`.
-1. Auditoría ampliada a `campaign/year/season/week/entry/session`.
-1. Forma de auditoría por entidad: `created_at_utc` + `updated_at_utc` en todas
+1. Timestamps pendientes: orden canÃ³nico final solo garantizado tras `refresh`.
+1. AuditorÃ­a ampliada a `campaign/year/season/week/entry/session`.
+1. Forma de auditorÃ­a por entidad: `created_at_utc` + `updated_at_utc` en todas
    las entidades auditadas.
-1. `updated_at_utc` cambia en toda escritura persistida, también derivada.
-1. La matriz incluye también listas con orden de dominio (timestamps `N/A` o
-   fallback), para dejar `#16` más cerrada.
+1. `updated_at_utc` cambia en toda escritura persistida, tambiÃ©n derivada.
+1. La matriz incluye tambiÃ©n listas con orden de dominio (timestamps `N/A` o
+   fallback), para dejar `#16` mÃ¡s cerrada.
 
-## Política de auditoría temporal (server-only)
+## PolÃ­tica de auditorÃ­a temporal (server-only)
 
 ### Regla de origen
 
 - `created_at_utc` y `updated_at_utc` se escriben como timestamps de servidor.
-- El cliente no persiste timestamps “definitivos” locales para auditoría.
+- El cliente no persiste timestamps â€œdefinitivosâ€ locales para auditorÃ­a.
 
 ### Regla de escritura
 
-1. En creación de documento se escriben `created_at_utc` y `updated_at_utc` en
-   la misma operación lógica.
-1. En actualización se preserva `created_at_utc` y se actualiza
+1. En creaciÃ³n de documento se escriben `created_at_utc` y `updated_at_utc` en
+   la misma operaciÃ³n lÃ³gica.
+1. En actualizaciÃ³n se preserva `created_at_utc` y se actualiza
    `updated_at_utc`.
-1. Si una operación compuesta/derivada modifica un documento (por ejemplo
-   `auto-stop`, recálculo o side-effect), ese documento también actualiza su
+1. Si una operaciÃ³n compuesta/derivada modifica un documento (por ejemplo
+   `auto-stop`, recÃ¡lculo o side-effect), ese documento tambiÃ©n actualiza su
    `updated_at_utc`.
 1. En hard delete no se usa `deleted_at_utc`; el documento se elimina
    directamente.
@@ -90,76 +90,76 @@ No incluye:
 
 | entity | created_at_utc | updated_at_utc | deleted_at_utc_mvp | timestamp_fields_adicionales | notas |
 | --- | --- | --- | --- | --- | --- |
-| `campaign` | Sí | Sí | No | `week_cursor` / `resource_totals` son datos, no timestamps | `updated_at_utc` cambia en provisión/extensión y cambios persistidos de campaña |
-| `year` | Sí | Sí | No | Ninguno | Auditoría de documento temporal aunque su mutabilidad sea baja |
-| `season` | Sí | Sí | No | Ninguno | Auditoría de documento temporal aunque su mutabilidad sea baja |
-| `week` | Sí | Sí | No | Ninguno | Incluye cierres/reaperturas y `notes` |
-| `entry` | Sí | Sí | No | Ninguno | Incluye cambios de `resource_deltas` y reordenación si el doc cambia |
-| `session` | Sí | Sí | No | `started_at_utc`, `ended_at_utc` | `started_at_utc`/`ended_at_utc` modelan el intervalo; auditoría es aparte |
+| `campaign` | SÃ­ | SÃ­ | No | `week_cursor` / `resource_totals` son datos, no timestamps | `updated_at_utc` cambia en provisiÃ³n/extensiÃ³n y cambios persistidos de campaÃ±a |
+| `year` | SÃ­ | SÃ­ | No | Ninguno | AuditorÃ­a de documento temporal aunque su mutabilidad sea baja |
+| `season` | SÃ­ | SÃ­ | No | Ninguno | AuditorÃ­a de documento temporal aunque su mutabilidad sea baja |
+| `week` | SÃ­ | SÃ­ | No | Ninguno | Incluye cierres/reaperturas |
+| `entry` | SÃ­ | SÃ­ | No | Ninguno | Incluye cambios de `resource_deltas` y reordenaciÃ³n si el doc cambia |
+| `session` | SÃ­ | SÃ­ | No | `started_at_utc`, `ended_at_utc` | `started_at_utc`/`ended_at_utc` modelan el intervalo; auditorÃ­a es aparte |
 
 ## Reglas de escritura de timestamps (create/update/side-effects/hard delete)
 
 | familia_operacion | docs_que_crea | docs_que_actualiza | campos_timestamp_en_create | campos_timestamp_en_update | side_effects_actualizan_updated_at | notas |
 | --- | --- | --- | --- | --- | --- | --- |
-| `Campaign.provision_initial_years` | `campaign` (si aplica), `year`, `season`, `week` | `campaign` | `created_at_utc`, `updated_at_utc` | `updated_at_utc` | Sí | `campaign.updated_at_utc` refleja provisión/ajuste de cursor/totales si cambian |
-| `Campaign.extend_years_plus_one` | `year`, `season`, `week` | `campaign` | `created_at_utc`, `updated_at_utc` | `updated_at_utc` | Sí | Incluye postcondición de `week_cursor` |
-| `Week.*` (`close/reopen/reclose/update_notes`) | Ninguno | `week` (y `session` si `auto-stop`) | N/A | `updated_at_utc` | Sí | `auto-stop` actualiza `session.updated_at_utc` |
-| `Entry.create/update/reorder` | `entry` (create) | `entry` | `created_at_utc`, `updated_at_utc` | `updated_at_utc` | Sí | `reorder` puede afectar múltiples entries; las entries modificadas actualizan `updated_at_utc` |
-| `Entry.resource_deltas` (`adjust/set/clear`) | Ninguno | `entry`, `campaign` | N/A | `updated_at_utc` | Sí | `Entry` y `campaign` actualizan `updated_at_utc` si persisten cambios |
-| `Entry.delete` | Ninguno | `session` (auto-stop previo, si aplica) | N/A | `updated_at_utc` (en la sesión antes de borrar) | Sí | Hard delete de `entry` y `session`; sin `deleted_at_utc` |
-| `Session.start/stop/auto_stop/manual_*` | `session` (start/manual_create) | `session` (stop/auto/manual_update) | `created_at_utc`, `updated_at_utc` | `updated_at_utc` | Sí | `started_at_utc`/`ended_at_utc` son campos funcionales del intervalo |
+| `Campaign.provision_initial_years` | `campaign` (si aplica), `year`, `season`, `week` | `campaign` | `created_at_utc`, `updated_at_utc` | `updated_at_utc` | SÃ­ | `campaign.updated_at_utc` refleja provisiÃ³n/ajuste de cursor/totales si cambian |
+| `Campaign.extend_years_plus_one` | `year`, `season`, `week` | `campaign` | `created_at_utc`, `updated_at_utc` | `updated_at_utc` | SÃ­ | Incluye postcondiciÃ³n de `week_cursor` |
+| `Week.*` (`close/reopen/reclose`) | Ninguno | `week` (y `session` si `auto-stop`) | N/A | `updated_at_utc` | SÃ­ | `auto-stop` actualiza `session.updated_at_utc` |
+| `Entry.create/update/reorder` | `entry` (create) | `entry` | `created_at_utc`, `updated_at_utc` | `updated_at_utc` | SÃ­ | `reorder` puede afectar mÃºltiples entries; las entries modificadas actualizan `updated_at_utc` |
+| `Entry.resource_deltas` (`adjust/set/clear`) | Ninguno | `entry`, `campaign` | N/A | `updated_at_utc` | SÃ­ | `Entry` y `campaign` actualizan `updated_at_utc` si persisten cambios |
+| `Entry.delete` | Ninguno | `session` (auto-stop previo, si aplica) | N/A | `updated_at_utc` (en la sesiÃ³n antes de borrar) | SÃ­ | Hard delete de `entry` y `session`; sin `deleted_at_utc` |
+| `Session.start/stop/auto_stop/manual_*` | `session` (start/manual_create) | `session` (stop/auto/manual_update) | `created_at_utc`, `updated_at_utc` | `updated_at_utc` | SÃ­ | `started_at_utc`/`ended_at_utc` son campos funcionales del intervalo |
 
-## Política de orden estable (query + cliente)
+## PolÃ­tica de orden estable (query + cliente)
 
 ### Regla general
 
-1. Cada lista define una **tupla canónica de orden**.
+1. Cada lista define una **tupla canÃ³nica de orden**.
 1. La query aplica el prefijo de orden que Firestore puede garantizar.
-1. El cliente completa la tupla canónica y reordena localmente.
-1. El último desempate canónico es `document_id` lexicográfico ascendente.
+1. El cliente completa la tupla canÃ³nica y reordena localmente.
+1. El Ãºltimo desempate canÃ³nico es `document_id` lexicogrÃ¡fico ascendente.
 
 ### Regla de dominio vs timestamp
 
-Cuando exista orden de dominio explícito (por ejemplo `week_number` u
+Cuando exista orden de dominio explÃ­cito (por ejemplo `week_number` u
 `order_index`), ese orden es primario. Los timestamps se usan como fallback o
 desempate estable, no como reemplazo del orden funcional del dominio.
 
 ## Manejo de timestamps pendientes
 
-- El orden canónico final solo se garantiza con timestamps de servidor ya
+- El orden canÃ³nico final solo se garantiza con timestamps de servidor ya
   confirmados.
-- Antes de confirmación puede existir estado/lista provisional en UI.
-- Tras `refresh`, el cliente reaplica la tupla canónica final.
-- Esta política no obliga a ocultar elementos pendientes; solo evita prometer
+- Antes de confirmaciÃ³n puede existir estado/lista provisional en UI.
+- Tras `refresh`, el cliente reaplica la tupla canÃ³nica final.
+- Esta polÃ­tica no obliga a ocultar elementos pendientes; solo evita prometer
   estabilidad final antes del `refresh`.
 
-## Matriz de listas y tuplas canónicas
+## Matriz de listas y tuplas canÃ³nicas
 
 | logical_list_id | uso_ui_o_lectura | query_order_prefix | client_canonical_tuple | timestamp_role | null_handling | pending_timestamp_behavior | notas |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `year_selector_list` | Selector temporal de año (UI) | `year_number ASC` (si aplica) | `(year_number ASC)` | `N/A` | `N/A` | `N/A` | Lista de dominio |
-| `season_list_within_year` | Navegación/estructura dentro de año | Sin prefijo natural útil por orden semántico | `(season_rank ASC, season_type ASC)` con `summer=0`, `winter=1` | `N/A` | `N/A` | `N/A` | Orden canónico fijo `summer -> winter` |
+| `year_selector_list` | Selector temporal de aÃ±o (UI) | `year_number ASC` (si aplica) | `(year_number ASC)` | `N/A` | `N/A` | `N/A` | Lista de dominio |
+| `season_list_within_year` | NavegaciÃ³n/estructura dentro de aÃ±o | Sin prefijo natural Ãºtil por orden semÃ¡ntico | `(season_rank ASC, season_type ASC)` con `summer=0`, `winter=1` | `N/A` | `N/A` | `N/A` | Orden canÃ³nico fijo `summer -> winter` |
 | `week_selector_list` | Selector temporal de semana (UI) | `week_number ASC` | `(week_number ASC)` | `N/A` | `N/A` | `N/A` | Lista de dominio |
 | `timeline_week_groups` | Grupos/secciones de week en timeline | `week_number ASC` | `(week_number ASC)` | `N/A` | `N/A` | `N/A` | Compatible con `#16` |
 | `week_entries_list` | Lista de entries de una `Week` (panel foco / selector de entry) | `order_index ASC` | `(order_index ASC, created_at_utc ASC, entry_id ASC)` | Fallback/desempate | `N/A` | `created_at_utc` pendiente puede dar orden provisional hasta `refresh` | `updated_at_utc` no se usa para evitar drift visual por ediciones no relacionadas con orden |
-| `timeline_entries_flat` | Timeline aplanado multi-week (si `#16` lo define) | Prefijo máximo posible según query de `#16` | `(week_number ASC, order_index ASC, created_at_utc ASC, entry_id ASC)` | Fallback/desempate | `N/A` | `created_at_utc` pendiente => orden provisional | Lista condicional; `#16` cerrada no la activa en el MVP actual |
-| `entry_sessions_combined_list` | Sesiones de una `Entry` (activa + histórico) | `started_at_utc DESC` | `(is_active DESC, started_at_utc DESC, updated_at_utc DESC, session_id ASC)` | Principal + desempate | `ended_at_utc = null` => `is_active=1` | timestamps pendientes => orden provisional hasta `refresh` | Activa primero por regla de dominio |
-| `entry_sessions_history_list` | Histórico de sesiones (sin activa o filtrando activas) | `started_at_utc DESC` | `(started_at_utc DESC, updated_at_utc DESC, session_id ASC)` | Principal + desempate | `N/A` | timestamps pendientes => orden provisional hasta `refresh` | Histórico descendente |
+| `timeline_entries_flat` | Timeline aplanado multi-week (si `#16` lo define) | Prefijo mÃ¡ximo posible segÃºn query de `#16` | `(week_number ASC, order_index ASC, created_at_utc ASC, entry_id ASC)` | Fallback/desempate | `N/A` | `created_at_utc` pendiente => orden provisional | Lista condicional; `#16` cerrada no la activa en el MVP actual |
+| `entry_sessions_combined_list` | Sesiones de una `Entry` (activa + histÃ³rico) | `started_at_utc DESC` | `(is_active DESC, started_at_utc DESC, updated_at_utc DESC, session_id ASC)` | Principal + desempate | `ended_at_utc = null` => `is_active=1` | timestamps pendientes => orden provisional hasta `refresh` | Activa primero por regla de dominio |
+| `entry_sessions_history_list` | HistÃ³rico de sesiones (sin activa o filtrando activas) | `started_at_utc DESC` | `(started_at_utc DESC, updated_at_utc DESC, session_id ASC)` | Principal + desempate | `N/A` | timestamps pendientes => orden provisional hasta `refresh` | HistÃ³rico descendente |
 
-## Alineación con #12, #16 y #40
+## AlineaciÃ³n con #12, #16 y #40
 
 ### `#12` (`docs/firestore-operation-contract.md`)
 
-- `#12` sigue definiendo contrato por operación (pre/post/rechazos/atomicidad).
-- `#18` define auditoría temporal y orden estable por lista.
-- `#12` debe referenciar este documento y dejar de decir que la política de
-  timestamps/desempates está “diferida”.
+- `#12` sigue definiendo contrato por operaciÃ³n (pre/post/rechazos/atomicidad).
+- `#18` define auditorÃ­a temporal y orden estable por lista.
+- `#12` debe referenciar este documento y dejar de decir que la polÃ­tica de
+  timestamps/desempates estÃ¡ â€œdiferidaâ€.
 
-### `#16` (consultas mínimas)
+### `#16` (consultas mÃ­nimas)
 
-- `#16` queda desbloqueada con una matriz de orden explícita por lista.
-- `#16` puede centrarse en inventario de consultas, paginación y coste,
-  reutilizando las tuplas canónicas definidas aquí.
+- `#16` queda desbloqueada con una matriz de orden explÃ­cita por lista.
+- `#16` puede centrarse en inventario de consultas, paginaciÃ³n y coste,
+  reutilizando las tuplas canÃ³nicas definidas aquÃ­.
 - `#16` adopta `timeline_week_groups` (weeks) y deja `timeline_entries_flat`
   fuera del MVP actual.
 
@@ -167,33 +167,33 @@ desempate estable, no como reemplazo del orden funcional del dominio.
 
 - No existe log `ResourceChange` en el MVP activo.
 - `#18` no necesita inventariar listas/eventos de `ResourceChange`.
-- Los cambios de recursos quedan cubiertos por auditoría/orden del documento
+- Los cambios de recursos quedan cubiertos por auditorÃ­a/orden del documento
   `Entry` cuando el contexto de UI lo requiera.
 
-## Casos de aceptación / verificación documental
+## Casos de aceptaciÃ³n / verificaciÃ³n documental
 
-1. La política elimina `deleted_at_utc` del MVP y documenta hard delete sin
+1. La polÃ­tica elimina `deleted_at_utc` del MVP y documenta hard delete sin
    soft delete.
 1. `Campaign`, `Year`, `Season`, `Week`, `Entry` y `Session` quedan con
    `created_at_utc` + `updated_at_utc`.
-1. `updated_at_utc` se actualiza también en side-effects (`auto-stop`,
-   recálculos, etc.) cuando el documento cambia persistentemente.
-1. Las listas de dominio (`year/season/week`) tienen orden canónico explícito
+1. `updated_at_utc` se actualiza tambiÃ©n en side-effects (`auto-stop`,
+   recÃ¡lculos, etc.) cuando el documento cambia persistentemente.
+1. Las listas de dominio (`year/season/week`) tienen orden canÃ³nico explÃ­cito
    aunque no usen timestamps como criterio principal.
 1. El timeline de entries usa orden de dominio primero (`week_number`,
    `order_index`) y timestamps solo como fallback/desempate.
-1. La lista combinada de sesiones pone la activa primero y mantiene histórico
+1. La lista combinada de sesiones pone la activa primero y mantiene histÃ³rico
    estable con desempates.
 1. Los timestamps pendientes solo garantizan orden provisional hasta `refresh`.
 1. `#12`, `#16` y `#40` quedan alineadas sin contradicciones de orden/timestamps.
 
-## Riesgos, límites y decisiones diferidas
+## Riesgos, lÃ­mites y decisiones diferidas
 
-- La técnica exacta para resolver `serverTimestamp` pendiente en la UI queda a
-  implementación.
-- La forma exacta de índices/`orderBy` en Firestore se concreta en `#16` y
-  código.
-- La paginación real de listas largas (si aplica) se define en `#16`.
+- La tÃ©cnica exacta para resolver `serverTimestamp` pendiente en la UI queda a
+  implementaciÃ³n.
+- La forma exacta de Ã­ndices/`orderBy` en Firestore se concreta en `#16` y
+  cÃ³digo.
+- La paginaciÃ³n real de listas largas (si aplica) se define en `#16`.
 
 ## Referencias
 
@@ -212,3 +212,4 @@ desempate estable, no como reemplazo del orden funcional del dominio.
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/12`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/16`
 - `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/40`
+

--- a/docs/ui-main-shell-architecture-mvs.md
+++ b/docs/ui-main-shell-architecture-mvs.md
@@ -1,34 +1,34 @@
-# UI Main Shell Architecture (MVS)
+﻿# UI Main Shell Architecture (MVS)
 
 ## 1) Resumen de decisiones
 
 - Se mantiene estructura de tres capas: `model.py`, `state.py`, `view.py`.
 - El runtime sigue siendo declarativo: `page.render(build_app_root, page)`.
-- `MainShellState` es `@ft.observable` y concentra orquestación de lecturas,
+- `MainShellState` es `@ft.observable` y concentra orquestaciÃ³n de lecturas,
   escrituras y estado local de UI.
 - `build_main_shell_view` es helper puro de render (sin `@ft.component`).
 - No se usa `page.update()` ni `control.update()` en `src/.../ui`.
 - Se recupera paridad funcional pre-`#94` sin reintroducir capas `MVU+effects`
   eliminadas (`dispatcher/reducer/effects/intents/selectors`).
 
-## 2) Árbol actual del feature
+## 2) Ãrbol actual del feature
 
 ```text
 src/frosthaven_campaign_journal/ui/features/main_shell/
-├── __init__.py
-├── model.py
-├── state.py
-└── view.py
+â”œâ”€â”€ __init__.py
+â”œâ”€â”€ model.py
+â”œâ”€â”€ state.py
+â””â”€â”€ view.py
 ```
 
 ## 3) Tabla por archivo
 
 | Archivo | Tipo | Responsabilidad |
 | --- | --- | --- |
-| `model.py` | MODEL | Contratos de datos de render (`MainShellViewData` + estados declarativos de confirmación/formularios). |
+| `model.py` | MODEL | Contratos de datos de render (`MainShellViewData` + estados declarativos de confirmaciÃ³n/formularios). |
 | `state.py` | STATE | Estado observable y handlers de UI + wiring real Firestore (`Q1..Q8` + writes). |
-| `view.py` | VIEW | Composición visual y binding directo a handlers del estado. |
-| `__init__.py` | Integración | API pública estable del feature. |
+| `view.py` | VIEW | ComposiciÃ³n visual y binding directo a handlers del estado. |
+| `__init__.py` | IntegraciÃ³n | API pÃºblica estable del feature. |
 
 ## 4) Flujo declarativo
 
@@ -44,9 +44,8 @@ src/frosthaven_campaign_journal/ui/features/main_shell/
 - `ConfirmationViewState`
 - `EntryFormViewState`
 - `SessionFormViewState`
-- `WeekNotesEditorViewState`
 
-Estos contratos permiten reemplazar modales imperativos por edición/confirmación
+Estos contratos permiten reemplazar modales imperativos por ediciÃ³n/confirmaciÃ³n
 declarativa renderizada en el panel central.
 
 ## 6) Cobertura funcional recuperada en `state.py`
@@ -54,22 +53,25 @@ declarativa renderizada en el panel central.
 - Lecturas: `load_main_screen_snapshot`, `read_q5_entries_for_selected_week`,
   `read_entry_by_ref`, `read_q8_sessions_for_entry`.
 - Writes:
-  - campaña: `extend_years_plus_one`
-  - week: `update_week_notes`, `close_week`, `reopen_week`, `reclose_week`
+  - campaÃ±a: `extend_years_plus_one`
+  - week: `close_week`, `reopen_week`, `reclose_week`
   - session: `start_session`, `stop_session`, `manual_create_session`,
     `manual_update_session`, `manual_delete_session`
   - entry: `create_entry`, `update_entry`, `delete_entry`,
     `reorder_entry_within_week`
   - resources: `replace_entry_resource_deltas`
 - Reglas de consistencia:
-  - visor sticky separado de navegación temporal
-  - protección de borrador sucio antes de cambios de contexto
+  - visor sticky separado de navegaciÃ³n temporal
+  - protecciÃ³n de borrador sucio antes de cambios de contexto
   - refresh selectivo Q5/Q8 tras operaciones
   - flags `*_write_pending` + errores por dominio
 
 ## 7) Guardrails de arquitectura
 
 1. Runtime declarativo obligatorio (`page.render` + `@ft.component` en root).
-1. Estado observable único de pantalla (`MainShellState`).
+1. Estado observable Ãºnico de pantalla (`MainShellState`).
 1. Binding directo desde vista a handlers del estado.
 1. No usar `page.update()` ni `control.update()` en capa `ui`.
+
+
+

--- a/src/frosthaven_campaign_journal/data/__init__.py
+++ b/src/frosthaven_campaign_journal/data/__init__.py
@@ -49,7 +49,6 @@ from .week_writes import (
     close_week,
     reopen_week,
     reclose_week,
-    update_week_notes,
 )
 from .write_errors import (
     FirestoreConflictError,
@@ -99,5 +98,4 @@ __all__ = [
     "stop_session",
     "update_entry",
     "update_entry_notes",
-    "update_week_notes",
 ]

--- a/src/frosthaven_campaign_journal/data/main_screen_reads.py
+++ b/src/frosthaven_campaign_journal/data/main_screen_reads.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -26,7 +26,6 @@ class WeekRead:
     year_number: int
     week_number: int
     status: str
-    notes: str | None
 
 
 @dataclass(frozen=True)
@@ -86,21 +85,21 @@ def read_q1_campaign_main(client: firestore.Client) -> CampaignMainRead:
         raise FirestoreReadError(f"Error leyendo Q1 (`campaigns/{CAMPAIGN_ID}`): {exc}") from exc
 
     if not snapshot.exists:
-        raise FirestoreReadError(f"No existe el documento de campaña `campaigns/{CAMPAIGN_ID}`.")
+        raise FirestoreReadError(f"No existe el documento de campaÃ±a `campaigns/{CAMPAIGN_ID}`.")
 
     data = snapshot.to_dict() or {}
 
     resource_totals_raw = data.get("resource_totals") or {}
     if not isinstance(resource_totals_raw, dict):
-        raise FirestoreReadError("Q1 inválido: `resource_totals` debe ser un mapa.")
+        raise FirestoreReadError("Q1 invÃ¡lido: `resource_totals` debe ser un mapa.")
 
     resource_totals: dict[str, int] = {}
     for key, value in resource_totals_raw.items():
         if not isinstance(key, str):
-            raise FirestoreReadError("Q1 inválido: `resource_totals` contiene una clave no string.")
+            raise FirestoreReadError("Q1 invÃ¡lido: `resource_totals` contiene una clave no string.")
         if isinstance(value, bool) or not isinstance(value, int):
             raise FirestoreReadError(
-                f"Q1 inválido: `resource_totals[{key}]` debe ser entero, recibido {type(value).__name__}."
+                f"Q1 invÃ¡lido: `resource_totals[{key}]` debe ser entero, recibido {type(value).__name__}."
             )
         resource_totals[key] = value
 
@@ -127,11 +126,11 @@ def read_q2_years_list(client: firestore.Client) -> list[int]:
                     year_number = int(snapshot.id)
                 except ValueError as exc:
                     raise FirestoreReadError(
-                        f"Q2 inválido: year `{snapshot.id}` sin `year_number` parseable."
+                        f"Q2 invÃ¡lido: year `{snapshot.id}` sin `year_number` parseable."
                     ) from exc
             if not isinstance(year_number, int) or year_number <= 0:
                 raise FirestoreReadError(
-                    f"Q2 inválido: `year_number` no válido en doc `{snapshot.id}`."
+                    f"Q2 invÃ¡lido: `year_number` no vÃ¡lido en doc `{snapshot.id}`."
                 )
             years.append(year_number)
     except FirestoreReadError:
@@ -175,19 +174,13 @@ def _read_weeks_for_season(
                     week_number = int(snapshot.id)
                 except Exception as exc:
                     raise FirestoreReadError(
-                        f"Q3/Q4 inválido: `week_number` no válido en `{snapshot.reference.path}`."
+                        f"Q3/Q4 invÃ¡lido: `week_number` no vÃ¡lido en `{snapshot.reference.path}`."
                     ) from exc
 
             status = data.get("status")
             if status not in {"open", "closed"}:
                 raise FirestoreReadError(
-                    f"Q3/Q4 inválido: `status` no válido en `{snapshot.reference.path}`."
-                )
-
-            notes = data.get("notes")
-            if notes is not None and not isinstance(notes, str):
-                raise FirestoreReadError(
-                    f"Q3/Q4 inválido: `notes` debe ser string/null en `{snapshot.reference.path}`."
+                    f"Q3/Q4 invÃ¡lido: `status` no vÃ¡lido en `{snapshot.reference.path}`."
                 )
 
             weeks.append(
@@ -195,14 +188,13 @@ def _read_weeks_for_season(
                     year_number=year_number,
                     week_number=week_number,
                     status=status,
-                    notes=notes,
                 )
             )
     except FirestoreReadError:
         raise
     except Exception as exc:
         raise FirestoreReadError(
-            f"Error leyendo weeks de `{season_type}` para año {year_number}: {exc}"
+            f"Error leyendo weeks de `{season_type}` para aÃ±o {year_number}: {exc}"
         ) from exc
 
     return weeks
@@ -259,7 +251,7 @@ def read_q5_entries_for_selected_week(
         raise
     except Exception as exc:
         raise FirestoreReadError(
-            f"Error leyendo Q5 (`entries_selected_week`) para week {week_number} (año {year_number}): {exc}"
+            f"Error leyendo Q5 (`entries_selected_week`) para week {week_number} (aÃ±o {year_number}): {exc}"
         ) from exc
 
     return sorted(
@@ -366,12 +358,12 @@ def read_q7_active_entry_doc_if_needed(
 
     entry_doc_ref = active_session.session_ref.parent.parent
     if entry_doc_ref is None:
-        raise FirestoreReadError("Q7 inválido: no se pudo resolver la Entry owner desde la sesión activa.")
+        raise FirestoreReadError("Q7 invÃ¡lido: no se pudo resolver la Entry owner desde la sesiÃ³n activa.")
 
     active_entry_ref = _entry_ref_from_entry_doc_ref(entry_doc_ref)
 
     # Q7 es condicional; en #54 lo usamos siempre para label del activo.
-    # Mantenemos el parámetro para alineación con #16 y facilitar #54+.
+    # Mantenemos el parÃ¡metro para alineaciÃ³n con #16 y facilitar #54+.
     _ = viewer_entry_ref
 
     try:
@@ -380,7 +372,7 @@ def read_q7_active_entry_doc_if_needed(
         raise FirestoreReadError(f"Error leyendo Q7 (`active_entry_doc_if_needed`): {exc}") from exc
 
     if not entry_snapshot.exists:
-        raise FirestoreReadError("Q7 inválido: la Entry owner de la sesión activa no existe.")
+        raise FirestoreReadError("Q7 invÃ¡lido: la Entry owner de la sesiÃ³n activa no existe.")
 
     data = entry_snapshot.to_dict() or {}
     entry_type_raw = data.get("type")
@@ -391,7 +383,7 @@ def read_q7_active_entry_doc_if_needed(
     if scenario_ref_raw is None:
         scenario_ref = None
     elif isinstance(scenario_ref_raw, bool) or not isinstance(scenario_ref_raw, int):
-        raise FirestoreReadError("Q7 inválido: `scenario_ref` debe ser entero o null.")
+        raise FirestoreReadError("Q7 invÃ¡lido: `scenario_ref` debe ser entero o null.")
     else:
         scenario_ref = scenario_ref_raw
 
@@ -413,7 +405,7 @@ def load_main_screen_snapshot(
     campaign_main = read_q1_campaign_main(client)
     years = read_q2_years_list(client)
     if not years:
-        raise FirestoreReadError("Q2 inválido: no hay años provisionados en la campaña.")
+        raise FirestoreReadError("Q2 invÃ¡lido: no hay aÃ±os provisionados en la campaÃ±a.")
 
     if selected_year is not None and selected_year in years:
         effective_year = selected_year
@@ -463,7 +455,7 @@ def _resolve_season_type_for_week(*, year_number: int, week_number: int) -> str:
     local_week = week_number - ((year_number - 1) * WEEKS_PER_YEAR)
     if not 1 <= local_week <= WEEKS_PER_YEAR:
         raise FirestoreReadError(
-            f"Week {week_number} no pertenece al año {year_number} según el template temporal MVP."
+            f"Week {week_number} no pertenece al aÃ±o {year_number} segÃºn el template temporal MVP."
         )
     return "summer" if local_week <= 10 else "winter"
 
@@ -472,12 +464,12 @@ def _map_entry_snapshot(snapshot: Any, *, year_number: int, week_number: int) ->
     data = snapshot.to_dict() or {}
     entry_type = data.get("type")
     if not isinstance(entry_type, str) or not entry_type:
-        raise FirestoreReadError(f"Q5/Q7 inválido: `type` no válido en `{snapshot.reference.path}`.")
+        raise FirestoreReadError(f"Q5/Q7 invÃ¡lido: `type` no vÃ¡lido en `{snapshot.reference.path}`.")
 
     order_index = data.get("order_index")
     if isinstance(order_index, bool) or not isinstance(order_index, int) or order_index <= 0:
         raise FirestoreReadError(
-            f"Q5/Q7 inválido: `order_index` no válido en `{snapshot.reference.path}`."
+            f"Q5/Q7 invÃ¡lido: `order_index` no vÃ¡lido en `{snapshot.reference.path}`."
         )
 
     scenario_ref_raw = data.get("scenario_ref")
@@ -486,20 +478,19 @@ def _map_entry_snapshot(snapshot: Any, *, year_number: int, week_number: int) ->
         scenario_ref = None
     elif isinstance(scenario_ref_raw, bool) or not isinstance(scenario_ref_raw, int):
         raise FirestoreReadError(
-            f"Q5/Q7 inválido: `scenario_ref` no válido en `{snapshot.reference.path}`."
+            f"Q5/Q7 invÃ¡lido: `scenario_ref` no vÃ¡lido en `{snapshot.reference.path}`."
         )
     else:
         scenario_ref = scenario_ref_raw
 
     notes_raw = data.get("notes")
-    notes: str | None
     if notes_raw is None:
         notes = None
     elif isinstance(notes_raw, str):
         notes = notes_raw
     else:
         raise FirestoreReadError(
-            f"Q5/Q7 inválido: `notes` debe ser string/null en `{snapshot.reference.path}`."
+            f"Q5/Q7 invÃ¡lido: `notes` debe ser string/null en `{snapshot.reference.path}`."
         )
 
     scenario_outcome_raw = data.get("scenario_outcome")
@@ -510,23 +501,23 @@ def _map_entry_snapshot(snapshot: Any, *, year_number: int, week_number: int) ->
         scenario_outcome = scenario_outcome_raw
     else:
         raise FirestoreReadError(
-            f"Q5/Q7 inválido: `scenario_outcome` debe ser victory/defeat/null en `{snapshot.reference.path}`."
+            f"Q5/Q7 invÃ¡lido: `scenario_outcome` debe ser victory/defeat/null en `{snapshot.reference.path}`."
         )
 
     resource_deltas_raw = data.get("resource_deltas") or {}
     if not isinstance(resource_deltas_raw, dict):
         raise FirestoreReadError(
-            f"Q5/Q7 inválido: `resource_deltas` debe ser mapa en `{snapshot.reference.path}`."
+            f"Q5/Q7 invÃ¡lido: `resource_deltas` debe ser mapa en `{snapshot.reference.path}`."
         )
     resource_deltas: dict[str, int] = {}
     for key, value in resource_deltas_raw.items():
         if not isinstance(key, str):
             raise FirestoreReadError(
-                f"Q5/Q7 inválido: clave de `resource_deltas` no string en `{snapshot.reference.path}`."
+                f"Q5/Q7 invÃ¡lido: clave de `resource_deltas` no string en `{snapshot.reference.path}`."
             )
         if isinstance(value, bool) or not isinstance(value, int):
             raise FirestoreReadError(
-                f"Q5/Q7 inválido: `resource_deltas[{key}]` no entero en `{snapshot.reference.path}`."
+                f"Q5/Q7 invÃ¡lido: `resource_deltas[{key}]` no entero en `{snapshot.reference.path}`."
             )
         resource_deltas[key] = value
 
@@ -550,16 +541,16 @@ def _entry_ref_from_entry_doc_ref(entry_doc_ref: Any) -> EntryRef:
         season_doc_ref = week_doc_ref.parent.parent
         year_doc_ref = season_doc_ref.parent.parent
     except Exception as exc:
-        raise FirestoreReadError("Q7 inválido: no se pudo reconstruir la jerarquía de la Entry activa.") from exc
+        raise FirestoreReadError("Q7 invÃ¡lido: no se pudo reconstruir la jerarquÃ­a de la Entry activa.") from exc
 
     if week_doc_ref is None or year_doc_ref is None:
-        raise FirestoreReadError("Q7 inválido: jerarquía incompleta al resolver la Entry activa.")
+        raise FirestoreReadError("Q7 invÃ¡lido: jerarquÃ­a incompleta al resolver la Entry activa.")
 
     try:
         year_number = int(year_doc_ref.id)
         week_number = int(week_doc_ref.id)
     except ValueError as exc:
-        raise FirestoreReadError("Q7 inválido: IDs de year/week no parseables en la ruta de la Entry activa.") from exc
+        raise FirestoreReadError("Q7 invÃ¡lido: IDs de year/week no parseables en la ruta de la Entry activa.") from exc
 
     return EntryRef(
         year_number=year_number,
@@ -590,3 +581,4 @@ def _sortable_dt_desc(value: Any | None) -> tuple[int, float]:
     except Exception:
         return (1, 0.0)
     return (0, -ts)
+

--- a/src/frosthaven_campaign_journal/data/week_writes.py
+++ b/src/frosthaven_campaign_journal/data/week_writes.py
@@ -28,42 +28,6 @@ class WeekWriteResult:
     auto_stopped_session_id: str | None = None
 
 
-def update_week_notes(
-    client: firestore.Client,
-    *,
-    year_number: int,
-    week_number: int,
-    notes: str,
-) -> WeekWriteResult:
-    if not isinstance(notes, str):
-        raise FirestoreValidationError("Las notas de week deben ser texto.")
-
-    week_doc_ref = _week_doc_ref(client, year_number=year_number, week_number=week_number)
-    transaction = client.transaction()
-
-    @firestore.transactional
-    def _run(txn: firestore.Transaction) -> None:
-        snapshot = _get_doc_snapshot(txn, week_doc_ref)
-        if not snapshot.exists:
-            raise FirestoreTransitionInvalidError("La week ya no existe.")
-        txn.update(
-            week_doc_ref,
-            {
-                "notes": notes,
-                "updated_at_utc": firestore.SERVER_TIMESTAMP,
-            },
-        )
-
-    try:
-        _run(transaction)
-    except (FirestoreWriteError, FirestoreConflictError, FirestoreTransitionInvalidError, FirestoreValidationError):
-        raise
-    except Exception as exc:  # pragma: no cover - defensive mapping
-        _map_firestore_write_exception(exc)
-
-    return WeekWriteResult(week_number=week_number)
-
-
 def close_week(
     client: firestore.Client,
     *,

--- a/src/frosthaven_campaign_journal/models/__init__.py
+++ b/src/frosthaven_campaign_journal/models/__init__.py
@@ -44,7 +44,6 @@ class WeekSummary:
     week_number: int
     is_closed: bool
     status_label: str
-    notes_preview: str
 
 
 @dataclass

--- a/src/frosthaven_campaign_journal/ui/common/resources/groups.py
+++ b/src/frosthaven_campaign_journal/ui/common/resources/groups.py
@@ -13,6 +13,7 @@ class ResourceUiGroup:
 
 
 _RESOURCE_UI_GROUP_DEFS: tuple[tuple[str, str, tuple[tuple[str, ...], ...]], ...] = (
+    ("others", "Otros", (("inspiration", "morale", "soldiers"),)),
     ("materials", "Materiales", (("lumber", "metal", "hide"),)),
     (
         "plants",
@@ -22,7 +23,6 @@ _RESOURCE_UI_GROUP_DEFS: tuple[tuple[str, str, tuple[tuple[str, ...], ...]], ...
             ("flamefruit", "rockroot", "snowthistle"),
         ),
     ),
-    ("others", "Otros", (("inspiration", "morale", "soldiers"),)),
 )
 
 

--- a/src/frosthaven_campaign_journal/ui/common/resources/resource_total_row.py
+++ b/src/frosthaven_campaign_journal/ui/common/resources/resource_total_row.py
@@ -12,7 +12,10 @@ class ResourceTotalRow(ft.Row):
     total_text: str = "0"
     text_color: str = COLOR_WHITE
     value_color: str = COLOR_RESOURCE_TOTAL_VALUE
+    icon_color: str | None = None
     icon_width: int = 20
+    label_size: int = 12
+    value_size: int = 12
     label_width: int = 136
     value_width: int = 44
 
@@ -21,14 +24,20 @@ class ResourceTotalRow(ft.Row):
             ft.Container(
                 width=self.icon_width,
                 alignment=ft.Alignment.CENTER_LEFT,
-                content=ft.Image(src=self.icon_src, width=18, height=18),
+                content=ft.Image(
+                    src=self.icon_src,
+                    width=18,
+                    height=18,
+                    color=self.icon_color,
+                    color_blend_mode=ft.BlendMode.SRC_IN if self.icon_color else None,
+                ),
             ),
             ft.Container(
                 width=self.label_width,
                 alignment=ft.Alignment.CENTER_LEFT,
                 content=ft.Text(
                     self.label_es,
-                    size=12,
+                    size=self.label_size,
                     color=self.text_color,
                     no_wrap=True,
                     overflow=ft.TextOverflow.ELLIPSIS,
@@ -39,7 +48,7 @@ class ResourceTotalRow(ft.Row):
                 alignment=ft.Alignment.CENTER_RIGHT,
                 content=ft.Text(
                     self.total_text,
-                    size=12,
+                    size=self.value_size,
                     color=self.value_color,
                     weight=ft.FontWeight.W_700,
                     text_align=ft.TextAlign.RIGHT,
@@ -50,11 +59,11 @@ class ResourceTotalRow(ft.Row):
 
     def init(self) -> None:
         super().init()
-        self.spacing = 6
+        self.spacing = 4
         self.vertical_alignment = ft.CrossAxisAlignment.CENTER
         self.controls = self._build_controls()
 
     def before_update(self) -> None:
-        self.spacing = 6
+        self.spacing = 4
         self.vertical_alignment = ft.CrossAxisAlignment.CENTER
         self.controls = self._build_controls()

--- a/src/frosthaven_campaign_journal/ui/common/theme/layout.py
+++ b/src/frosthaven_campaign_journal/ui/common/theme/layout.py
@@ -2,4 +2,4 @@ from __future__ import annotations
 
 TOP_BAR_HEIGHT = 72
 ENTRY_TABS_BAR_HEIGHT = 44
-BOTTOM_BAR_HEIGHT = 128
+BOTTOM_BAR_HEIGHT = 108

--- a/src/frosthaven_campaign_journal/ui/main_shell/model.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/model.py
@@ -64,7 +64,6 @@ class MainShellViewData:
     entry_form: "EntryFormViewState | None"
     entry_notes_editor: "EntryNotesEditorViewState | None"
     session_form: "SessionFormViewState | None"
-    week_notes_editor: "WeekNotesEditorViewState | None"
 
 
 @dataclass(frozen=True)
@@ -104,7 +103,3 @@ class SessionFormViewState:
     error_message: str | None
 
 
-@dataclass(frozen=True)
-class WeekNotesEditorViewState:
-    notes_value: str
-    error_message: str | None

--- a/src/frosthaven_campaign_journal/ui/main_shell/state/shell_state.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/state/shell_state.py
@@ -26,7 +26,6 @@ from frosthaven_campaign_journal.ui.main_shell.state.types import (
     EntryPanelReadState,
     MainScreenReadState,
     SessionFormState,
-    WeekNotesEditorState,
 )
 
 
@@ -49,7 +48,6 @@ class MainShellState(
     entry_form_state: EntryFormState | None = None
     entry_notes_editor_state: EntryNotesEditorState | None = None
     session_form_state: SessionFormState | None = None
-    week_notes_editor_state: WeekNotesEditorState | None = None
     info_message: str | None = None
     _pending_context_action: Callable[[], None] | None = field(default=None, init=False, repr=False)
     _pending_context_action_label: str | None = field(default=None, init=False, repr=False)

--- a/src/frosthaven_campaign_journal/ui/main_shell/state/types.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/state/types.py
@@ -85,9 +85,3 @@ class SessionFormState:
     ended_time_local: str
     active_without_end: bool
     error_message: str | None = None
-
-
-@dataclass
-class WeekNotesEditorState:
-    notes_value: str
-    error_message: str | None = None

--- a/src/frosthaven_campaign_journal/ui/main_shell/state/utils.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/state/utils.py
@@ -8,13 +8,11 @@ from frosthaven_campaign_journal.models import EntryRef, EntrySummary, ViewerSes
 
 def map_week_read_to_summary(week: WeekRead) -> WeekSummary:
     is_closed = week.status == "closed"
-    notes_preview = week.notes or ""
     return WeekSummary(
         year_number=week.year_number,
         week_number=week.week_number,
         is_closed=is_closed,
         status_label=week.status,
-        notes_preview=notes_preview,
     )
 
 

--- a/src/frosthaven_campaign_journal/ui/main_shell/state/view_data.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/state/view_data.py
@@ -10,7 +10,6 @@ from frosthaven_campaign_journal.ui.main_shell.model import (
     MainShellViewData,
     SessionFormViewState,
     WeekEntryCardViewData,
-    WeekNotesEditorViewState,
 )
 
 
@@ -53,13 +52,6 @@ class MainShellViewDataMixin:
                 active_without_end=self.session_form_state.active_without_end,
                 error_message=self.session_form_state.error_message,
             )
-        week_notes_view: WeekNotesEditorViewState | None = None
-        if self.week_notes_editor_state is not None:
-            week_notes_view = WeekNotesEditorViewState(
-                notes_value=self.week_notes_editor_state.notes_value,
-                error_message=self.week_notes_editor_state.error_message,
-            )
-
         week_entry_cards = [
             _build_week_entry_card_view_data(
                 entry=entry,
@@ -119,7 +111,6 @@ class MainShellViewDataMixin:
             entry_form=entry_form_view,
             entry_notes_editor=entry_notes_view,
             session_form=session_form_view,
-            week_notes_editor=week_notes_view,
         )
 
 

--- a/src/frosthaven_campaign_journal/ui/main_shell/state/week_entry_resources.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/state/week_entry_resources.py
@@ -9,13 +9,11 @@ from frosthaven_campaign_journal.data import (
     replace_entry_resource_deltas,
     update_entry,
     update_entry_notes,
-    update_week_notes,
 )
 from frosthaven_campaign_journal.models import ENTRY_RESOURCE_KEYS, EntryRef, entry_ref_matches_selected_week
 from frosthaven_campaign_journal.ui.main_shell.state.types import (
     EntryFormState,
     EntryNotesEditorState,
-    WeekNotesEditorState,
 )
 from frosthaven_campaign_journal.ui.main_shell.state.utils import (
     find_entry_in_list,
@@ -24,51 +22,6 @@ from frosthaven_campaign_journal.ui.main_shell.state.utils import (
 
 
 class MainShellWeekEntryResourceActionsMixin:
-    def on_open_week_notes_modal(self, _event: ft.ControlEvent | None = None) -> None:
-        selected_week = self._find_selected_week_for_write()
-        if selected_week is None:
-            self._set_week_error("No hay semana seleccionada para editar notas.")
-            self.notify()
-            return
-        self.week_notes_editor_state = WeekNotesEditorState(
-            notes_value=selected_week.notes_preview or "",
-            error_message=None,
-        )
-        self.notify()
-
-    def on_week_notes_change(self, event: ft.ControlEvent) -> None:
-        if self.week_notes_editor_state is None:
-            return
-        self.week_notes_editor_state.notes_value = event.control.value or ""
-        self.week_notes_editor_state.error_message = None
-        self.notify()
-
-    def on_cancel_week_notes_editor(self, _event: ft.ControlEvent | None = None) -> None:
-        self.week_notes_editor_state = None
-        self.notify()
-
-    def on_submit_week_notes(self, _event: ft.ControlEvent | None = None) -> None:
-        editor = self.week_notes_editor_state
-        selected_week = self._find_selected_week_for_write()
-        if editor is None:
-            return
-        if selected_week is None:
-            editor.error_message = "No hay semana seleccionada para guardar notas."
-            self.notify()
-            return
-        result = self._run_week_write(
-            lambda client: update_week_notes(
-                client,
-                year_number=selected_week.year_number,
-                week_number=selected_week.week_number,
-                notes=editor.notes_value,
-            ),
-            success_message="Notas de semana actualizadas.",
-        )
-        if result is not None:
-            self.week_notes_editor_state = None
-        self.notify()
-
     def on_request_week_close(self, _event: ft.ControlEvent | None = None) -> None:
         selected_week = self._find_selected_week_for_write()
         if selected_week is None:

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/center_focus.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/center_focus.py
@@ -31,7 +31,6 @@ from frosthaven_campaign_journal.ui.main_shell.view.center_helpers import (
     _build_card,
     _format_navigation_line,
     _format_session_line,
-    _format_week_status_label,
 )
 
 WEEK_ENTRY_CARD_WIDTH = 540
@@ -54,84 +53,8 @@ def _build_focus_empty_mode(data: MainShellViewData) -> ft.Control:
     )
 
 
-def _build_focus_week_mode(data: MainShellViewData, state: MainShellState, week: WeekSummary) -> ft.Control:
-    return ft.Column(
-        expand=True,
-        spacing=12,
-        controls=[
-            _build_week_header_card(data, state, week),
-            _build_week_cards_lane(data, state),
-        ],
-    )
-
-
-def _build_week_header_card(data: MainShellViewData, state: MainShellState, week: WeekSummary) -> ft.Control:
-    week_actions: list[ft.Control] = [
-        ft.OutlinedButton(
-            "Editar notas semana",
-            on_click=state.on_open_week_notes_modal,
-            disabled=data.week_write_pending,
-            height=32,
-        ),
-        ft.OutlinedButton(
-            "Crear entrada",
-            on_click=state.on_open_entry_add_modal,
-            disabled=data.entry_write_pending,
-            height=32,
-        ),
-    ]
-
-    if week.is_closed:
-        week_actions.append(
-            ft.FilledButton(
-                "Reabrir",
-                on_click=state.on_request_week_reopen,
-                disabled=data.week_write_pending,
-                height=32,
-            )
-        )
-    else:
-        week_actions.extend(
-            [
-                ft.FilledButton(
-                    "Cerrar",
-                    on_click=state.on_request_week_close,
-                    disabled=data.week_write_pending,
-                    height=32,
-                ),
-                ft.OutlinedButton(
-                    "Recerrar",
-                    on_click=state.on_request_week_reclose,
-                    disabled=data.week_write_pending,
-                    height=32,
-                ),
-            ]
-        )
-
-    body_lines = [
-        f"Estado: {_format_week_status_label(week.status_label)}",
-        f"Notas de semana: {week.notes_preview or 'Sin notas'}",
-        _format_navigation_line(data),
-    ]
-    if data.week_write_error_message:
-        body_lines.append(f"Error de semana: {data.week_write_error_message}")
-    if data.entry_write_error_message:
-        body_lines.append(f"Error de entrada: {data.entry_write_error_message}")
-
-    return ft.Container(
-        padding=ft.Padding.all(12),
-        bgcolor=COLOR_PANEL_BG,
-        border=ft.Border.all(1, COLOR_PANEL_BORDER),
-        border_radius=8,
-        content=ft.Column(
-            spacing=8,
-            controls=[
-                ft.Text(f"Semana {week.week_number}", size=22, weight=ft.FontWeight.BOLD),
-                ft.Row(spacing=8, wrap=True, controls=week_actions),
-                ft.Text("\n".join(body_lines), size=13, color=COLOR_TEXT_MUTED),
-            ],
-        ),
-    )
+def _build_focus_week_mode(data: MainShellViewData, state: MainShellState, _week: WeekSummary) -> ft.Control:
+    return _build_week_cards_lane(data, state)
 
 
 def _build_week_cards_lane(data: MainShellViewData, state: MainShellState) -> ft.Control:
@@ -144,7 +67,7 @@ def _build_week_cards_lane(data: MainShellViewData, state: MainShellState) -> ft
     if not data.week_entry_cards:
         return _build_card(
             title="Entradas de la semana",
-            body="Semana sin entradas. Usa 'Crear entrada' para añadir un escenario o un puesto fronterizo.",
+            body="Semana sin entradas. Usa el botón + para crear un escenario o un puesto fronterizo.",
         )
 
     card_count = len(data.week_entry_cards)
@@ -212,20 +135,10 @@ def _build_entry_card_header(
     card: WeekEntryCardViewData,
 ) -> ft.Control:
     entry = card.entry
-    header_badges: list[ft.Control] = []
     outcome_icon = _build_entry_outcome_icon(entry)
+    title_controls: list[ft.Control] = [ft.Text(entry.label, size=18, weight=ft.FontWeight.BOLD, color=COLOR_TEXT_HEADING)]
     if outcome_icon is not None:
-        header_badges.append(outcome_icon)
-
-    header_badges.append(
-        ft.Container(
-            padding=ft.Padding(left=8, top=2, right=8, bottom=2),
-            bgcolor=COLOR_PANEL_INNER_BG,
-            border=ft.Border.all(1, COLOR_PANEL_INNER_BORDER),
-            border_radius=999,
-            content=ft.Text(_format_entry_type_label(entry), size=11, color=COLOR_TEXT_MUTED),
-        )
-    )
+        title_controls.append(outcome_icon)
 
     action_buttons: list[ft.Control] = [
         ft.IconButton(
@@ -282,24 +195,18 @@ def _build_entry_card_header(
                         expand=True,
                         spacing=2,
                         controls=[
-                            ft.Text(entry.label, size=18, weight=ft.FontWeight.BOLD, color=COLOR_TEXT_HEADING),
-                            ft.Row(spacing=6, wrap=True, controls=header_badges),
+                            ft.Row(spacing=6, wrap=True, controls=title_controls),
                         ],
                     ),
                     ft.Row(spacing=2, controls=action_buttons),
                 ],
-            ),
-            ft.Text(
-                f"Semana {entry.ref.week_number} · Año {entry.ref.year_number}",
-                size=12,
-                color=COLOR_TEXT_MUTED,
             ),
         ],
     )
 
 
 def _build_entry_card_details(entry: EntrySummary) -> ft.Control:
-    detail_lines: list[str] = [f"Tipo: {_format_entry_type_label(entry)}"]
+    detail_lines: list[str] = []
     if entry.scenario_ref is not None:
         detail_lines.append(f"Referencia de escenario: {entry.scenario_ref}")
 
@@ -547,14 +454,6 @@ def _build_entry_outcome_icon(entry: EntrySummary) -> ft.Control | None:
     if entry.scenario_outcome == "defeat":
         return ft.Icon(ft.Icons.CANCEL, size=18, color=COLOR_DEFEAT_ICON, tooltip="Derrota")
     return None
-
-
-def _format_entry_type_label(entry: EntrySummary) -> str:
-    if entry.entry_type == "scenario":
-        return "Escenario"
-    if entry.entry_type == "outpost":
-        return "Puesto fronterizo"
-    return entry.entry_type
 
 
 def _build_entry_card_status_texts(

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/center_forms.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/center_forms.py
@@ -29,30 +29,6 @@ def _build_confirmation_card(data: MainShellViewData, state: MainShellState) -> 
     )
 
 
-def _build_week_notes_editor(data: MainShellViewData, state: MainShellState) -> ft.Control:
-    assert data.week_notes_editor is not None
-    return build_panel(
-        controls=[
-            ft.Text("Editar notas de semana", size=14, weight=ft.FontWeight.BOLD, color=COLOR_TEXT_HEADING),
-            ft.TextField(
-                value=data.week_notes_editor.notes_value,
-                multiline=True,
-                min_lines=3,
-                max_lines=6,
-                on_change=state.on_week_notes_change,
-            ),
-            ft.Row(
-                spacing=8,
-                controls=[
-                    ft.TextButton("Cancelar", on_click=state.on_cancel_week_notes_editor),
-                    ft.FilledButton("Guardar notas", on_click=state.on_submit_week_notes),
-                ],
-            ),
-            ft.Text(data.week_notes_editor.error_message or "", size=12, color=COLOR_ERROR_TEXT),
-        ],
-    )
-
-
 def _build_entry_form_editor(data: MainShellViewData, state: MainShellState) -> ft.Control:
     assert data.entry_form is not None
     is_scenario = data.entry_form.entry_type == "scenario"

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/center_panel.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/center_panel.py
@@ -3,7 +3,7 @@
 import flet as ft
 
 from frosthaven_campaign_journal.ui.common.components.surfaces import BannerTone, build_banner
-from frosthaven_campaign_journal.ui.common.theme.colors import COLOR_CENTER_BG, COLOR_TEXT_HEADING
+from frosthaven_campaign_journal.ui.common.theme.colors import COLOR_CENTER_BG
 from frosthaven_campaign_journal.ui.main_shell.model import MainShellViewData
 from frosthaven_campaign_journal.ui.main_shell.state import MainShellState
 from frosthaven_campaign_journal.ui.main_shell.view.center_focus import (
@@ -15,7 +15,6 @@ from frosthaven_campaign_journal.ui.main_shell.view.center_forms import (
     _build_entry_form_editor,
     _build_entry_notes_editor,
     _build_session_form_editor,
-    _build_week_notes_editor,
 )
 from frosthaven_campaign_journal.ui.main_shell.view.center_helpers import _find_selected_week
 
@@ -29,11 +28,13 @@ def build_center_panel(data: MainShellViewData, state: MainShellState) -> ft.Con
         top_controls.append(build_banner(title="Advertencia", body=data.read_warning_message, tone=BannerTone.WARNING))
     if data.info_message:
         top_controls.append(build_banner(title="Información", body=data.info_message, tone=BannerTone.INFO))
+    if data.week_write_error_message:
+        top_controls.append(build_banner(title="Error de semana", body=data.week_write_error_message, tone=BannerTone.ERROR))
+    if data.entry_write_error_message:
+        top_controls.append(build_banner(title="Error de entrada", body=data.entry_write_error_message, tone=BannerTone.ERROR))
 
     if data.confirmation is not None:
         top_controls.append(_build_confirmation_card(data, state))
-    if data.week_notes_editor is not None:
-        top_controls.append(_build_week_notes_editor(data, state))
     if data.entry_form is not None:
         top_controls.append(_build_entry_form_editor(data, state))
     if data.entry_notes_editor is not None:
@@ -42,22 +43,6 @@ def build_center_panel(data: MainShellViewData, state: MainShellState) -> ft.Con
         top_controls.append(_build_session_form_editor(data, state))
 
     selected_week = _find_selected_week(data)
-    if selected_week is not None:
-        top_controls.append(
-            ft.Row(
-                alignment=ft.MainAxisAlignment.END,
-                controls=[
-                    ft.IconButton(
-                        icon=ft.Icons.REFRESH,
-                        icon_size=18,
-                        icon_color=COLOR_TEXT_HEADING,
-                        tooltip="Refrescar datos de la semana visible",
-                        on_click=state.on_manual_refresh,
-                    ),
-                ],
-            )
-        )
-
     focus_control = (
         _build_focus_week_mode(data, state, selected_week)
         if selected_week is not None

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/shell_view.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/shell_view.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import flet as ft
 
+from frosthaven_campaign_journal.models import WeekSummary
+from frosthaven_campaign_journal.ui.main_shell.model import MainShellViewData
 from frosthaven_campaign_journal.ui.main_shell.state import MainShellState
 from frosthaven_campaign_journal.ui.common.theme.colors import (
     COLOR_BOTTOM_BAR_BG,
     COLOR_CENTER_BG,
+    COLOR_TOP_NAV_BUTTON_BG,
     COLOR_TOP_BAR_BG,
+    COLOR_WHITE,
 )
 from frosthaven_campaign_journal.ui.common.theme.layout import (
     BOTTOM_BAR_HEIGHT,
@@ -27,20 +31,94 @@ def build_main_shell_view(state: MainShellState) -> ft.Control:
             leading_width=0,
             title_spacing=0,
             elevation=0,
-            force_material_transparency=True,
+            force_material_transparency=False,
             bgcolor=COLOR_TOP_BAR_BG,
             title=build_top_temporal_bar(data, state),
         ),
         bottom_appbar=ft.BottomAppBar(
             height=BOTTOM_BAR_HEIGHT,
-            padding=ft.Padding(left=16, top=12, right=16, bottom=12),
+            padding=ft.Padding(left=12, top=8, right=12, bottom=8),
             elevation=0,
             bgcolor=COLOR_BOTTOM_BAR_BG,
             content=build_status_bar(data),
         ),
+        floating_action_button=_build_week_actions_fab(data, state),
+        floating_action_button_location=ft.FloatingActionButtonLocation.END_FLOAT,
         content=ft.Container(
             expand=True,
             bgcolor=COLOR_CENTER_BG,
             content=build_center_panel(data, state),
         ),
+    )
+
+
+def _find_selected_week(data: MainShellViewData) -> WeekSummary | None:
+    if data.state.selected_week is None:
+        return None
+    for week in data.weeks_for_selected_year:
+        if week.week_number == data.state.selected_week:
+            return week
+    return None
+
+
+def _build_week_actions_fab(data: MainShellViewData, state: MainShellState) -> ft.Control | None:
+    selected_week = _find_selected_week(data)
+    if selected_week is None:
+        return None
+
+    write_pending = data.week_write_pending or data.entry_write_pending or data.campaign_write_pending
+    menu_items: list[ft.PopupMenuItem] = [
+        ft.PopupMenuItem(
+            icon=ft.Icons.ADD_CIRCLE_OUTLINE,
+            content="Crear entrada",
+            on_click=state.on_open_entry_add_modal,
+            disabled=data.entry_write_pending or data.campaign_write_pending,
+        ),
+    ]
+
+    if selected_week.is_closed:
+        menu_items.append(
+            ft.PopupMenuItem(
+                icon=ft.Icons.LOCK_OPEN,
+                content="Reabrir semana",
+                on_click=state.on_request_week_reopen,
+                disabled=write_pending,
+            )
+        )
+    else:
+        menu_items.extend(
+            [
+                ft.PopupMenuItem(
+                    icon=ft.Icons.LOCK,
+                    content="Cerrar semana",
+                    on_click=state.on_request_week_close,
+                    disabled=write_pending,
+                ),
+                ft.PopupMenuItem(
+                    icon=ft.Icons.LOCK_RESET,
+                    content="Recerrar semana",
+                    on_click=state.on_request_week_reclose,
+                    disabled=write_pending,
+                ),
+            ]
+        )
+
+    menu_items.append(
+        ft.PopupMenuItem(
+            icon=ft.Icons.REFRESH,
+            content="Refrescar",
+            on_click=state.on_manual_refresh,
+            disabled=data.campaign_write_pending,
+        )
+    )
+
+    return ft.PopupMenuButton(
+        icon=ft.Icons.ADD,
+        icon_size=26,
+        icon_color=COLOR_WHITE,
+        tooltip="Acciones de semana",
+        bgcolor=COLOR_TOP_NAV_BUTTON_BG,
+        shape=ft.CircleBorder(),
+        padding=14,
+        items=menu_items,
     )

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/status_bar.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/status_bar.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 import flet as ft
 
@@ -12,21 +12,12 @@ from frosthaven_campaign_journal.ui.common.theme.colors import (
     COLOR_STATUS_LABEL_BG,
     COLOR_STATUS_LABEL_BORDER,
     COLOR_STATUS_LABEL_TEXT,
-    COLOR_STATUS_TEXT_SECONDARY,
-    COLOR_STATUS_TEXT_TERTIARY,
     COLOR_WHITE,
 )
 from frosthaven_campaign_journal.ui.main_shell.model import MainShellViewData
 
 
 def build_status_bar(data: MainShellViewData) -> ft.Control:
-    active_text, active_detail_text = _active_status_texts(data)
-    viewer_text = (
-        f"Viendo: {data.viewer_entry.label} (S{data.viewer_entry.ref.week_number})"
-        if data.viewer_entry is not None
-        else "Sin entrada en visor"
-    )
-
     return ft.Row(
         vertical_alignment=ft.CrossAxisAlignment.CENTER,
         controls=[
@@ -34,38 +25,10 @@ def build_status_bar(data: MainShellViewData) -> ft.Control:
                 expand=True,
                 content=ft.Row(
                     scroll=ft.ScrollMode.AUTO,
-                    spacing=10,
+                    spacing=8,
                     controls=[
                         _build_resource_group_box(data, group)
                         for group in iter_resource_ui_groups()
-                    ],
-                ),
-            ),
-            ft.Container(
-                width=360,
-                content=ft.Column(
-                    spacing=1,
-                    horizontal_alignment=ft.CrossAxisAlignment.END,
-                    controls=[
-                        ft.Text(
-                            active_text,
-                            size=13,
-                            weight=ft.FontWeight.BOLD,
-                            color=COLOR_WHITE,
-                            text_align=ft.TextAlign.RIGHT,
-                        ),
-                        ft.Text(
-                            active_detail_text or viewer_text,
-                            size=12,
-                            color=COLOR_STATUS_TEXT_SECONDARY,
-                            text_align=ft.TextAlign.RIGHT,
-                        ),
-                        ft.Text(
-                            f"{viewer_text} · env={data.env_name}",
-                            size=11,
-                            color=COLOR_STATUS_TEXT_TERTIARY,
-                            text_align=ft.TextAlign.RIGHT,
-                        ),
                     ],
                 ),
             ),
@@ -80,7 +43,7 @@ def _build_resource_group_box(data: MainShellViewData, group: ResourceUiGroup) -
             ft.Container(
                 expand=1,
                 content=ft.Column(
-                    spacing=4,
+                    spacing=3,
                     controls=[
                         _build_resource_total_row(
                             item=item,
@@ -97,21 +60,21 @@ def _build_resource_group_box(data: MainShellViewData, group: ResourceUiGroup) -
         columns_control = column_controls[0]
     else:
         columns_control = ft.Row(
-            spacing=12,
+            spacing=10,
             vertical_alignment=ft.CrossAxisAlignment.START,
             controls=column_controls,
         )
 
     return LabeledGroupBox(
         label=group.label_es,
-        width=(462 if len(group.columns) > 1 else 235),
+        width=(430 if len(group.columns) > 1 else 228),
         content=columns_control,
         bgcolor=COLOR_STATUS_GROUP_BG,
         border_color=COLOR_STATUS_GROUP_BORDER,
         label_bgcolor=COLOR_STATUS_LABEL_BG,
         label_border_color=COLOR_STATUS_LABEL_BORDER,
         label_text_color=COLOR_STATUS_LABEL_TEXT,
-        padding=ft.Padding(left=8, top=10, right=8, bottom=6),
+        padding=ft.Padding(left=8, top=9, right=8, bottom=4),
     )
 
 
@@ -126,8 +89,11 @@ def _build_resource_total_row(
         total_text=_format_saved_total(resource_totals, item.key),
         text_color=COLOR_WHITE,
         value_color=COLOR_RESOURCE_TOTAL_VALUE,
-        label_width=136,
-        value_width=44,
+        icon_color=COLOR_WHITE,
+        label_size=13,
+        value_size=14,
+        label_width=116,
+        value_width=32,
     )
 
 
@@ -135,14 +101,3 @@ def _format_saved_total(resource_totals: dict[str, int] | None, resource_key: st
     if resource_totals is None:
         return "N/D"
     return str(resource_totals.get(resource_key, 0))
-
-
-def _active_status_texts(data: MainShellViewData) -> tuple[str, str]:
-    if data.active_status_error_message:
-        return ("Estado activo no disponible", data.active_status_error_message)
-    if data.active_entry_ref is None:
-        return ("Sin sesión activa", "")
-    label = data.active_entry_label or f"Entrada {data.active_entry_ref.entry_id}"
-    if data.viewer_entry is not None and data.viewer_entry.ref == data.active_entry_ref:
-        return (f"Con sesión activa: {label} · aquí", "")
-    return (f"Con sesión activa: {label} · en otra entrada", "")

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/temporal_bar.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/temporal_bar.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 import flet as ft
 
@@ -9,9 +9,10 @@ from frosthaven_campaign_journal.ui.common.theme.colors import (
     COLOR_SEASON_LABEL_BG,
     COLOR_SEASON_LABEL_BORDER,
     COLOR_SEASON_LABEL_TEXT,
-    COLOR_TOP_BAR_TEXT,
     COLOR_TEXT_MUTED,
     COLOR_TEXT_PRIMARY,
+    COLOR_TOP_BAR_BG,
+    COLOR_TOP_BAR_TEXT,
     COLOR_TOP_NAV_BUTTON_BG,
     COLOR_TOP_NAV_BUTTON_DISABLED_BG,
     COLOR_TOP_NAV_BUTTON_TEXT_DISABLED,
@@ -49,7 +50,7 @@ def build_top_temporal_bar(data: MainShellViewData, state: MainShellState) -> ft
         right_year_label = ">"
         right_year_action = None
     elif is_last_year:
-        right_year_label = "+ Año"
+        right_year_label = "+"
         right_year_action = (
             state.on_open_extend_year_plus_one_confirm if not data.campaign_write_pending else None
         )
@@ -99,20 +100,20 @@ def build_top_temporal_bar(data: MainShellViewData, state: MainShellState) -> ft
             )
 
         week_strip_content = ft.Row(
-            spacing=8,
+            spacing=6,
             wrap=False,
             scroll=ft.ScrollMode.AUTO,
             controls=season_blocks,
         )
 
     year_group = ft.Row(
-        spacing=12,
+        spacing=10,
         vertical_alignment=ft.CrossAxisAlignment.CENTER,
         controls=[
             _build_year_nav_button("<", left_year_action),
             ft.Text(
                 year_title,
-                size=42,
+                size=34,
                 weight=ft.FontWeight.BOLD,
                 color=COLOR_TOP_BAR_TEXT,
             ),
@@ -121,9 +122,10 @@ def build_top_temporal_bar(data: MainShellViewData, state: MainShellState) -> ft
     )
 
     return ft.Container(
-        padding=ft.Padding(left=12, top=10, right=12, bottom=10),
+        bgcolor=COLOR_TOP_BAR_BG,
+        padding=ft.Padding(left=12, top=8, right=12, bottom=8),
         content=ft.Row(
-            spacing=16,
+            spacing=12,
             alignment=ft.MainAxisAlignment.START,
             vertical_alignment=ft.CrossAxisAlignment.CENTER,
             controls=[
@@ -160,7 +162,7 @@ def _build_week_season_block(
     return LabeledGroupBox(
         label=season_label,
         content=ft.Row(
-            spacing=6,
+            spacing=4,
             controls=[
                 _build_week_tile(
                     week=week,
@@ -176,7 +178,7 @@ def _build_week_season_block(
         label_bgcolor=COLOR_SEASON_LABEL_BG,
         label_border_color=COLOR_SEASON_LABEL_BORDER,
         label_text_color=COLOR_SEASON_LABEL_TEXT,
-        padding=ft.Padding(left=4, top=8, right=4, bottom=4),
+        padding=ft.Padding(left=4, top=8, right=4, bottom=3),
     )
 
 
@@ -185,17 +187,16 @@ def _build_year_nav_button(
     on_click: ft.OptionalEventCallable["ControlEvent"],
 ) -> ft.Control:
     enabled = on_click is not None
-    is_extended_label = label == "+ Año"
     return ft.Container(
-        width=88 if is_extended_label else 52,
-        height=40 if is_extended_label else 52,
+        width=50,
+        height=50,
         border_radius=999,
         bgcolor=COLOR_TOP_NAV_BUTTON_BG if enabled else COLOR_TOP_NAV_BUTTON_DISABLED_BG,
         alignment=ft.Alignment.CENTER,
         on_click=on_click,
         content=ft.Text(
             label,
-            size=16 if is_extended_label else 24,
+            size=24,
             weight=ft.FontWeight.BOLD,
             color=COLOR_WHITE if enabled else COLOR_TOP_NAV_BUTTON_TEXT_DISABLED,
         ),
@@ -216,8 +217,8 @@ def _build_week_tile(
         bgcolor = COLOR_WEEK_TILE_CLOSED_BG if week.is_closed else COLOR_WEEK_TILE_BG
     text_color = COLOR_WEEK_TILE_CLOSED_TEXT if week.is_closed else COLOR_TEXT_PRIMARY
     return ft.Container(
-        width=46,
-        height=42,
+        width=40,
+        height=36,
         bgcolor=bgcolor,
         border=border,
         border_radius=2,
@@ -226,7 +227,7 @@ def _build_week_tile(
         on_click=None if disabled else on_select_week_click,
         content=ft.Text(
             str(week.week_number),
-            size=13,
+            size=12,
             weight=ft.FontWeight.W_600,
             color=text_color,
         ),


### PR DESCRIPTION
## Resumen
- Rediseño de shell para tablet: barra superior compacta y con fondo visible.
- Acciones semanales movidas a FAB contextual (`Crear`, `Cerrar/Reabrir/Recerrar`, `Refrescar`).
- Limpieza del visor: se elimina cabecera de semana y metadatos redundantes en cards.
- Barra inferior simplificada a recursos totales (sin estado textual).
- Orden visual de recursos unificado: `Otros -> Materiales -> Plantas`.
- Retirada completa de `Week.update_notes` (runtime + documentación oficial).

## Verificación
- `pipenv run python -m compileall src`
- Búsqueda sin rutas activas de notas de semana en código (`NO_WEEK_NOTES_CODE_PATHS`).
- Búsqueda sin referencias activas en contratos MVP (`NO_ACTIVE_WEEK_NOTES_REFERENCES`).

## Checklist
- [x] Código implementado.
- [x] Documentación oficial alineada.
- [x] Verificación técnica ejecutada.