### PR TITLE
feat(ui): rediseñar barra de acciones de entry

### DIFF
--- a/src/frosthaven_campaign_journal/ui/main_shell/state/week_entry_resources.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/state/week_entry_resources.py
@@ -140,6 +140,9 @@ class MainShellWeekEntryResourceActionsMixin:
         if isinstance(entry_ref, EntryRef):
             self._open_entry_delete_confirm_for_ref(entry_ref)
 
+    def on_open_entry_delete_confirm_for_entry(self, entry_ref: EntryRef) -> None:
+        self._open_entry_delete_confirm_for_ref(entry_ref)
+
     def on_reorder_entry_up(self, _event: ft.ControlEvent | None = None) -> None:
         entry_ref = self._get_viewer_entry_ref_for_entry_write()
         if entry_ref is None:
@@ -159,12 +162,11 @@ class MainShellWeekEntryResourceActionsMixin:
         self.notify()
 
     def _reorder_entry_by_ref(self, entry_ref: EntryRef, *, direction: str) -> None:
-        success_message = "Entrada movida hacia arriba." if direction == "up" else "Entrada movida hacia abajo."
         self._run_entry_write(
             lambda client: reorder_entry_within_week(client, entry_ref=entry_ref, direction=direction),
             reload_q5=entry_ref_matches_selected_week(self.local_state, entry_ref),
             reload_q8=False,
-            success_message=success_message,
+            success_message="Entrada reordenada.",
         )
 
     def on_reorder_entry_up_click(self, event: ft.ControlEvent) -> None:
@@ -178,6 +180,14 @@ class MainShellWeekEntryResourceActionsMixin:
         if isinstance(entry_ref, EntryRef):
             self._reorder_entry_by_ref(entry_ref, direction="down")
             self.notify()
+
+    def on_reorder_entry_left_for_entry(self, entry_ref: EntryRef) -> None:
+        self._reorder_entry_by_ref(entry_ref, direction="up")
+        self.notify()
+
+    def on_reorder_entry_right_for_entry(self, entry_ref: EntryRef) -> None:
+        self._reorder_entry_by_ref(entry_ref, direction="down")
+        self.notify()
 
     def on_entry_form_set_type(self, event: ft.ControlEvent) -> None:
         form = self.entry_form_state

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/center_focus.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/center_focus.py
@@ -72,8 +72,14 @@ def _build_week_cards_lane(data: MainShellViewData, state: MainShellState) -> ft
 
     card_count = len(data.week_entry_cards)
     wrappers: list[ft.Control] = []
-    for card in data.week_entry_cards:
-        card_control = _build_week_entry_card(data, state, card)
+    for card_index, card in enumerate(data.week_entry_cards):
+        card_control = _build_week_entry_card(
+            data,
+            state,
+            card,
+            card_index=card_index,
+            card_count=card_count,
+        )
         if card_count <= 2:
             wrappers.append(ft.Container(expand=1, content=card_control))
         else:
@@ -96,6 +102,9 @@ def _build_week_entry_card(
     data: MainShellViewData,
     state: MainShellState,
     card: WeekEntryCardViewData,
+    *,
+    card_index: int,
+    card_count: int,
 ) -> ft.Control:
     active_border_color = COLOR_ENTRY_TAB_SELECTED_UNDERLINE if card.is_active_session_owner else COLOR_PANEL_BORDER
     status_texts = _build_entry_card_status_texts(data, card)
