### PR TITLE
feat(ui): compactar tarjeta semanal y paleta azul para tablet (#109)

### DIFF
--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -6,7 +6,7 @@
 - `purpose`: Registrar decisiones con trazabilidad y precedencia.
 - `status`: active
 - `source_of_truth`: official
-- `last_updated`: 2026-03-05
+- `last_updated`: 2026-03-06
 - `next_review`: 2026-03-12
 
 ## Formato canónico por entrada
@@ -1196,3 +1196,32 @@
   `src/frosthaven_campaign_journal/data/firestore_client.py`,
   `scripts/build-android-with-mobile-secrets.ps1`,
   `docs/android-release-flow.md`, `CHANGELOG.md`
+
+### DEC-0052
+
+- `date`: 2026-03-06
+- `status`: accepted
+- `problem`: tras la compactación previa de la shell tablet, la tarjeta de
+  `Entry` seguía dejando demasiado hueco vertical entre título y recursos, los
+  controles de delta desperdiciaban ancho y las etiquetas rojas competían
+  visualmente con la semana seleccionada/FAB en un viewport contractual
+  `2560x1600` landscape.
+- `decision`: compactar la geometría de `LabeledGroupBox` y de la tarjeta de
+  `Entry`, rehacer `ResourceDeltaRow` con una zona fija derecha para `- valor +`
+  y una zona izquierda expandible con truncado seguro, pasar etiquetas de grupo
+  y botones de año a azul claro con texto oscuro, y alinear `Eliminar entrada`
+  con el color claro del resto del popup.
+- `rationale`: recupera densidad útil en tablet sin reintroducir lógica
+  responsive por viewport, mantiene el rojo reservado para focos activos
+  principales y evita solapes entre etiqueta, total proyectado y delta.
+- `impact`: `center_focus.py` reduce padding/spacing en la tarjeta semanal y en
+  las cajas de recursos/sesiones; `resource_delta_row.py` fija una huella más
+  compacta para los botones `+/-` y el valor; `colors.py` redefine los
+  semánticos de etiquetas y navegación anual hacia la paleta azul; y
+  `labeled_group_box.py` reduce el overlap superior por defecto.
+- `references`: `src/frosthaven_campaign_journal/ui/common/components/labeled_group_box.py`,
+  `src/frosthaven_campaign_journal/ui/common/resources/resource_delta_row.py`,
+  `src/frosthaven_campaign_journal/ui/common/theme/colors.py`,
+  `src/frosthaven_campaign_journal/ui/main_shell/view/center_focus.py`,
+  `src/frosthaven_campaign_journal/ui/main_shell/view/temporal_bar.py`,
+  `https://www.mi.com/global/product/xiaomi-pad-5/specs`

--- a/src/frosthaven_campaign_journal/ui/common/components/labeled_group_box.py
+++ b/src/frosthaven_campaign_journal/ui/common/components/labeled_group_box.py
@@ -19,7 +19,7 @@ class LabeledGroupBox(ft.Stack):
     label_top: int = 0
     label_text_size: int = 10
     label_text_weight: ft.FontWeight = ft.FontWeight.W_600
-    label_overlap: int = 8
+    label_overlap: int = 6
 
     def _resolved_padding(self) -> ft.Padding:
         return self.padding or ft.Padding(left=8, top=8, right=8, bottom=6)

--- a/src/frosthaven_campaign_journal/ui/common/resources/resource_delta_row.py
+++ b/src/frosthaven_campaign_journal/ui/common/resources/resource_delta_row.py
@@ -14,6 +14,9 @@ from frosthaven_campaign_journal.ui.common.theme.colors import (
 
 
 ResourceDeltaClickHandler = Callable[[ft.ControlEvent], None]
+_DELTA_ACTION_BUTTON_SIZE = 28
+_DELTA_ACTION_ZONE_WIDTH = 88
+_DELTA_VALUE_WIDTH = 32
 
 
 @ft.control
@@ -58,42 +61,76 @@ class ResourceDeltaRow(ft.Row):
             ft.Row(
                 expand=True,
                 spacing=4,
+                wrap=False,
                 controls=[
                     ft.Text(
                         value=self.label_es,
                         size=13,
                         weight=ft.FontWeight.W_600,
                         color=COLOR_TEXT_PRIMARY,
+                        max_lines=1,
+                        no_wrap=True,
+                        overflow=ft.TextOverflow.ELLIPSIS,
                     ),
                     ft.Text(
                         value=_format_projected_total_text(self.projected_total),
                         size=12,
                         color=COLOR_TEXT_MUTED,
                         italic=True,
+                        max_lines=1,
+                        no_wrap=True,
+                        overflow=ft.TextOverflow.ELLIPSIS,
                     ),
                 ],
             ),
-            ft.IconButton(
-                icon=ft.Icons.REMOVE,
-                icon_size=16,
-                tooltip="Restar 1",
-                on_click=self._handle_decrement,
-                disabled=self.disabled,
-            ),
-            ft.Text(
-                value=_format_delta_text(self.delta_value),
-                size=14,
-                width=42,
-                text_align=ft.TextAlign.CENTER,
-                weight=ft.FontWeight.W_700,
-                color=_delta_text_color(self.delta_value),
-            ),
-            ft.IconButton(
-                icon=ft.Icons.ADD,
-                icon_size=16,
-                tooltip="Sumar 1",
-                on_click=self._handle_increment,
-                disabled=self.disabled,
+            ft.Container(
+                width=_DELTA_ACTION_ZONE_WIDTH,
+                alignment=ft.Alignment.CENTER_RIGHT,
+                content=ft.Row(
+                    spacing=0,
+                    alignment=ft.MainAxisAlignment.END,
+                    vertical_alignment=ft.CrossAxisAlignment.CENTER,
+                    controls=[
+                        ft.IconButton(
+                            icon=ft.Icons.REMOVE,
+                            icon_size=16,
+                            tooltip="Restar 1",
+                            on_click=self._handle_decrement,
+                            disabled=self.disabled,
+                            padding=0,
+                            visual_density=ft.VisualDensity.COMPACT,
+                            size_constraints=ft.BoxConstraints(
+                                min_width=_DELTA_ACTION_BUTTON_SIZE,
+                                max_width=_DELTA_ACTION_BUTTON_SIZE,
+                                min_height=_DELTA_ACTION_BUTTON_SIZE,
+                                max_height=_DELTA_ACTION_BUTTON_SIZE,
+                            ),
+                        ),
+                        ft.Text(
+                            value=_format_delta_text(self.delta_value),
+                            size=14,
+                            width=_DELTA_VALUE_WIDTH,
+                            text_align=ft.TextAlign.CENTER,
+                            weight=ft.FontWeight.W_700,
+                            color=_delta_text_color(self.delta_value),
+                        ),
+                        ft.IconButton(
+                            icon=ft.Icons.ADD,
+                            icon_size=16,
+                            tooltip="Sumar 1",
+                            on_click=self._handle_increment,
+                            disabled=self.disabled,
+                            padding=0,
+                            visual_density=ft.VisualDensity.COMPACT,
+                            size_constraints=ft.BoxConstraints(
+                                min_width=_DELTA_ACTION_BUTTON_SIZE,
+                                max_width=_DELTA_ACTION_BUTTON_SIZE,
+                                min_height=_DELTA_ACTION_BUTTON_SIZE,
+                                max_height=_DELTA_ACTION_BUTTON_SIZE,
+                            ),
+                        ),
+                    ],
+                ),
             ),
         ]
 
@@ -101,13 +138,13 @@ class ResourceDeltaRow(ft.Row):
         super().init()
         self.alignment = ft.MainAxisAlignment.START
         self.vertical_alignment = ft.CrossAxisAlignment.CENTER
-        self.spacing = 10
+        self.spacing = 6
         self.controls = self._build_controls()
 
     def before_update(self) -> None:
         self.alignment = ft.MainAxisAlignment.START
         self.vertical_alignment = ft.CrossAxisAlignment.CENTER
-        self.spacing = 10
+        self.spacing = 6
         self.controls = self._build_controls()
 
 

--- a/src/frosthaven_campaign_journal/ui/common/theme/colors.py
+++ b/src/frosthaven_campaign_journal/ui/common/theme/colors.py
@@ -46,12 +46,12 @@ class SemanticColor(str, Enum):
     BOTTOM_BAR_BG = PaletteColor.CERULEAN.value
     TOP_BAR_BG = BOTTOM_BAR_BG
     TOP_BAR_TEXT = NEUTRAL_WHITE
-    TOP_NAV_BUTTON_BG = NEUTRAL_WHITE
-    TOP_NAV_BUTTON_BORDER = ACCENT_BG
-    TOP_NAV_BUTTON_TEXT = ACCENT_BG
-    TOP_NAV_BUTTON_DISABLED_BG = _blend(NEUTRAL_WHITE, PaletteColor.HONEYDEW.value, 0.35)
-    TOP_NAV_BUTTON_BORDER_DISABLED = _blend(PaletteColor.PUNCH_RED.value, NEUTRAL_WHITE, 0.62)
-    TOP_NAV_BUTTON_TEXT_DISABLED = _blend(PaletteColor.PUNCH_RED.value, NEUTRAL_WHITE, 0.58)
+    TOP_NAV_BUTTON_BG = PaletteColor.FROSTED_BLUE.value
+    TOP_NAV_BUTTON_BORDER = PaletteColor.CERULEAN.value
+    TOP_NAV_BUTTON_TEXT = PaletteColor.OXFORD_NAVY.value
+    TOP_NAV_BUTTON_DISABLED_BG = _blend(PaletteColor.FROSTED_BLUE.value, PaletteColor.HONEYDEW.value, 0.42)
+    TOP_NAV_BUTTON_BORDER_DISABLED = _blend(PaletteColor.CERULEAN.value, PaletteColor.HONEYDEW.value, 0.45)
+    TOP_NAV_BUTTON_TEXT_DISABLED = _blend(PaletteColor.OXFORD_NAVY.value, PaletteColor.HONEYDEW.value, 0.48)
 
     WEEK_TILE_BG = _blend(PaletteColor.CERULEAN.value, NEUTRAL_WHITE, 0.68)
     WEEK_TILE_CLOSED_BG = _blend(PaletteColor.OXFORD_NAVY.value, PaletteColor.FROSTED_BLUE.value, 0.70)
@@ -63,9 +63,9 @@ class SemanticColor(str, Enum):
     WEEK_BLOCK_SUMMER_BG = _blend(PaletteColor.FROSTED_BLUE.value, PaletteColor.HONEYDEW.value, 0.45)
     WEEK_BLOCK_WINTER_BG = _blend(PaletteColor.FROSTED_BLUE.value, PaletteColor.HONEYDEW.value, 0.45)
     WEEK_BLOCK_BORDER = _blend(PaletteColor.CERULEAN.value, PaletteColor.OXFORD_NAVY.value, 0.25)
-    SEASON_LABEL_BG = NEUTRAL_WHITE
-    SEASON_LABEL_BORDER = ACCENT_BG
-    SEASON_LABEL_TEXT = ACCENT_BG
+    SEASON_LABEL_BG = PaletteColor.FROSTED_BLUE.value
+    SEASON_LABEL_BORDER = PaletteColor.CERULEAN.value
+    SEASON_LABEL_TEXT = PaletteColor.OXFORD_NAVY.value
 
     ENTRY_TAB_BG = _blend(PaletteColor.FROSTED_BLUE.value, PaletteColor.HONEYDEW.value, 0.60)
     ENTRY_TAB_SELECTED_UNDERLINE = PaletteColor.CERULEAN.value
@@ -79,9 +79,9 @@ class SemanticColor(str, Enum):
 
     STATUS_GROUP_BG = _blend(PaletteColor.FROSTED_BLUE.value, PaletteColor.HONEYDEW.value, 0.45)
     STATUS_GROUP_BORDER = _blend(PaletteColor.CERULEAN.value, PaletteColor.OXFORD_NAVY.value, 0.25)
-    STATUS_LABEL_BG = NEUTRAL_WHITE
-    STATUS_LABEL_BORDER = ACCENT_BG
-    STATUS_LABEL_TEXT = ACCENT_BG
+    STATUS_LABEL_BG = PaletteColor.FROSTED_BLUE.value
+    STATUS_LABEL_BORDER = PaletteColor.CERULEAN.value
+    STATUS_LABEL_TEXT = PaletteColor.OXFORD_NAVY.value
     STATUS_TEXT_SECONDARY = _blend(NEUTRAL_WHITE, PaletteColor.FROSTED_BLUE.value, 0.28)
     STATUS_TEXT_TERTIARY = _blend(NEUTRAL_WHITE, PaletteColor.FROSTED_BLUE.value, 0.40)
     RESOURCE_TOTAL_VALUE = NEUTRAL_WHITE

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/center_focus.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/center_focus.py
@@ -113,13 +113,13 @@ def _build_week_entry_card(
 
     return ft.Container(
         expand=True,
-        padding=ft.Padding.all(12),
+        padding=ft.Padding.all(10),
         bgcolor=COLOR_BOTTOM_BAR_BG,
         border=ft.Border.all(2 if card.is_active_session_owner else 1, active_border_color),
         border_radius=10,
         content=ft.Column(
             expand=True,
-            spacing=10,
+            spacing=6,
             controls=[
                 _build_entry_card_header(
                     data,
@@ -132,7 +132,7 @@ def _build_week_entry_card(
                     expand=True,
                     content=ft.ListView(
                         expand=True,
-                        spacing=10,
+                        spacing=8,
                         padding=0,
                         controls=[
                             _build_entry_resources_card(data, state, card),
@@ -200,7 +200,7 @@ def _build_entry_card_header(
             items=[
                 ft.PopupMenuItem(
                     icon=ft.Icons.ARROW_BACK,
-                    text="Mover a la izquierda",
+                    content="Mover a la izquierda",
                     on_click=(
                         lambda _event, entry_ref=entry.ref: state.on_reorder_entry_left_for_entry(entry_ref)
                     ),
@@ -208,7 +208,7 @@ def _build_entry_card_header(
                 ),
                 ft.PopupMenuItem(
                     icon=ft.Icons.ARROW_FORWARD,
-                    text="Mover a la derecha",
+                    content="Mover a la derecha",
                     on_click=(
                         lambda _event, entry_ref=entry.ref: state.on_reorder_entry_right_for_entry(entry_ref)
                     ),
@@ -222,8 +222,8 @@ def _build_entry_card_header(
                     content=ft.Row(
                         spacing=8,
                         controls=[
-                            ft.Icon(ft.Icons.DELETE_OUTLINE, size=18, color=COLOR_DESTRUCTIVE_ICON),
-                            ft.Text("Eliminar entrada", color=COLOR_DESTRUCTIVE_ICON),
+                            ft.Icon(ft.Icons.DELETE_OUTLINE, size=18, color=COLOR_WHITE),
+                            ft.Text("Eliminar entrada", color=COLOR_WHITE),
                         ],
                     ),
                 ),
@@ -296,14 +296,14 @@ def _build_entry_resources_card(
                         ),
                     )
                 )
-            column_controls.append(ft.Column(spacing=6, expand=True, controls=resource_rows))
+            column_controls.append(ft.Column(spacing=4, expand=True, controls=resource_rows))
 
         group_content: ft.Control
         if len(column_controls) == 1:
             group_content = column_controls[0]
         else:
             group_content = ft.Row(
-                spacing=12,
+                spacing=10,
                 vertical_alignment=ft.CrossAxisAlignment.START,
                 controls=column_controls,
             )
@@ -316,7 +316,7 @@ def _build_entry_resources_card(
             label_bgcolor=COLOR_STATUS_LABEL_BG,
             label_border_color=COLOR_STATUS_LABEL_BORDER,
             label_text_color=COLOR_STATUS_LABEL_TEXT,
-            padding=ft.Padding(left=8, top=10, right=8, bottom=8),
+            padding=ft.Padding(left=8, top=8, right=8, bottom=6),
         )
 
     layout_rows: list[ft.Control] = []
@@ -333,7 +333,7 @@ def _build_entry_resources_card(
     if first_row_boxes:
         layout_rows.append(
             ft.Row(
-                spacing=8,
+                spacing=6,
                 vertical_alignment=ft.CrossAxisAlignment.START,
                 controls=first_row_boxes,
             )
@@ -344,7 +344,7 @@ def _build_entry_resources_card(
         layout_rows.append(plants_box)
 
     return ft.Column(
-        spacing=8,
+        spacing=6,
         controls=layout_rows,
     )
 
@@ -377,7 +377,7 @@ def _build_entry_sessions_card(
         ft.Text(status_line, size=12, color=COLOR_TEXT_MUTED),
         ft.Text(f"Total jugado (Q8): {card.sessions_total_text}", size=12, color=COLOR_TEXT_MUTED),
         ft.Row(
-            spacing=8,
+            spacing=6,
             wrap=True,
             controls=[
                 ft.FilledButton(
@@ -408,13 +408,13 @@ def _build_entry_sessions_card(
 
     return LabeledGroupBox(
         label="Sesiones",
-        content=ft.Column(spacing=8, controls=controls),
+        content=ft.Column(spacing=6, controls=controls),
         bgcolor=COLOR_STATUS_GROUP_BG,
         border_color=COLOR_STATUS_GROUP_BORDER,
         label_bgcolor=COLOR_STATUS_LABEL_BG,
         label_border_color=COLOR_STATUS_LABEL_BORDER,
         label_text_color=COLOR_STATUS_LABEL_TEXT,
-        padding=ft.Padding.all(12),
+        padding=ft.Padding(left=10, top=9, right=10, bottom=10),
     )
 
 


### PR DESCRIPTION
## Resumen
- compactar la tarjeta semanal de `Entry` para recuperar densidad ?til en tablet
- rehacer la fila de delta con zona fija `- valor +` y truncado seguro del texto
- pasar etiquetas/botones temporales a la paleta azul clara y corregir la legibilidad de `Eliminar entrada`

## Issue
Closes #109

## Validaci?n
- [x] `git diff --cached --check`
- [x] `pipenv run python -m unittest discover -s tests -p 'test_*.py'` con `PYTHONPATH=src`
- [x] comprobaci?n visual parcial en Flet web de colorimetr?a/carga base
- [ ] validaci?n visual completa en viewport tablet `2560x1600`

## Notas
- Durante esta sesi?n Charlotte no ha permitido emular el viewport tablet ni desplazar la tira semanal hasta las semanas 34-36, as? que la validaci?n visual completa queda pendiente en entorno interactivo de tablet/web ancho.
