### PR TITLE
fix(ui): unificar contraste de FAB y paleta 2 tonos

### DIFF
--- a/src/frosthaven_campaign_journal/ui/common/theme/colors.py
+++ b/src/frosthaven_campaign_journal/ui/common/theme/colors.py
@@ -51,8 +51,8 @@ class SemanticColor(str, Enum):
     WEEK_TILE_CLOSED_TEXT = _blend(PaletteColor.OXFORD_NAVY.value, NEUTRAL_WHITE, 0.50)
     WEEK_TILE_SELECTED_BG = _blend(PaletteColor.CERULEAN.value, NEUTRAL_WHITE, 0.84)
     WEEK_TILE_SELECTED_BORDER = PaletteColor.CERULEAN.value
-    WEEK_BLOCK_SUMMER_BG = _blend(PaletteColor.FROSTED_BLUE.value, PaletteColor.HONEYDEW.value, 0.28)
-    WEEK_BLOCK_WINTER_BG = _blend(PaletteColor.CERULEAN.value, PaletteColor.HONEYDEW.value, 0.60)
+    WEEK_BLOCK_SUMMER_BG = _blend(PaletteColor.FROSTED_BLUE.value, PaletteColor.HONEYDEW.value, 0.45)
+    WEEK_BLOCK_WINTER_BG = _blend(PaletteColor.FROSTED_BLUE.value, PaletteColor.HONEYDEW.value, 0.45)
     WEEK_BLOCK_BORDER = _blend(PaletteColor.CERULEAN.value, PaletteColor.OXFORD_NAVY.value, 0.25)
     SEASON_LABEL_BG = _blend(PaletteColor.HONEYDEW.value, NEUTRAL_WHITE, 0.50)
     SEASON_LABEL_BORDER = _blend(PaletteColor.CERULEAN.value, PaletteColor.OXFORD_NAVY.value, 0.18)
@@ -68,8 +68,8 @@ class SemanticColor(str, Enum):
     PANEL_INNER_BG = PaletteColor.HONEYDEW.value
     PANEL_INNER_BORDER = _blend(PaletteColor.CERULEAN.value, PaletteColor.HONEYDEW.value, 0.62)
 
