### PR TITLE
feat(main_shell): mover feedback transitorio a toast y diálogos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# Changelog
+# Changelog
 
 Todos los cambios relevantes del proyecto se documentan en este archivo.
 
@@ -8,6 +8,19 @@ y usa versionado
 [SemVer](https://semver.org/lang/es/).
 
 ## [Unreleased]
+
+### Añadido
+
+- Tests unitarios de `MainShellState` para `ToastState`, `event_id` de
+  confirmación y limpieza de estado tras cancelar/confirmar.
+
+### Cambiado
+
+- `main_shell` mueve los mensajes informativos a `SnackBar` flotante y las
+  confirmaciones a `AlertDialog` modal con botones alineados visualmente al FAB.
+- `app_root.py` pasa a puentear overlays de Flet desde estado transitorio,
+  mientras el panel central mantiene solo banners de error/advertencia y
+  formularios inline.
 
 ## [0.2.1] - 2026-03-05
 

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -1225,3 +1225,12 @@
   `src/frosthaven_campaign_journal/ui/main_shell/view/center_focus.py`,
   `src/frosthaven_campaign_journal/ui/main_shell/view/temporal_bar.py`,
   `https://www.mi.com/global/product/xiaomi-pad-5/specs`
+### DEC-0053
+
+- `date`: 2026-03-06
+- `status`: accepted
+- `problem`: `main_shell` mostraba mensajes informativos y confirmaciones como bloques inline en el panel central, ocupando espacio útil y mezclando feedback transitorio con edición persistente.
+- `decision`: mover mensajes informativos a `SnackBar` flotante y preguntas de confirmación a `AlertDialog` modal, manteniendo `MainShellState` como fuente de verdad y concentrando el bridge hacia overlays de Flet en `ui/app_root.py` mediante `event_id` transitorios.
+- `rationale`: separa feedback efímero del contenido principal, evita acoplar la capa de estado a `Page`, y permite reemitir el mismo mensaje o la misma confirmación sin perder eventos por igualdad de contenido.
+- `impact`: `model.py` y `view_data.py` dejan de exponer `info_message`/confirmación inline; `app_root.py` pasa a abrir/cerrar overlays; los botones del diálogo heredan la paleta del FAB; y se añaden tests para `toast_state`/`confirmation_state` con `event_id`.
+- `references`: `src/frosthaven_campaign_journal/ui/app_root.py`, `src/frosthaven_campaign_journal/ui/main_shell/state/types.py`, `src/frosthaven_campaign_journal/ui/main_shell/state/runtime_support.py`, `src/frosthaven_campaign_journal/ui/main_shell/view/center_panel.py`, `docs/ui-main-shell-architecture-mvs.md`, `CHANGELOG.md`

--- a/docs/ui-main-shell-architecture-mvs.md
+++ b/docs/ui-main-shell-architecture-mvs.md
@@ -1,77 +1,77 @@
-﻿# UI Main Shell Architecture (MVS)
+# UI Main Shell Architecture (MVS)
 
 ## 1) Resumen de decisiones
 
-- Se mantiene estructura de tres capas: `model.py`, `state.py`, `view.py`.
-- El runtime sigue siendo declarativo: `page.render(build_app_root, page)`.
-- `MainShellState` es `@ft.observable` y concentra orquestaciÃ³n de lecturas,
-  escrituras y estado local de UI.
-- `build_main_shell_view` es helper puro de render (sin `@ft.component`).
-- No se usa `page.update()` ni `control.update()` en `src/.../ui`.
-- Se recupera paridad funcional pre-`#94` sin reintroducir capas `MVU+effects`
-  eliminadas (`dispatcher/reducer/effects/intents/selectors`).
+- Se mantiene estructura MVS con estado observable único en `MainShellState`.
+- El runtime sigue siendo declarativo con `page.render(build_app_root, page)`.
+- Los formularios de `entry`, notas y sesión continúan inline en el panel central.
+- Los mensajes informativos pasan a `SnackBar` flotante.
+- Las preguntas de confirmación pasan a `AlertDialog` modal.
+- El bridge a overlays vive solo en `ui/app_root.py`; el estado no se acopla a `Page`.
+- No se usa `page.update()` ni `control.update()` en la capa `ui`.
 
-## 2) Ãrbol actual del feature
+## 2) Árbol actual del feature
 
 ```text
-src/frosthaven_campaign_journal/ui/features/main_shell/
-â”œâ”€â”€ __init__.py
-â”œâ”€â”€ model.py
-â”œâ”€â”€ state.py
-â””â”€â”€ view.py
+src/frosthaven_campaign_journal/ui/
+├── app_root.py
+└── main_shell/
+    ├── __init__.py
+    ├── model.py
+    ├── state/
+    └── view/
 ```
 
 ## 3) Tabla por archivo
 
 | Archivo | Tipo | Responsabilidad |
 | --- | --- | --- |
-| `model.py` | MODEL | Contratos de datos de render (`MainShellViewData` + estados declarativos de confirmaciÃ³n/formularios). |
-| `state.py` | STATE | Estado observable y handlers de UI + wiring real Firestore (`Q1..Q8` + writes). |
-| `view.py` | VIEW | ComposiciÃ³n visual y binding directo a handlers del estado. |
-| `__init__.py` | IntegraciÃ³n | API pÃºblica estable del feature. |
+| `ui/app_root.py` | Root bridge | Observa `toast_state` y `confirmation_state`, y abre/cierra `SnackBar` y `AlertDialog`. |
+| `ui/main_shell/model.py` | MODEL | Contratos de render declarativos del panel principal. |
+| `ui/main_shell/state/` | STATE | Estado observable, handlers de UI, lecturas y escrituras. |
+| `ui/main_shell/view/` | VIEW | Render puro del shell y binding directo a handlers del estado. |
 
-## 4) Flujo declarativo
+## 4) Flujo declarativo actual
 
 1. El root crea estado con `ft.use_state(MainShellState.create)`.
-1. La vista llama `data = state.build_view_data()`.
-1. Controles invocan handlers del estado (`on_*`).
-1. El estado muta `local_state`, `read_state`, `entry_panel_state` y UI-state
-   declarativo (confirmaciones, formularios, editor de notas).
-1. El estado dispara `notify()` y la vista se reconstruye.
+1. La vista llama `state.build_view_data()` y renderiza solo contenido inline.
+1. Los handlers `on_*` mutan `local_state`, `read_state`, `entry_panel_state` y estado transitorio de UI.
+1. `toast_state` y `confirmation_state` emiten `event_id` nuevos en cada evento.
+1. `app_root.py` detecta esos `event_id` con `ft.use_effect` + `ft.use_ref` y abre el overlay correspondiente.
+1. El estado sigue siendo la fuente de verdad; el root solo traduce eventos a overlays de Flet.
 
-## 5) Estado declarativo de UI en `model.py`
+## 5) Estado declarativo de UI
 
-- `ConfirmationViewState`
+### Inline
+
 - `EntryFormViewState`
+- `EntryNotesEditorViewState`
 - `SessionFormViewState`
 
-Estos contratos permiten reemplazar modales imperativos por ediciÃ³n/confirmaciÃ³n
-declarativa renderizada en el panel central.
+### Overlays transitorios
 
-## 6) Cobertura funcional recuperada en `state.py`
+- `ToastState(message, event_id)`
+- `ConfirmationState(..., event_id)`
 
-- Lecturas: `load_main_screen_snapshot`, `read_q5_entries_for_selected_week`,
-  `read_entry_by_ref`, `read_q8_sessions_for_entry`.
-- Writes:
-  - campaÃ±a: `extend_years_plus_one`
-  - week: `close_week`, `reopen_week`, `reclose_week`
-  - session: `start_session`, `stop_session`, `manual_create_session`,
-    `manual_update_session`, `manual_delete_session`
-  - entry: `create_entry`, `update_entry`, `delete_entry`,
-    `reorder_entry_within_week`
-  - resources: `replace_entry_resource_deltas`
-- Reglas de consistencia:
-  - visor sticky separado de navegaciÃ³n temporal
-  - protecciÃ³n de borrador sucio antes de cambios de contexto
-  - refresh selectivo Q5/Q8 tras operaciones
-  - flags `*_write_pending` + errores por dominio
+El `event_id` evita que dos emisiones sucesivas con el mismo texto o payload se pierdan.
+
+## 6) Overlays del root
+
+- `SnackBar`
+  - `behavior=FLOATING`
+  - auto-dismiss
+  - icono de cierre
+  - margen inferior suficiente para no solapar bottom bar ni FAB
+- `AlertDialog`
+  - `modal=True`
+  - usa `title`, `body` y `confirm_label` ya definidos en estado
+  - botón de confirmar con la paleta del FAB
+  - botón de cancelar outlined con la misma paleta
 
 ## 7) Guardrails de arquitectura
 
 1. Runtime declarativo obligatorio (`page.render` + `@ft.component` en root).
-1. Estado observable Ãºnico de pantalla (`MainShellState`).
-1. Binding directo desde vista a handlers del estado.
-1. No usar `page.update()` ni `control.update()` en capa `ui`.
-
-
-
+1. Estado observable único de pantalla (`MainShellState`).
+1. Ningún mixin de estado conoce `Page` ni abre overlays directamente.
+1. Los banners inline se reservan para `warning` y `error`.
+1. Las confirmaciones y mensajes informativos transitorios se resuelven en el root.

--- a/src/frosthaven_campaign_journal/ui/app_root.py
+++ b/src/frosthaven_campaign_journal/ui/app_root.py
@@ -2,12 +2,152 @@ from __future__ import annotations
 
 import flet as ft
 
+from frosthaven_campaign_journal.ui.common.theme.colors import (
+    COLOR_ACCENT_BG,
+    COLOR_BANNER_INFO_BG,
+    COLOR_BANNER_INFO_TEXT,
+    COLOR_PANEL_INNER_BG,
+    COLOR_TEXT_HEADING,
+    COLOR_TEXT_PRIMARY,
+    COLOR_WHITE,
+)
+from frosthaven_campaign_journal.ui.common.theme.layout import BOTTOM_BAR_HEIGHT
 from frosthaven_campaign_journal.ui.main_shell import MainShellState, build_main_shell_view
+
+_SNACKBAR_SIDE_MARGIN = 16
+_SNACKBAR_BOTTOM_MARGIN = BOTTOM_BAR_HEIGHT + 24
+
+
+def _close_overlay(overlay: ft.AlertDialog | ft.SnackBar | None) -> None:
+    if overlay is None or not overlay.open:
+        return
+    overlay.open = False
+    overlay.update()
+
+
+def _build_dialog_button_style(*, filled: bool) -> ft.ButtonStyle:
+    return ft.ButtonStyle(
+        bgcolor=COLOR_ACCENT_BG if filled else None,
+        color=COLOR_WHITE if filled else COLOR_ACCENT_BG,
+        side=None if filled else ft.BorderSide(1.25, COLOR_ACCENT_BG),
+        shape=ft.RoundedRectangleBorder(radius=12),
+        padding=ft.Padding(left=16, top=12, right=16, bottom=12),
+    )
 
 
 @ft.component
 def build_app_root(page: ft.Page) -> ft.Control:
     shell_state, _ = ft.use_state(MainShellState.create)
+    active_toast = ft.use_ref(None)
+    last_toast_event_id = ft.use_ref(None)
+    active_confirmation = ft.use_ref(None)
+    last_confirmation_event_id = ft.use_ref(None)
+
+    def _sync_info_toast() -> None:
+        toast = shell_state.toast_state
+        if toast.event_id is None or not toast.message or toast.event_id == last_toast_event_id.current:
+            return
+
+        last_toast_event_id.current = toast.event_id
+        _close_overlay(active_toast.current)
+
+        def _on_dismiss(_event: ft.ControlEvent) -> None:
+            if active_toast.current is snackbar:
+                active_toast.current = None
+            if shell_state.toast_state.event_id == toast.event_id:
+                shell_state._clear_info_toast(event_id=toast.event_id)
+                shell_state.notify()
+
+        snackbar = ft.SnackBar(
+            bgcolor=COLOR_BANNER_INFO_BG,
+            content=ft.Row(
+                spacing=10,
+                vertical_alignment=ft.CrossAxisAlignment.CENTER,
+                controls=[
+                    ft.Icon(ft.Icons.INFO_OUTLINE, color=COLOR_BANNER_INFO_TEXT, size=18),
+                    ft.Text(toast.message, color=COLOR_BANNER_INFO_TEXT, expand=True),
+                ],
+            ),
+            behavior=ft.SnackBarBehavior.FLOATING,
+            show_close_icon=True,
+            close_icon_color=COLOR_BANNER_INFO_TEXT,
+            margin=ft.Margin(
+                left=_SNACKBAR_SIDE_MARGIN,
+                top=0,
+                right=_SNACKBAR_SIDE_MARGIN,
+                bottom=_SNACKBAR_BOTTOM_MARGIN,
+            ),
+            on_dismiss=_on_dismiss,
+        )
+        active_toast.current = snackbar
+        page.show_dialog(snackbar)
+
+    ft.use_effect(_sync_info_toast, dependencies=[shell_state.toast_state.event_id])
+
+    def _sync_confirmation_dialog() -> None:
+        confirmation = shell_state.confirmation_state
+        if (
+            confirmation.key is None
+            or confirmation.event_id is None
+            or confirmation.event_id == last_confirmation_event_id.current
+        ):
+            return
+
+        last_confirmation_event_id.current = confirmation.event_id
+        _close_overlay(active_confirmation.current)
+        handled = {"value": False}
+
+        def _handle_cancel(_event: ft.ControlEvent | None = None) -> None:
+            handled["value"] = True
+            _close_overlay(dialog)
+            shell_state.on_cancel_pending_action()
+
+        def _handle_confirm(_event: ft.ControlEvent | None = None) -> None:
+            handled["value"] = True
+            _close_overlay(dialog)
+            shell_state.on_confirm_pending_action()
+
+        def _on_dismiss(_event: ft.ControlEvent) -> None:
+            if active_confirmation.current is dialog:
+                active_confirmation.current = None
+            if handled["value"]:
+                return
+            handled["value"] = True
+            if (
+                shell_state.confirmation_state.key == confirmation.key
+                and shell_state.confirmation_state.event_id == confirmation.event_id
+            ):
+                shell_state.on_cancel_pending_action()
+
+        dialog = ft.AlertDialog(
+            modal=True,
+            bgcolor=COLOR_PANEL_INNER_BG,
+            title=ft.Text(
+                confirmation.title,
+                size=18,
+                weight=ft.FontWeight.W_600,
+                color=COLOR_TEXT_HEADING,
+            ),
+            content=ft.Text(confirmation.body, size=14, color=COLOR_TEXT_PRIMARY),
+            actions=[
+                ft.OutlinedButton(
+                    "Cancelar",
+                    style=_build_dialog_button_style(filled=False),
+                    on_click=_handle_cancel,
+                ),
+                ft.FilledButton(
+                    confirmation.confirm_label,
+                    style=_build_dialog_button_style(filled=True),
+                    on_click=_handle_confirm,
+                ),
+            ],
+            actions_alignment=ft.MainAxisAlignment.END,
+            on_dismiss=_on_dismiss,
+        )
+        active_confirmation.current = dialog
+        page.show_dialog(dialog)
+
+    ft.use_effect(_sync_confirmation_dialog, dependencies=[shell_state.confirmation_state.event_id])
 
     return ft.Container(
         expand=True,

--- a/src/frosthaven_campaign_journal/ui/main_shell/model.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/model.py
@@ -59,19 +59,9 @@ class MainShellViewData:
     read_error_message: str | None
     read_warning_message: str | None
     env_name: str
-    info_message: str | None
-    confirmation: "ConfirmationViewState | None"
     entry_form: "EntryFormViewState | None"
     entry_notes_editor: "EntryNotesEditorViewState | None"
     session_form: "SessionFormViewState | None"
-
-
-@dataclass(frozen=True)
-class ConfirmationViewState:
-    key: str
-    title: str
-    body: str
-    confirm_label: str
 
 
 @dataclass(frozen=True)
@@ -101,5 +91,3 @@ class SessionFormViewState:
     ended_time_local: str
     active_without_end: bool
     error_message: str | None
-
-

--- a/src/frosthaven_campaign_journal/ui/main_shell/state/navigation.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/state/navigation.py
@@ -177,7 +177,7 @@ class MainShellNavigationMixin:
                     reload_q5=False,
                     reload_q8=False,
                 )
-                self.info_message = (
+                self._emit_info_toast(
                     f"Año {result.new_year_number} creado "
                     f"(semanas {result.created_week_start}-{result.created_week_end})."
                 )
@@ -198,7 +198,12 @@ class MainShellNavigationMixin:
             return
 
         if key == "session_delete":
-            if isinstance(payload, tuple) and len(payload) == 2 and isinstance(payload[0], EntryRef) and isinstance(payload[1], str):
+            if (
+                isinstance(payload, tuple)
+                and len(payload) == 2
+                and isinstance(payload[0], EntryRef)
+                and isinstance(payload[1], str)
+            ):
                 self._run_session_write(
                     lambda client, entry_ref: manual_delete_session(
                         client,

--- a/src/frosthaven_campaign_journal/ui/main_shell/state/runtime_read.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/state/runtime_read.py
@@ -252,11 +252,14 @@ class MainShellRuntimeReadMixin:
         confirm_label: str,
         payload: Any,
     ) -> None:
-        self.confirmation_state.key = key
-        self.confirmation_state.title = title
-        self.confirmation_state.body = body
-        self.confirmation_state.confirm_label = confirm_label
-        self.confirmation_state.payload = payload
+        self.confirmation_state = ConfirmationState(
+            key=key,
+            title=title,
+            body=body,
+            confirm_label=confirm_label,
+            payload=payload,
+            event_id=self._next_ui_event_id(),
+        )
 
     def _clear_confirmation(self) -> None:
         self.confirmation_state = ConfirmationState()

--- a/src/frosthaven_campaign_journal/ui/main_shell/state/runtime_support.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/state/runtime_support.py
@@ -6,6 +6,7 @@ from frosthaven_campaign_journal.data import (
     FirestoreReadError,
 )
 from frosthaven_campaign_journal.models import ENTRY_RESOURCE_KEYS, EntryRef, EntrySummary
+from frosthaven_campaign_journal.ui.main_shell.state.types import ToastState
 
 
 class MainShellRuntimeSupportMixin:
@@ -91,12 +92,20 @@ class MainShellRuntimeSupportMixin:
         for entry in self.entry_panel_state.entries_for_selected_week:
             self._sync_resource_draft_from_entry_snapshot(entry)
 
+    def _emit_info_toast(self, message: str) -> None:
+        self.toast_state = ToastState(message=message, event_id=self._next_ui_event_id())
+
+    def _clear_info_toast(self, *, event_id: int | None = None) -> None:
+        if event_id is not None and self.toast_state.event_id != event_id:
+            return
+        self.toast_state = ToastState()
+
     def _discard_resource_draft_for_context_change(self, *, show_notice: bool) -> None:
         had_dirty = self._has_any_dirty_resource_draft()
         self._clear_resource_draft_state()
         self.entry_panel_state.resource_write_error_message = None
         if show_notice and had_dirty:
-            self.info_message = "Cambios de recursos sin guardar descartados al cambiar de contexto."
+            self._emit_info_toast("Cambios de recursos sin guardar descartados al cambiar de contexto.")
 
     def _clear_write_errors(self) -> None:
         self.entry_panel_state.session_write_error_message = None

--- a/src/frosthaven_campaign_journal/ui/main_shell/state/runtime_write.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/state/runtime_write.py
@@ -64,11 +64,11 @@ class MainShellRuntimeWriteMixin:
                 reload_q8=False,
             )
             if result.auto_stopped_session_id:
-                self.info_message = (
+                self._emit_info_toast(
                     f"Semana actualizada. Se auto-cerró la sesión {result.auto_stopped_session_id}."
                 )
             else:
-                self.info_message = success_message
+                self._emit_info_toast(success_message)
             return result
         except (
             FirestoreConfigError,
@@ -108,7 +108,7 @@ class MainShellRuntimeWriteMixin:
                 reload_q5=(self.local_state.selected_week is not None),
                 reload_q8=False,
             )
-            self.info_message = success_message
+            self._emit_info_toast(success_message)
             return True
         except (
             FirestoreConfigError,
@@ -148,11 +148,11 @@ class MainShellRuntimeWriteMixin:
                 reload_q8=reload_q8,
             )
             if result.auto_stopped_session_id:
-                self.info_message = (
+                self._emit_info_toast(
                     f"Entrada actualizada. Se auto-cerró la sesión {result.auto_stopped_session_id}."
                 )
             else:
-                self.info_message = success_message
+                self._emit_info_toast(success_message)
             return result
         except (
             FirestoreConfigError,
@@ -189,7 +189,7 @@ class MainShellRuntimeWriteMixin:
                 reload_q5=(self.local_state.selected_week is not None),
                 reload_q8=False,
             )
-            self.info_message = success_message
+            self._emit_info_toast(success_message)
             return result
         except (
             FirestoreConfigError,

--- a/src/frosthaven_campaign_journal/ui/main_shell/state/shell_state.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/state/shell_state.py
@@ -26,6 +26,7 @@ from frosthaven_campaign_journal.ui.main_shell.state.types import (
     EntryPanelReadState,
     MainScreenReadState,
     SessionFormState,
+    ToastState,
 )
 
 
@@ -48,12 +49,17 @@ class MainShellState(
     entry_form_state: EntryFormState | None = None
     entry_notes_editor_state: EntryNotesEditorState | None = None
     session_form_state: SessionFormState | None = None
-    info_message: str | None = None
+    toast_state: ToastState = field(default_factory=ToastState)
     _pending_context_action: Callable[[], None] | None = field(default=None, init=False, repr=False)
     _pending_context_action_label: str | None = field(default=None, init=False, repr=False)
+    _ui_event_seq: int = field(default=0, init=False, repr=False)
 
     @classmethod
     def create(cls) -> MainShellState:
         state = cls()
         state.initialize()
         return state
+
+    def _next_ui_event_id(self) -> int:
+        self._ui_event_seq += 1
+        return self._ui_event_seq

--- a/src/frosthaven_campaign_journal/ui/main_shell/state/types.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/state/types.py
@@ -56,6 +56,13 @@ class ConfirmationState:
     body: str = ""
     confirm_label: str = "Confirmar"
     payload: Any = None
+    event_id: int | None = None
+
+
+@dataclass
+class ToastState:
+    message: str | None = None
+    event_id: int | None = None
 
 
 @dataclass

--- a/src/frosthaven_campaign_journal/ui/main_shell/state/view_data.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/state/view_data.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta, timezone
 
 from frosthaven_campaign_journal.models import EntryRef, EntrySummary, ViewerSessionItem
 from frosthaven_campaign_journal.ui.main_shell.model import (
-    ConfirmationViewState,
     EntryFormViewState,
     EntryNotesEditorViewState,
     MainShellViewData,
@@ -15,14 +14,6 @@ from frosthaven_campaign_journal.ui.main_shell.model import (
 
 class MainShellViewDataMixin:
     def build_view_data(self) -> MainShellViewData:
-        confirmation_view: ConfirmationViewState | None = None
-        if self.confirmation_state.key is not None:
-            confirmation_view = ConfirmationViewState(
-                key=self.confirmation_state.key,
-                title=self.confirmation_state.title,
-                body=self.confirmation_state.body,
-                confirm_label=self.confirmation_state.confirm_label,
-            )
         entry_form_view: EntryFormViewState | None = None
         if self.entry_form_state is not None:
             entry_form_view = EntryFormViewState(
@@ -106,8 +97,6 @@ class MainShellViewDataMixin:
             read_error_message=self.read_state.error_message,
             read_warning_message=self.read_state.warning_message,
             env_name=self.env_name,
-            info_message=self.info_message,
-            confirmation=confirmation_view,
             entry_form=entry_form_view,
             entry_notes_editor=entry_notes_view,
             session_form=session_form_view,

--- a/src/frosthaven_campaign_journal/ui/main_shell/state/week_entry_resources.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/state/week_entry_resources.py
@@ -443,5 +443,5 @@ class MainShellWeekEntryResourceActionsMixin:
             self.entry_panel_state.resource_draft_values = dict(normalized)
             self.entry_panel_state.resource_draft_dirty = False
             self.entry_panel_state.resource_write_error_message = None
-        self.info_message = "Cambios de recursos descartados."
+        self._emit_info_toast("Cambios de recursos descartados.")
         self.notify()

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/center_forms.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/center_forms.py
@@ -6,27 +6,9 @@ from frosthaven_campaign_journal.ui.common.components.surfaces import build_pane
 from frosthaven_campaign_journal.ui.common.theme.colors import (
     COLOR_ERROR_TEXT,
     COLOR_TEXT_HEADING,
-    COLOR_TEXT_PRIMARY,
 )
 from frosthaven_campaign_journal.ui.main_shell.model import MainShellViewData
 from frosthaven_campaign_journal.ui.main_shell.state import MainShellState
-
-
-def _build_confirmation_card(data: MainShellViewData, state: MainShellState) -> ft.Control:
-    assert data.confirmation is not None
-    return build_panel(
-        controls=[
-            ft.Text(data.confirmation.title, size=15, weight=ft.FontWeight.BOLD, color=COLOR_TEXT_HEADING),
-            ft.Text(data.confirmation.body, size=13, color=COLOR_TEXT_PRIMARY),
-            ft.Row(
-                spacing=8,
-                controls=[
-                    ft.TextButton("Cancelar", on_click=state.on_cancel_pending_action),
-                    ft.FilledButton(data.confirmation.confirm_label, on_click=state.on_confirm_pending_action),
-                ],
-            ),
-        ],
-    )
 
 
 def _build_entry_form_editor(data: MainShellViewData, state: MainShellState) -> ft.Control:

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/center_panel.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/center_panel.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import flet as ft
 
@@ -11,7 +11,6 @@ from frosthaven_campaign_journal.ui.main_shell.view.center_focus import (
     _build_focus_week_mode,
 )
 from frosthaven_campaign_journal.ui.main_shell.view.center_forms import (
-    _build_confirmation_card,
     _build_entry_form_editor,
     _build_entry_notes_editor,
     _build_session_form_editor,
@@ -26,15 +25,11 @@ def build_center_panel(data: MainShellViewData, state: MainShellState) -> ft.Con
         top_controls.append(build_banner(title="Error de lectura", body=data.read_error_message, tone=BannerTone.ERROR))
     if data.read_warning_message:
         top_controls.append(build_banner(title="Advertencia", body=data.read_warning_message, tone=BannerTone.WARNING))
-    if data.info_message:
-        top_controls.append(build_banner(title="Información", body=data.info_message, tone=BannerTone.INFO))
     if data.week_write_error_message:
         top_controls.append(build_banner(title="Error de semana", body=data.week_write_error_message, tone=BannerTone.ERROR))
     if data.entry_write_error_message:
         top_controls.append(build_banner(title="Error de entrada", body=data.entry_write_error_message, tone=BannerTone.ERROR))
 
-    if data.confirmation is not None:
-        top_controls.append(_build_confirmation_card(data, state))
     if data.entry_form is not None:
         top_controls.append(_build_entry_form_editor(data, state))
     if data.entry_notes_editor is not None:

--- a/tests/main_shell_test_support.py
+++ b/tests/main_shell_test_support.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from types import ModuleType
+
+
+def install_data_stub() -> None:
+    if "frosthaven_campaign_journal.data" in sys.modules:
+        return
+
+    data_stub = ModuleType("frosthaven_campaign_journal.data")
+
+    class FirestoreConfigError(Exception):
+        pass
+
+    class FirestoreReadError(Exception):
+        pass
+
+    class FirestoreConflictError(Exception):
+        pass
+
+    class FirestoreTransitionInvalidError(Exception):
+        pass
+
+    class FirestoreValidationError(Exception):
+        pass
+
+    class FirestoreWriteError(Exception):
+        pass
+
+    @dataclass
+    class CampaignWriteResult:
+        new_year_number: int = 0
+        created_week_start: int = 0
+        created_week_end: int = 0
+
+    @dataclass
+    class WeekWriteResult:
+        auto_stopped_session_id: str | None = None
+
+    @dataclass
+    class EntryWriteResult:
+        entry_ref: object | None = None
+        auto_stopped_session_id: str | None = None
+
+    @dataclass
+    class ResourceBulkWriteResult:
+        pass
+
+    @dataclass
+    class WeekRead:
+        year_number: int = 0
+        week_number: int = 0
+        status: str = "open"
+
+    @dataclass
+    class EntryRead:
+        ref: object | None = None
+        label: str = ""
+        entry_type: str = "scenario"
+        scenario_ref: int | None = None
+        notes: str | None = None
+        scenario_outcome: str | None = None
+        order_index: int = 0
+        resource_deltas: dict[str, int] = field(default_factory=dict)
+        created_at_utc: object | None = None
+        updated_at_utc: object | None = None
+
+    @dataclass
+    class EntrySessionRead:
+        session_id: str = ""
+        started_at_utc: object | None = None
+        ended_at_utc: object | None = None
+        created_at_utc: object | None = None
+        updated_at_utc: object | None = None
+
+    def _unexpected(*_args, **_kwargs):
+        raise AssertionError("Unexpected call into frosthaven_campaign_journal.data stub")
+
+    for name, value in {
+        "FirestoreConfigError": FirestoreConfigError,
+        "FirestoreReadError": FirestoreReadError,
+        "FirestoreConflictError": FirestoreConflictError,
+        "FirestoreTransitionInvalidError": FirestoreTransitionInvalidError,
+        "FirestoreValidationError": FirestoreValidationError,
+        "FirestoreWriteError": FirestoreWriteError,
+        "CampaignWriteResult": CampaignWriteResult,
+        "WeekWriteResult": WeekWriteResult,
+        "EntryWriteResult": EntryWriteResult,
+        "ResourceBulkWriteResult": ResourceBulkWriteResult,
+        "WeekRead": WeekRead,
+        "EntryRead": EntryRead,
+        "EntrySessionRead": EntrySessionRead,
+        "build_firestore_client": _unexpected,
+        "load_main_screen_snapshot": _unexpected,
+        "read_entry_by_ref": _unexpected,
+        "read_q5_entries_for_selected_week": _unexpected,
+        "read_q8_sessions_for_entry": _unexpected,
+        "extend_years_plus_one": _unexpected,
+        "manual_delete_session": _unexpected,
+        "close_week": _unexpected,
+        "delete_entry": _unexpected,
+        "reclose_week": _unexpected,
+        "reopen_week": _unexpected,
+        "manual_create_session": _unexpected,
+        "manual_update_session": _unexpected,
+        "start_session": _unexpected,
+        "stop_session": _unexpected,
+        "create_entry": _unexpected,
+        "reorder_entry_within_week": _unexpected,
+        "replace_entry_resource_deltas": _unexpected,
+        "update_entry": _unexpected,
+        "update_entry_notes": _unexpected,
+    }.items():
+        setattr(data_stub, name, value)
+
+    sys.modules["frosthaven_campaign_journal.data"] = data_stub

--- a/tests/test_main_shell_center_panel.py
+++ b/tests/test_main_shell_center_panel.py
@@ -5,6 +5,10 @@ from typing import Iterator
 
 import flet as ft
 
+from tests.main_shell_test_support import install_data_stub
+
+install_data_stub()
+
 from frosthaven_campaign_journal.models import WeekSummary
 from frosthaven_campaign_journal.ui.main_shell.state.shell_state import MainShellState
 from frosthaven_campaign_journal.ui.main_shell.view.center_panel import build_center_panel
@@ -78,6 +82,25 @@ class MainShellCenterPanelTests(unittest.TestCase):
         text_values = _text_values(panel)
         self.assertIn("Entradas de la semana", text_values)
         self.assertNotIn("Selecciona una semana.", text_values)
+
+    def test_center_panel_does_not_render_info_or_confirmation_inline(self) -> None:
+        state = _build_state(selected_week=1)
+        state._emit_info_toast("Cambios guardados.")
+        state._set_confirmation(
+            key="week_close",
+            title="Cerrar semana",
+            body="¿Quieres continuar?",
+            confirm_label="Cerrar",
+            payload=(1, 1),
+        )
+
+        panel = build_center_panel(state.build_view_data(), state)
+        text_values = _text_values(panel)
+
+        self.assertNotIn("Información", text_values)
+        self.assertNotIn("Cambios guardados.", text_values)
+        self.assertNotIn("Cerrar semana", text_values)
+        self.assertNotIn("¿Quieres continuar?", text_values)
 
 
 if __name__ == "__main__":

--- a/tests/test_main_shell_feedback_events.py
+++ b/tests/test_main_shell_feedback_events.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import unittest
+
+from tests.main_shell_test_support import install_data_stub
+
+install_data_stub()
+
+from frosthaven_campaign_journal.ui.main_shell.state.shell_state import MainShellState
+
+
+class MainShellFeedbackEventTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.state = MainShellState()
+        self.state.notify = lambda: None
+
+    def test_emit_info_toast_repeats_same_message_with_new_event_id(self) -> None:
+        self.state._emit_info_toast("Cambios guardados.")
+        first_message = self.state.toast_state.message
+        first_event_id = self.state.toast_state.event_id
+
+        self.state._emit_info_toast("Cambios guardados.")
+
+        self.assertEqual(self.state.toast_state.message, first_message)
+        self.assertIsNotNone(first_event_id)
+        self.assertIsNotNone(self.state.toast_state.event_id)
+        self.assertNotEqual(self.state.toast_state.event_id, first_event_id)
+
+    def test_set_confirmation_repeats_same_payload_with_new_event_id(self) -> None:
+        self.state._set_confirmation(
+            key="week_close",
+            title="Cerrar semana",
+            body="¿Quieres continuar?",
+            confirm_label="Cerrar",
+            payload=(1, 2),
+        )
+        first_event_id = self.state.confirmation_state.event_id
+
+        self.state._set_confirmation(
+            key="week_close",
+            title="Cerrar semana",
+            body="¿Quieres continuar?",
+            confirm_label="Cerrar",
+            payload=(1, 2),
+        )
+
+        self.assertIsNotNone(first_event_id)
+        self.assertIsNotNone(self.state.confirmation_state.event_id)
+        self.assertNotEqual(self.state.confirmation_state.event_id, first_event_id)
+
+    def test_cancel_pending_action_clears_confirmation_and_pending_action(self) -> None:
+        self.state._queue_pending_context_action(lambda: None, action_label="refrescar")
+        self.state._set_confirmation(
+            key="week_close",
+            title="Cerrar semana",
+            body="¿Quieres continuar?",
+            confirm_label="Cerrar",
+            payload=(1, 2),
+        )
+
+        self.state.on_cancel_pending_action()
+
+        self.assertIsNone(self.state.confirmation_state.key)
+        self.assertIsNone(self.state.confirmation_state.event_id)
+        self.assertIsNone(self.state._pending_context_action)
+        self.assertIsNone(self.state._pending_context_action_label)
+
+    def test_confirm_pending_action_clears_confirmation_and_runs_pending_action(self) -> None:
+        ran: list[bool] = []
+        self.state.entry_panel_state.resource_draft_dirty = True
+        self.state._queue_pending_context_action(lambda: ran.append(True), action_label="refrescar")
+        self.state._set_confirmation(
+            key="discard_resource_draft_context_change",
+            title="Cambios de recursos sin guardar",
+            body="¿Quieres descartar y continuar?",
+            confirm_label="Descartar y continuar",
+            payload="refrescar",
+        )
+
+        self.state.on_confirm_pending_action()
+
+        self.assertEqual(ran, [True])
+        self.assertIsNone(self.state.confirmation_state.key)
+        self.assertIsNone(self.state.confirmation_state.event_id)
+        self.assertIsNone(self.state._pending_context_action)
+        self.assertIsNone(self.state._pending_context_action_label)
+        self.assertEqual(
+            self.state.toast_state.message,
+            "Cambios de recursos sin guardar descartados al cambiar de contexto.",
+        )
+        self.assertIsNotNone(self.state.toast_state.event_id)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Resumen

- mover mensajes informativos de `main_shell` a `SnackBar` flotante gestionado desde `app_root.py`
- mover preguntas de confirmación a `AlertDialog` modal con botones alineados a la paleta del FAB
- retirar el render inline de info/confirmaciones del panel central y cubrir el cambio con tests/documentación

## Validación

- `python -m unittest tests.test_main_shell_center_panel tests.test_main_shell_feedback_events`
- `python -m py_compile` sobre los archivos tocados

Closes #111