@@ -110,7 +119,13 @@ def _build_week_entry_card(
             expand=True,
             spacing=10,
             controls=[
-                _build_entry_card_header(data, state, card),
+                _build_entry_card_header(
+                    data,
+                    state,
+                    card,
+                    can_move_left=(card_index > 0),
+                    can_move_right=(card_index < card_count - 1),
+                ),
                 ft.Container(
                     expand=True,
                     content=ft.ListView(
@@ -132,6 +147,9 @@ def _build_entry_card_header(
     data: MainShellViewData,
     state: MainShellState,
     card: WeekEntryCardViewData,
+    *,
+    can_move_left: bool,
+    can_move_right: bool,
 ) -> ft.Control:
     entry = card.entry
     outcome_icon = _build_entry_outcome_icon(entry)
@@ -141,33 +159,6 @@ def _build_entry_card_header(
 
     action_buttons: list[ft.Control] = [
         ft.IconButton(
-            icon=ft.Icons.ARROW_UPWARD,
-            icon_size=18,
-            icon_color=COLOR_WHITE,
-            tooltip="Subir",
-            data=entry.ref,
-            on_click=state.on_reorder_entry_up_click,
-            disabled=card.entry_write_pending,
-        ),
-        ft.IconButton(
-            icon=ft.Icons.ARROW_DOWNWARD,
-            icon_size=18,
-            icon_color=COLOR_WHITE,
-            tooltip="Bajar",
-            data=entry.ref,
-            on_click=state.on_reorder_entry_down_click,
-            disabled=card.entry_write_pending,
-        ),
-        ft.IconButton(
-            icon=ft.Icons.EDIT,
-            icon_size=18,
-            icon_color=COLOR_WHITE,
-            tooltip="Editar tipo/ref",
-            data=entry.ref,
-            on_click=state.on_open_edit_entry_modal_click,
-            disabled=card.entry_write_pending,
-        ),
-        ft.IconButton(
             icon=ft.Icons.EDIT_NOTE,
             icon_size=18,
             icon_color=COLOR_WHITE,
@@ -176,32 +167,67 @@ def _build_entry_card_header(
             on_click=state.on_open_entry_notes_editor_click,
             disabled=card.entry_write_pending,
         ),
-        ft.IconButton(
-            icon=ft.Icons.SAVE_OUTLINED,
-            icon_size=18,
-            icon_color=COLOR_WHITE,
-            tooltip="Guardar recursos",
-            on_click=lambda _event, entry_ref=entry.ref: state.on_save_resource_draft_for_entry(entry_ref),
-            disabled=card.resource_write_pending or not card.resource_draft_dirty,
-        ),
-        ft.IconButton(
-            icon=ft.Icons.UNDO,
-            icon_size=18,
-            icon_color=COLOR_WHITE,
-            tooltip="Descartar cambios de recursos",
-            on_click=lambda _event, entry_ref=entry.ref: state.on_discard_resource_draft_for_entry(entry_ref),
-            disabled=card.resource_write_pending or not card.resource_draft_dirty,
-        ),
-        ft.IconButton(
-            icon=ft.Icons.DELETE_OUTLINE,
-            icon_size=18,
-            tooltip="Eliminar",
-            icon_color=COLOR_DESTRUCTIVE_ICON,
-            data=entry.ref,
-            on_click=state.on_open_entry_delete_confirm_click,
-            disabled=card.entry_write_pending,
-        ),
     ]
+    if card.resource_draft_dirty:
+        action_buttons.extend(
+            [
+                ft.IconButton(
+                    icon=ft.Icons.SAVE_OUTLINED,
+                    icon_size=18,
+                    icon_color=COLOR_WHITE,
+                    tooltip="Guardar recursos",
+                    on_click=lambda _event, entry_ref=entry.ref: state.on_save_resource_draft_for_entry(entry_ref),
+                    disabled=card.resource_write_pending,
+                ),
+                ft.IconButton(
+                    icon=ft.Icons.DO_NOT_DISTURB_ALT_OUTLINED,
+                    icon_size=18,
+                    icon_color=COLOR_WHITE,
+                    tooltip="No guardar cambios de recursos",
+                    on_click=lambda _event, entry_ref=entry.ref: state.on_discard_resource_draft_for_entry(entry_ref),
+                    disabled=card.resource_write_pending,
+                ),
+            ]
+        )
+
+    action_buttons.append(
+        ft.PopupMenuButton(
+            icon=ft.Icons.MORE_HORIZ,
+            icon_color=COLOR_WHITE,
+            tooltip="Más acciones",
+            items=[
+                ft.PopupMenuItem(
+                    icon=ft.Icons.ARROW_BACK,
+                    text="Mover a la izquierda",
+                    on_click=(
+                        lambda _event, entry_ref=entry.ref: state.on_reorder_entry_left_for_entry(entry_ref)
+                    ),
+                    disabled=card.entry_write_pending or not can_move_left,
+                ),
+                ft.PopupMenuItem(
+                    icon=ft.Icons.ARROW_FORWARD,
+                    text="Mover a la derecha",
+                    on_click=(
+                        lambda _event, entry_ref=entry.ref: state.on_reorder_entry_right_for_entry(entry_ref)
+                    ),
+                    disabled=card.entry_write_pending or not can_move_right,
+                ),
+                ft.PopupMenuItem(
+                    on_click=(
+                        lambda _event, entry_ref=entry.ref: state.on_open_entry_delete_confirm_for_entry(entry_ref)
+                    ),
+                    disabled=card.entry_write_pending,
+                    content=ft.Row(
+                        spacing=8,
+                        controls=[
+                            ft.Icon(ft.Icons.DELETE_OUTLINE, size=18, color=COLOR_DESTRUCTIVE_ICON),
+                            ft.Text("Eliminar entrada", color=COLOR_DESTRUCTIVE_ICON),
+                        ],
+                    ),
+                ),
+            ],
+        )
+    )
 
     return ft.Column(
         spacing=6,


### PR DESCRIPTION
## Resumen
- Rediseño incremental de la barra de acciones de `Entry` (`#104`).
- Se retira `Editar tipo/ref` y reordenación visible `Subir/Bajar`.
- Se mantiene `Editar notas` y se muestran `Guardar recursos` + `No guardar` solo con draft sucio.
- Se añade menú `...` con `Mover a la izquierda`, `Mover a la derecha` y `Eliminar entrada`.

## Cambios
- `center_focus.py`: nuevo layout de acciones del header por tarjeta, con visibilidad condicional y menú contextual.
- `week_entry_resources.py`: nuevos handlers por `entry_ref` para reorder izquierda/derecha y apertura de confirmación de borrado.

## Validación
- `pipenv run python -m compileall src/frosthaven_campaign_journal src/main.py`

## Issue
- Closes #104
- Matriz de auditoría publicada en comentario de la issue (funciona / no aporta / se elimina / se añade).