-    STATUS_GROUP_BG = _blend(PaletteColor.CERULEAN.value, PaletteColor.OXFORD_NAVY.value, 0.10)
-    STATUS_GROUP_BORDER = _blend(PaletteColor.FROSTED_BLUE.value, PaletteColor.CERULEAN.value, 0.35)
+    STATUS_GROUP_BG = _blend(PaletteColor.FROSTED_BLUE.value, PaletteColor.HONEYDEW.value, 0.45)
+    STATUS_GROUP_BORDER = _blend(PaletteColor.CERULEAN.value, PaletteColor.OXFORD_NAVY.value, 0.25)
     STATUS_LABEL_BG = _blend(PaletteColor.FROSTED_BLUE.value, NEUTRAL_WHITE, 0.32)
     STATUS_LABEL_BORDER = _blend(PaletteColor.FROSTED_BLUE.value, PaletteColor.OXFORD_NAVY.value, 0.20)
     STATUS_LABEL_TEXT = _blend(PaletteColor.OXFORD_NAVY.value, NEUTRAL_BLACK, 0.12)

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/center_focus.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/center_focus.py
@@ -9,6 +9,7 @@ from frosthaven_campaign_journal.ui.common.components import LabeledGroupBox
 from frosthaven_campaign_journal.ui.common.components.surfaces import build_inner_surface
 from frosthaven_campaign_journal.ui.common.resources import ResourceDeltaRow, iter_resource_ui_groups
 from frosthaven_campaign_journal.ui.common.theme.colors import (
+    COLOR_BOTTOM_BAR_BG,
     COLOR_DESTRUCTIVE_ICON,
     COLOR_DEFEAT_ICON,
     COLOR_ENTRY_TAB_SELECTED_UNDERLINE,
@@ -24,6 +25,7 @@ from frosthaven_campaign_journal.ui.common.theme.colors import (
     COLOR_TEXT_MUTED,
     COLOR_TEXT_PRIMARY,
     COLOR_VICTORY_ICON,
+    COLOR_WHITE,
 )
 from frosthaven_campaign_journal.ui.main_shell.model import MainShellViewData, WeekEntryCardViewData
 from frosthaven_campaign_journal.ui.main_shell.state import MainShellState
@@ -103,7 +105,7 @@ def _build_week_entry_card(
     return ft.Container(
         expand=True,
         padding=ft.Padding.all(12),
-        bgcolor=COLOR_PANEL_BG,
+        bgcolor=COLOR_BOTTOM_BAR_BG,
         border=ft.Border.all(2 if card.is_active_session_owner else 1, active_border_color),
         border_radius=10,
         content=ft.Column(
@@ -136,7 +138,7 @@ def _build_entry_card_header(
 ) -> ft.Control:
     entry = card.entry
     outcome_icon = _build_entry_outcome_icon(entry)
-    title_controls: list[ft.Control] = [ft.Text(entry.label, size=18, weight=ft.FontWeight.BOLD, color=COLOR_TEXT_HEADING)]
+    title_controls: list[ft.Control] = [ft.Text(entry.label, size=18, weight=ft.FontWeight.BOLD, color=COLOR_WHITE)]
     if outcome_icon is not None:
         title_controls.append(outcome_icon)
 
@@ -144,6 +146,7 @@ def _build_entry_card_header(
         ft.IconButton(
             icon=ft.Icons.ARROW_UPWARD,
             icon_size=18,
+            icon_color=COLOR_WHITE,
             tooltip="Subir",
             data=entry.ref,
             on_click=state.on_reorder_entry_up_click,
@@ -152,6 +155,7 @@ def _build_entry_card_header(
         ft.IconButton(
             icon=ft.Icons.ARROW_DOWNWARD,
             icon_size=18,
+            icon_color=COLOR_WHITE,
             tooltip="Bajar",
             data=entry.ref,
             on_click=state.on_reorder_entry_down_click,
@@ -160,6 +164,7 @@ def _build_entry_card_header(
         ft.IconButton(
             icon=ft.Icons.EDIT,
             icon_size=18,
+            icon_color=COLOR_WHITE,
             tooltip="Editar tipo/ref",
             data=entry.ref,
             on_click=state.on_open_edit_entry_modal_click,
@@ -168,6 +173,7 @@ def _build_entry_card_header(
         ft.IconButton(
             icon=ft.Icons.EDIT_NOTE,
             icon_size=18,
+            icon_color=COLOR_WHITE,
             tooltip="Editar notas",
             data=entry.ref,
             on_click=state.on_open_entry_notes_editor_click,

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/shell_view.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/shell_view.py
@@ -8,9 +8,8 @@ from frosthaven_campaign_journal.ui.main_shell.state import MainShellState
 from frosthaven_campaign_journal.ui.common.theme.colors import (
     COLOR_BOTTOM_BAR_BG,
     COLOR_CENTER_BG,
-    COLOR_TEXT_PRIMARY,
-    COLOR_TOP_NAV_BUTTON_BG,
     COLOR_TOP_BAR_BG,
+    COLOR_TOP_NAV_BUTTON_BG,
     COLOR_WHITE,
 )
 from frosthaven_campaign_journal.ui.common.theme.layout import (
@@ -21,7 +20,7 @@ from frosthaven_campaign_journal.ui.main_shell.view.center_panel import build_ce
 from frosthaven_campaign_journal.ui.main_shell.view.status_bar import build_status_bar
 from frosthaven_campaign_journal.ui.main_shell.view.temporal_bar import build_top_temporal_bar
 
-_FAB_MENU_TEXT_STYLE = ft.TextStyle(color=COLOR_TEXT_PRIMARY, size=15)
+_FAB_MENU_TEXT_STYLE = ft.TextStyle(color=COLOR_WHITE, size=15, weight=ft.FontWeight.W_600)
 _FAB_MENU_ITEM_MIN_WIDTH = 228
 _FAB_TRIGGER_SIZE = 56
 
@@ -74,13 +73,17 @@ def _build_fab_menu_item(
     disabled: bool,
 ) -> ft.PopupMenuItem:
     return ft.PopupMenuItem(
+        padding=0,
+        height=48,
         content=ft.Container(
             width=_FAB_MENU_ITEM_MIN_WIDTH,
+            bgcolor=COLOR_TOP_BAR_BG,
+            padding=ft.Padding(left=14, top=10, right=14, bottom=10),
             content=ft.Row(
                 spacing=10,
                 vertical_alignment=ft.CrossAxisAlignment.CENTER,
                 controls=[
-                    ft.Icon(icon, size=18, color=COLOR_TEXT_PRIMARY),
+                    ft.Icon(icon, size=18, color=COLOR_WHITE),
                     ft.Text(label, style=_FAB_MENU_TEXT_STYLE),
                 ],
             ),
@@ -161,6 +164,7 @@ def _build_week_actions_fab(data: MainShellViewData, state: MainShellState) -> f
         tooltip="Acciones de semana",
         shape=ft.RoundedRectangleBorder(radius=16),
         padding=0,
+        menu_padding=0,
         size_constraints=ft.BoxConstraints(
             min_width=_FAB_TRIGGER_SIZE,
             min_height=_FAB_TRIGGER_SIZE,

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/status_bar.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/status_bar.py
@@ -6,13 +6,12 @@ from frosthaven_campaign_journal.resource_catalog import ResourceCatalogItem
 from frosthaven_campaign_journal.ui.common.components import LabeledGroupBox
 from frosthaven_campaign_journal.ui.common.resources import ResourceTotalRow, ResourceUiGroup, iter_resource_ui_groups
 from frosthaven_campaign_journal.ui.common.theme.colors import (
-    COLOR_RESOURCE_TOTAL_VALUE,
     COLOR_STATUS_GROUP_BG,
     COLOR_STATUS_GROUP_BORDER,
     COLOR_STATUS_LABEL_BG,
     COLOR_STATUS_LABEL_BORDER,
     COLOR_STATUS_LABEL_TEXT,
-    COLOR_WHITE,
+    COLOR_TEXT_PRIMARY,
 )
 from frosthaven_campaign_journal.ui.main_shell.model import MainShellViewData
 
@@ -87,9 +86,9 @@ def _build_resource_total_row(
         icon_src=item.icon_src,
         label_es=item.label_es,
         total_text=_format_saved_total(resource_totals, item.key),
-        text_color=COLOR_WHITE,
-        value_color=COLOR_RESOURCE_TOTAL_VALUE,
-        icon_color=COLOR_WHITE,
+        text_color=COLOR_TEXT_PRIMARY,
+        value_color=COLOR_TEXT_PRIMARY,
+        icon_color=COLOR_TEXT_PRIMARY,
         label_size=13,
         value_size=14,
         label_width=116,

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/temporal_bar.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/temporal_bar.py
@@ -18,7 +18,6 @@ from frosthaven_campaign_journal.ui.common.theme.colors import (
     COLOR_TOP_NAV_BUTTON_TEXT_DISABLED,
     COLOR_WEEK_BLOCK_BORDER,
     COLOR_WEEK_BLOCK_SUMMER_BG,
-    COLOR_WEEK_BLOCK_WINTER_BG,
     COLOR_WEEK_TILE_BG,
     COLOR_WEEK_TILE_CLOSED_BG,
     COLOR_WEEK_TILE_CLOSED_TEXT,
@@ -94,7 +93,7 @@ def build_top_temporal_bar(data: MainShellViewData, state: MainShellState) -> ft
                     selected_week=data.state.selected_week,
                     disabled=data.campaign_write_pending,
                     on_select_week_click=state.on_select_week_click,
-                    block_bgcolor=COLOR_WEEK_BLOCK_WINTER_BG,
+                    block_bgcolor=COLOR_WEEK_BLOCK_SUMMER_BG,
                     season_label="Invierno",
                 )
             )


### PR DESCRIPTION
# Resumen
Unifica contraste de la shell principal con paleta de 2 tonos (oscuro/claro):
- men? FAB oscuro con texto/iconos blancos,
- estaciones con fondo claro ?nico,
- cajas de recursos en barra inferior en claro con texto/iconos oscuros,
- tarjetas de entrada del visor en oscuro para contrastar sobre el fondo claro.

## Issue relacionado
Closes #100

## Tipo de cambio
- [ ] Documentaci?n
- [ ] Flujo/proceso
- [x] Bugfix
- [ ] Funcionalidad

## Checklist
- [x] El alcance est? claro.
- [x] Los commits siguen Conventional Commits.
- [ ] El Markdown no tiene warnings de lint.
- [ ] Actualic? `CHANGELOG.md` si corresponde.
- [ ] La trazabilidad de decisiones est? actualizada.
- [x] Texto en castellano revisado (tildes/?/ortograf?a).
- [ ] Ramas mergeadas no reutilizables limpiadas (local/remoto) si aplica.
