### PR TITLE
feat: rediseñar sesiones activas en entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ y usa versionado
 
 - Tests unitarios de `MainShellState` para `ToastState`, `event_id` de
   confirmación y limpieza de estado tras cancelar/confirmar.
+- Helpers y componente de temporización en
+  `ui/main_shell/view/session_timing.py` para formatear sesiones y renderizar
+  reloj vivo `hh:mm:ss`.
+- Tests de vista para el toggle rápido `play/stop`, el resumen de sesiones por
+  entry y la caja de sesión activa en la barra inferior.
 
 ### Cambiado
 
@@ -21,6 +26,10 @@ y usa versionado
 - `app_root.py` pasa a puentear overlays de Flet desde estado transitorio,
   mientras el panel central mantiene solo banners de error/advertencia y
   formularios inline.
+- Las tarjetas de `Entry` mueven el control rápido de sesión al header con
+  iconos `play/stop`, compactan la caja `Sesiones` a formato resumen y la barra
+  inferior recupera el resumen de sesión activa global con reloj vivo y
+  subtítulo de contexto.
 
 ## [0.2.1] - 2026-03-05
 

--- a/docs/active-session-flow.md
+++ b/docs/active-session-flow.md
@@ -6,8 +6,8 @@
 - `purpose`: Definir el flujo funcional de sesiÃ³n activa (`start/stop/auto-stop`) del MVP, incluyendo cambio de foco, errores y recuperaciÃ³n esperada del cliente.
 - `status`: active
 - `source_of_truth`: official
-- `last_updated`: 2026-02-24
-- `next_review`: 2026-03-10
+- `last_updated`: 2026-03-06
+- `next_review`: 2026-03-16
 
 ## Objetivo
 
@@ -66,8 +66,12 @@ No incluye:
 1. `active_entry`:
    - `Entry` que posee la sesiÃ³n activa global (si existe), derivado de una
      `Session` con `ended_at_utc = null`.
-1. Los controles `Iniciar/Parar sesiÃ³n` viven en el bloque de la
-   `selected_entry` (junto a total jugado y lista de sesiones desplegable).
+1. El control rÃ¡pido `play/stop` vive en la barra de acciones del header de la
+   `Entry` visible/operable.
+1. El bloque `Sesiones` de esa `Entry` mantiene:
+   - total jugado;
+   - listado/resumen de sesiones;
+   - acciones manuales (`crear/editar/borrar`).
 1. Cambiar `selected_week` o `selected_entry` no implica por sÃ­ mismo cambiar
    `current week` ni cerrar la sesiÃ³n activa global.
 1. Una implementaciÃ³n puede mantener un **visor sticky** (Ãºltima entry visible)

--- a/docs/context-governance.md
+++ b/docs/context-governance.md
@@ -6,8 +6,8 @@
 - `purpose`: Gobierno de contexto, gate de calidad y estado verificable.
 - `status`: active
 - `source_of_truth`: official
-- `last_updated`: 2026-03-05
-- `next_review`: 2026-03-13
+- `last_updated`: 2026-03-06
+- `next_review`: 2026-03-16
 
 ## Alcance de Fase 0
 
@@ -254,6 +254,36 @@ Se valida:
     incluyendo orden visual `Otros -> Materiales -> Plantas`.
   - Soporte de notas de semana eliminado de modelos, estado, writes y contratos
     activos del MVP.
+
+### Hito H1-08
+
+- Fecha: 2026-03-06
+- Objetivo: mover el control rápido de sesión al header de las `Entry`,
+  compactar la caja `Sesiones` y recuperar el resumen de sesión activa global
+  en la barra inferior (`#103`).
+- Resultado: completado
+- Verificación A: aprobado (UI, tests y documentación oficial alineados con el
+  nuevo flujo de sesión activa)
+- Verificación B: aprobado (suite `python -m unittest discover -s tests -p
+  "test_*.py"` en verde y validación Flet web no mutativa en
+  `http://127.0.0.1:8550`)
+- Evidencia:
+  - `src/frosthaven_campaign_journal/ui/main_shell/view/center_focus.py`
+  - `src/frosthaven_campaign_journal/ui/main_shell/view/status_bar.py`
+  - `src/frosthaven_campaign_journal/ui/main_shell/view/session_timing.py`
+  - `tests/test_main_shell_center_panel.py`
+  - `tests/test_main_shell_status_bar.py`
+  - `tests/test_session_timing.py`
+  - `docs/active-session-flow.md`
+  - `docs/decision-log.md` (DEC-0054)
+  - `CHANGELOG.md`
+- Resumen:
+  - Cada tarjeta de `Entry` muestra `play` o `stop` en el header según
+    `active_entry_ref`.
+  - La caja `Sesiones` pasa a formato resumen de ancho completo con total
+    jugado, botón `Nueva sesión` y filas compactas editables.
+  - La barra inferior vuelve a mostrar la sesión activa global con reloj vivo
+    `hh:mm:ss` y subtítulo contextual `{Entry activa} · Semana X`.
 
 
 ## Conocimiento migrado desde legado

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -1234,3 +1234,13 @@
 - `rationale`: separa feedback efímero del contenido principal, evita acoplar la capa de estado a `Page`, y permite reemitir el mismo mensaje o la misma confirmación sin perder eventos por igualdad de contenido.
 - `impact`: `model.py` y `view_data.py` dejan de exponer `info_message`/confirmación inline; `app_root.py` pasa a abrir/cerrar overlays; los botones del diálogo heredan la paleta del FAB; y se añaden tests para `toast_state`/`confirmation_state` con `event_id`.
 - `references`: `src/frosthaven_campaign_journal/ui/app_root.py`, `src/frosthaven_campaign_journal/ui/main_shell/state/types.py`, `src/frosthaven_campaign_journal/ui/main_shell/state/runtime_support.py`, `src/frosthaven_campaign_journal/ui/main_shell/view/center_panel.py`, `docs/ui-main-shell-architecture-mvs.md`, `CHANGELOG.md`
+
+### DEC-0054
+
+- `date`: 2026-03-06
+- `status`: accepted
+- `problem`: la tarjeta de `Entry` seguía separando demasiado la operativa de sesiones entre botones redundantes dentro de la caja `Sesiones` y ausencia de resumen visible de la sesión activa global en la barra inferior.
+- `decision`: mover el `play/stop` rápido al header de cada tarjeta de `Entry`, compactar la caja `Sesiones` a formato resumen con total jugado + listado manual editable, y recuperar en la barra inferior una caja fija de sesión activa global con reloj vivo `hh:mm:ss` y subtítulo `{Entry activa} · Semana X`.
+- `rationale`: mejora jerarquía visual, acerca la acción frecuente al título de la entrada, y hace visible el estado de sesión activa aunque el usuario navegue por otra `Week`/`Entry`.
+- `impact`: supersede parcialmente `DEC-0045` en el punto que dejó la barra inferior solo para recursos; `center_focus.py` reordena acciones y filas de sesiones; `status_bar.py` vuelve a mostrar resumen activo; y `docs/active-session-flow.md` se alinea con la nueva ubicación del control rápido.
+- `references`: `src/frosthaven_campaign_journal/ui/main_shell/view/center_focus.py`, `src/frosthaven_campaign_journal/ui/main_shell/view/status_bar.py`, `src/frosthaven_campaign_journal/ui/main_shell/view/session_timing.py`, `docs/active-session-flow.md`, `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/103`

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/center_focus.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/center_focus.py
@@ -39,9 +39,11 @@ from frosthaven_campaign_journal.ui.main_shell.model import (
     WeekEntryCardViewData,
 )
 from frosthaven_campaign_journal.ui.main_shell.state import MainShellState
-from frosthaven_campaign_journal.ui.main_shell.view.center_helpers import (
-    _build_card,
-    _format_session_line,
+from frosthaven_campaign_journal.ui.main_shell.view.center_helpers import _build_card
+from frosthaven_campaign_journal.ui.main_shell.view.session_timing import (
+    build_session_duration_text,
+    format_session_summary_date,
+    format_session_summary_range,
 )
 
 WEEK_ENTRY_CARD_WIDTH = 540
@@ -186,7 +188,20 @@ def _build_entry_card_header(
     if outcome_icon is not None:
         title_controls.append(outcome_icon)
 
+    is_session_busy = data.session_write_pending or card.session_write_pending
     action_buttons: list[ft.Control] = [
+        ft.IconButton(
+            icon=(ft.Icons.STOP_CIRCLE_OUTLINED if card.is_active_session_owner else ft.Icons.PLAY_CIRCLE_OUTLINE),
+            icon_size=19,
+            icon_color=COLOR_WHITE,
+            tooltip=("Detener sesión" if card.is_active_session_owner else "Iniciar sesión"),
+            on_click=(
+                (lambda _event, entry_ref=entry.ref: state.on_stop_session_for_entry(entry_ref))
+                if card.is_active_session_owner
+                else (lambda _event, entry_ref=entry.ref: state.on_start_session_for_entry(entry_ref))
+            ),
+            disabled=is_session_busy,
+        ),
         ft.IconButton(
             icon=ft.Icons.EDIT_NOTE,
             icon_size=18,
@@ -306,10 +321,11 @@ def _build_entry_resources_card(
             resource_rows: list[ft.Control] = []
             for item in group_column:
                 current_delta = card.resource_draft_values.get(item.key, 0)
-                projected_total = (
-                    None
-                    if campaign_resource_totals is None
-                    else campaign_resource_totals.get(item.key, 0) + current_delta
+                projected_total = _calculate_projected_resource_total(
+                    campaign_resource_totals=campaign_resource_totals,
+                    resource_key=item.key,
+                    persisted_entry_delta=card.entry.resource_deltas.get(item.key, 0),
+                    draft_entry_delta=current_delta,
                 )
                 resource_rows.append(
                     ResourceDeltaRow(
@@ -392,19 +408,35 @@ def _build_entry_resources_card(
     )
 
 
+def _calculate_projected_resource_total(
+    *,
+    campaign_resource_totals: dict[str, int] | None,
+    resource_key: str,
+    persisted_entry_delta: int,
+    draft_entry_delta: int,
+) -> int | None:
+    if campaign_resource_totals is None:
+        return None
+    campaign_total = campaign_resource_totals.get(resource_key, 0)
+    return campaign_total - persisted_entry_delta + draft_entry_delta
+
+
 def _build_entry_sessions_card(
     data: MainShellViewData,
     state: MainShellState,
     card: WeekEntryCardViewData,
     status_line: str,
 ) -> ft.Control:
-    has_active_session = any(session.ended_at_utc is None for session in card.sessions)
+    is_session_busy = data.session_write_pending or card.session_write_pending
 
     rows: list[ft.Control] = []
     for session in card.sessions[:MAX_SESSIONS_PREVIEW]:
         rows.append(
             _build_session_row(
-                state, card.entry.ref, session, card.session_write_pending
+                state,
+                card.entry.ref,
+                session,
+                is_pending=is_session_busy,
             )
         )
 
@@ -426,46 +458,50 @@ def _build_entry_sessions_card(
                 color=COLOR_ERROR_TEXT,
             ),
         )
+    elif not card.sessions:
+        rows.append(
+            ft.Text(
+                "Sin sesiones registradas.",
+                size=12,
+                color=COLOR_TEXT_MUTED,
+            )
+        )
 
     controls: list[ft.Control] = [
-        ft.Text(status_line, size=12, color=COLOR_TEXT_MUTED),
-        ft.Text(
-            f"Total jugado (Q8): {card.sessions_total_text}",
-            size=12,
-            color=COLOR_TEXT_MUTED,
-        ),
         ft.Row(
-            spacing=6,
-            wrap=True,
+            alignment=ft.MainAxisAlignment.SPACE_BETWEEN,
+            vertical_alignment=ft.CrossAxisAlignment.CENTER,
             controls=[
+                ft.Column(
+                    expand=True,
+                    spacing=1,
+                    controls=[
+                        ft.Text(
+                            "Total jugado",
+                            size=11,
+                            color=COLOR_TEXT_MUTED,
+                        ),
+                        ft.Text(
+                            card.sessions_total_text,
+                            size=20,
+                            weight=ft.FontWeight.W_700,
+                            color=COLOR_TEXT_PRIMARY,
+                        ),
+                    ],
+                ),
                 ft.FilledButton(
-                    "Iniciar",
-                    on_click=lambda _event, entry_ref=card.entry.ref: state.on_start_session_for_entry(
-                        entry_ref
-                    ),
-                    disabled=card.session_write_pending,
-                    height=32,
-                ),
-                ft.OutlinedButton(
-                    "Detener",
-                    on_click=lambda _event, entry_ref=card.entry.ref: state.on_stop_session_for_entry(
-                        entry_ref
-                    ),
-                    disabled=card.session_write_pending or not has_active_session,
-                    height=32,
-                ),
-                ft.OutlinedButton(
                     "Nueva sesión",
                     on_click=(
                         lambda _event, entry_ref=card.entry.ref: state.on_open_manual_create_session_for_entry(
                             entry_ref
                         )
                     ),
-                    disabled=card.session_write_pending,
+                    disabled=is_session_busy,
                     height=32,
                 ),
             ],
         ),
+        ft.Text(status_line, size=12, color=COLOR_TEXT_MUTED),
     ]
 
     controls.extend(rows)
@@ -486,10 +522,11 @@ def _build_session_row(
     state: MainShellState,
     entry_ref: EntryRef,
     session: ViewerSessionItem,
+    *,
     is_pending: bool,
 ) -> ft.Control:
     return ft.Container(
-        padding=ft.Padding(left=8, top=6, right=8, bottom=6),
+        padding=ft.Padding(left=8, top=7, right=8, bottom=7),
         bgcolor=COLOR_PANEL_BG,
         border=ft.Border.all(1, COLOR_PANEL_INNER_BORDER),
         border_radius=6,
@@ -497,11 +534,47 @@ def _build_session_row(
             alignment=ft.MainAxisAlignment.SPACE_BETWEEN,
             vertical_alignment=ft.CrossAxisAlignment.CENTER,
             controls=[
-                ft.Text(
-                    _format_session_line(session), size=12, color=COLOR_TEXT_PRIMARY
+                ft.Row(
+                    expand=True,
+                    wrap=True,
+                    spacing=14,
+                    run_spacing=6,
+                    vertical_alignment=ft.CrossAxisAlignment.CENTER,
+                    controls=[
+                        _build_session_summary_metric(
+                            icon=ft.Icons.CALENDAR_MONTH_OUTLINED,
+                            content=ft.Text(
+                                format_session_summary_date(session.started_at_utc),
+                                size=12,
+                                color=COLOR_TEXT_PRIMARY,
+                            ),
+                        ),
+                        _build_session_summary_metric(
+                            icon=ft.Icons.SCHEDULE_OUTLINED,
+                            content=ft.Text(
+                                format_session_summary_range(
+                                    started_at_utc=session.started_at_utc,
+                                    ended_at_utc=session.ended_at_utc,
+                                ),
+                                size=12,
+                                color=COLOR_TEXT_PRIMARY,
+                            ),
+                        ),
+                        _build_session_summary_metric(
+                            icon=ft.Icons.HOURGLASS_BOTTOM_OUTLINED,
+                            content=build_session_duration_text(
+                                started_at_utc=session.started_at_utc,
+                                ended_at_utc=session.ended_at_utc,
+                                size=12,
+                                weight=ft.FontWeight.W_700,
+                                color=COLOR_TEXT_PRIMARY,
+                            ),
+                        ),
+                    ],
                 ),
                 ft.Row(
                     spacing=4,
+                    wrap=True,
                     controls=[
                         ft.OutlinedButton(
                             "Editar",
@@ -532,6 +605,18 @@ def _build_session_row(
     )
 
 
+def _build_session_summary_metric(*, icon: ft.IconData, content: ft.Control) -> ft.Control:
+    return ft.Row(
+        spacing=6,
+        tight=True,
+        vertical_alignment=ft.CrossAxisAlignment.CENTER,
+        controls=[
+            ft.Icon(icon, size=15, color=COLOR_TEXT_MUTED),
+            content,
+        ],
+    )
+
+
 def _build_entry_outcome_icon(entry: EntrySummary) -> ft.Control | None:
     if entry.entry_type != "scenario":
         return None
@@ -551,13 +636,11 @@ def _build_entry_card_status_texts(
     card: WeekEntryCardViewData,
 ) -> _EntryCardStatusTexts:
     if data.active_entry_ref is None:
-        sessions_status = "Sin sesión activa real."
+        sessions_status = "Sin sesión activa."
     elif card.is_active_session_owner:
-        sessions_status = (
-            f"Con sesión activa aquí: {data.active_entry_label or card.entry.label}."
-        )
+        sessions_status = "Sesión activa en esta entrada."
     else:
-        sessions_status = f"Con sesión activa en otra entrada: {data.active_entry_label or 'Entrada activa'}."
+        sessions_status = f"Sesión activa en {data.active_entry_label or 'otra entrada'}."
 
     return _EntryCardStatusTexts(
         sessions_status=sessions_status,

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/session_timing.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/session_timing.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import flet as ft
+
+
+def coerce_datetime(value: object | None) -> datetime | None:
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value
+
+
+def format_session_duration_hms(
+    *,
+    started_at_utc: object | None,
+    ended_at_utc: object | None = None,
+    now: datetime | None = None,
+) -> str:
+    started = coerce_datetime(started_at_utc)
+    if started is None:
+        return "00:00:00"
+
+    resolved_now = now or datetime.now(timezone.utc)
+    if resolved_now.tzinfo is None:
+        resolved_now = resolved_now.replace(tzinfo=timezone.utc)
+    ended = coerce_datetime(ended_at_utc) or resolved_now
+    if ended < started:
+        ended = started
+
+    total_seconds = int((ended - started).total_seconds())
+    hours, remainder = divmod(max(0, total_seconds), 3600)
+    minutes, seconds = divmod(remainder, 60)
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+
+
+def format_session_summary_date(started_at_utc: object | None) -> str:
+    started = coerce_datetime(started_at_utc)
+    if started is None:
+        return "n/d"
+    return started.astimezone().strftime("%d/%m/%y")
+
+
+def format_session_summary_range(
+    *,
+    started_at_utc: object | None,
+    ended_at_utc: object | None = None,
+) -> str:
+    started = coerce_datetime(started_at_utc)
+    if started is None:
+        return "n/d"
+
+    started_text = started.astimezone().strftime("%H:%M")
+    ended = coerce_datetime(ended_at_utc)
+    if ended is None:
+        return f"{started_text} - activa"
+    return f"{started_text} - {ended.astimezone().strftime('%H:%M')}"
+
+
+def build_active_session_subtitle(*, entry_label: str | None, week_number: int | None) -> str:
+    base_label = entry_label or "Entrada activa"
+    if week_number is None:
+        return base_label
+    return f"{base_label} · Semana {week_number}"
+
+
+def build_session_duration_text(
+    *,
+    started_at_utc: object | None,
+    ended_at_utc: object | None = None,
+    size: int,
+    weight: ft.FontWeight = ft.FontWeight.W_700,
+    color: str,
+    text_align: ft.TextAlign = ft.TextAlign.LEFT,
+) -> ft.Control:
+    try:
+        return SessionDurationText(
+            started_at_utc=started_at_utc,
+            ended_at_utc=ended_at_utc,
+            size=size,
+            weight=weight,
+            color=color,
+            text_align=text_align,
+        )
+    except RuntimeError:
+        return ft.Text(
+            value=format_session_duration_hms(
+                started_at_utc=started_at_utc,
+                ended_at_utc=ended_at_utc,
+            ),
+            size=size,
+            weight=weight,
+            color=color,
+            text_align=text_align,
+            no_wrap=True,
+        )
+
+
+@ft.component
+def SessionDurationText(
+    *,
+    started_at_utc: object | None,
+    ended_at_utc: object | None = None,
+    size: int,
+    weight: ft.FontWeight = ft.FontWeight.W_700,
+    color: str,
+    text_align: ft.TextAlign = ft.TextAlign.LEFT,
+) -> ft.Control:
+    tick, set_tick = ft.use_state(0)
+
+    def _setup():
+        if coerce_datetime(started_at_utc) is None or coerce_datetime(ended_at_utc) is not None:
+            return None
+
+        async def _tick() -> None:
+            while True:
+                await asyncio.sleep(1)
+                set_tick(lambda current: current + 1)
+
+        task = ft.context.page.run_task(_tick)
+
+        def _cleanup() -> None:
+            task.cancel()
+
+        return _cleanup
+
+    ft.use_effect(_setup, dependencies=[started_at_utc, ended_at_utc])
+    _ = tick
+
+    return ft.Text(
+        value=format_session_duration_hms(
+            started_at_utc=started_at_utc,
+            ended_at_utc=ended_at_utc,
+        ),
+        size=size,
+        weight=weight,
+        color=color,
+        text_align=text_align,
+        no_wrap=True,
+    )

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/status_bar.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/status_bar.py
@@ -12,26 +12,38 @@ from frosthaven_campaign_journal.ui.common.theme.colors import (
     COLOR_STATUS_LABEL_BORDER,
     COLOR_STATUS_LABEL_TEXT,
     COLOR_TEXT_PRIMARY,
+    COLOR_TEXT_MUTED,
 )
 from frosthaven_campaign_journal.ui.main_shell.model import MainShellViewData
+from frosthaven_campaign_journal.ui.main_shell.view.session_timing import (
+    build_active_session_subtitle,
+    build_session_duration_text,
+)
 
 
 def build_status_bar(data: MainShellViewData) -> ft.Control:
-    return ft.Row(
-        vertical_alignment=ft.CrossAxisAlignment.CENTER,
-        controls=[
-            ft.Container(
-                expand=True,
-                content=ft.Row(
-                    scroll=ft.ScrollMode.AUTO,
-                    spacing=8,
-                    controls=[
-                        _build_resource_group_box(data, group)
-                        for group in iter_resource_ui_groups()
-                    ],
-                ),
+    controls: list[ft.Control] = [
+        ft.Container(
+            expand=True,
+            content=ft.Row(
+                scroll=ft.ScrollMode.AUTO,
+                spacing=8,
+                controls=[
+                    _build_resource_group_box(data, group)
+                    for group in iter_resource_ui_groups()
+                ],
             ),
-        ],
+        ),
+    ]
+
+    active_session_box = _build_active_session_box(data)
+    if active_session_box is not None:
+        controls.append(active_session_box)
+
+    return ft.Row(
+        spacing=12,
+        vertical_alignment=ft.CrossAxisAlignment.CENTER,
+        controls=controls,
     )
 
 
@@ -100,3 +112,51 @@ def _format_saved_total(resource_totals: dict[str, int] | None, resource_key: st
     if resource_totals is None:
         return "N/D"
     return str(resource_totals.get(resource_key, 0))
+
+
+def _build_active_session_box(data: MainShellViewData) -> ft.Control | None:
+    if data.active_session_started_at_utc is None:
+        return None
+
+    active_week_number = data.active_entry_ref.week_number if data.active_entry_ref is not None else None
+    subtitle = build_active_session_subtitle(
+        entry_label=data.active_entry_label,
+        week_number=active_week_number,
+    )
+
+    return ft.Container(
+        width=250,
+        padding=ft.Padding(left=12, top=10, right=12, bottom=10),
+        bgcolor=COLOR_STATUS_GROUP_BG,
+        border=ft.Border.all(1, COLOR_STATUS_GROUP_BORDER),
+        border_radius=10,
+        content=ft.Column(
+            spacing=2,
+            controls=[
+                ft.Row(
+                    spacing=8,
+                    vertical_alignment=ft.CrossAxisAlignment.CENTER,
+                    controls=[
+                        ft.Icon(
+                            ft.Icons.TIMER_OUTLINED,
+                            size=20,
+                            color=COLOR_TEXT_PRIMARY,
+                        ),
+                        build_session_duration_text(
+                            started_at_utc=data.active_session_started_at_utc,
+                            size=24,
+                            weight=ft.FontWeight.W_700,
+                            color=COLOR_TEXT_PRIMARY,
+                        ),
+                    ],
+                ),
+                ft.Text(
+                    subtitle,
+                    size=11,
+                    color=COLOR_TEXT_MUTED,
+                    no_wrap=True,
+                    overflow=ft.TextOverflow.ELLIPSIS,
+                ),
+            ],
+        ),
+    )

--- a/tests/test_main_shell_center_panel.py
+++ b/tests/test_main_shell_center_panel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 import unittest
 from typing import Iterator
 
@@ -9,7 +10,15 @@ from tests.main_shell_test_support import install_data_stub
 
 install_data_stub()
 
-from frosthaven_campaign_journal.models import WeekSummary
+from frosthaven_campaign_journal.models import (
+    EntryRef,
+    EntrySummary,
+    ViewerSessionItem,
+    WeekSummary,
+)
+from frosthaven_campaign_journal.ui.common.resources.resource_delta_row import (
+    ResourceDeltaRow,
+)
 from frosthaven_campaign_journal.ui.main_shell.state.shell_state import MainShellState
 from frosthaven_campaign_journal.ui.main_shell.view.center_panel import (
     build_center_panel,
@@ -34,6 +43,52 @@ def _build_state(*, selected_week: int | None) -> MainShellState:
     return state
 
 
+def _set_single_entry_resources(
+    state: MainShellState,
+    *,
+    persisted_resource_deltas: dict[str, int],
+    campaign_resource_totals: dict[str, int] | None,
+    draft_resource_deltas: dict[str, int] | None = None,
+) -> EntryRef:
+    entry_ref = EntryRef(year_number=1, week_number=1, entry_id="entry-1")
+    state.entry_panel_state.entries_for_selected_week = [
+        EntrySummary(
+            ref=entry_ref,
+            label="Entrada 1",
+            entry_type="scenario",
+            resource_deltas=dict(persisted_resource_deltas),
+        )
+    ]
+    state.read_state.campaign_resource_totals = (
+        None if campaign_resource_totals is None else dict(campaign_resource_totals)
+    )
+    if draft_resource_deltas is not None:
+        state.entry_panel_state.resource_draft_by_entry_ref[entry_ref] = dict(
+            draft_resource_deltas
+        )
+    return entry_ref
+
+
+def _build_entry(*, entry_id: str, label: str) -> EntrySummary:
+    return EntrySummary(
+        ref=EntryRef(year_number=1, week_number=1, entry_id=entry_id),
+        label=label,
+        entry_type="scenario",
+        scenario_ref=1,
+        resource_deltas={},
+    )
+
+
+def _build_session(*, session_id: str, active: bool) -> ViewerSessionItem:
+    started = datetime.now(timezone.utc) - timedelta(hours=2, minutes=24, seconds=31)
+    ended = None if active else started + timedelta(hours=2, minutes=24, seconds=31)
+    return ViewerSessionItem(
+        session_id=session_id,
+        started_at_utc=started,
+        ended_at_utc=ended,
+    )
+
+
 def _iter_controls(control: ft.Control | None) -> Iterator[ft.Control]:
     if control is None:
         return
@@ -52,6 +107,44 @@ def _iter_controls(control: ft.Control | None) -> Iterator[ft.Control]:
 
 def _text_values(control: ft.Control) -> list[str]:
     return [item.value for item in _iter_controls(control) if isinstance(item, ft.Text)]
+
+
+def _button_labels(control: ft.Control) -> list[str]:
+    labels: list[str] = []
+    for item in _iter_controls(control):
+        content = getattr(item, "content", None)
+        if isinstance(content, str):
+            labels.append(content)
+    return labels
+
+
+def _tooltips(control: ft.Control) -> list[str]:
+    tooltips: list[str] = []
+    for item in _iter_controls(control):
+        tooltip = getattr(item, "tooltip", None)
+        if isinstance(tooltip, str) and tooltip:
+            tooltips.append(tooltip)
+    return tooltips
+
+
+def _find_resource_row(control: ft.Control, *, resource_key: str) -> ResourceDeltaRow:
+    for item in _iter_controls(control):
+        if isinstance(item, ResourceDeltaRow) and item.resource_key == resource_key:
+            if not item.controls:
+                item.init()
+            return item
+    raise AssertionError(
+        f"No se encontro ResourceDeltaRow para resource_key={resource_key!r}."
+    )
+
+
+def _find_projected_total_text(row: ResourceDeltaRow) -> str:
+    for value in _text_values(row):
+        if value.startswith("(") and value.endswith(")"):
+            return value
+    raise AssertionError(
+        f"No se encontro texto de total proyectado en la fila {row.resource_key!r}."
+    )
 
 
 class MainShellCenterPanelTests(unittest.TestCase):
@@ -77,7 +170,7 @@ class MainShellCenterPanelTests(unittest.TestCase):
         self.assertIn("Selecciona una semana", text_values)
         self.assertNotIn("Sin semana seleccionada", text_values)
         self.assertFalse(
-            any(value.startswith("Navegación actual:") for value in text_values)
+            any(value.startswith("Navegaci\u00f3n actual:") for value in text_values)
         )
 
     def test_selected_week_without_entries_keeps_week_mode_card(self) -> None:
@@ -95,7 +188,7 @@ class MainShellCenterPanelTests(unittest.TestCase):
         state._set_confirmation(
             key="week_close",
             title="Cerrar semana",
-            body="¿Quieres continuar?",
+            body="\u00bfQuieres continuar?",
             confirm_label="Cerrar",
             payload=(1, 1),
         )
@@ -103,10 +196,126 @@ class MainShellCenterPanelTests(unittest.TestCase):
         panel = build_center_panel(state.build_view_data(), state)
         text_values = _text_values(panel)
 
-        self.assertNotIn("Información", text_values)
+        self.assertNotIn("Informaci\u00f3n", text_values)
         self.assertNotIn("Cambios guardados.", text_values)
         self.assertNotIn("Cerrar semana", text_values)
-        self.assertNotIn("¿Quieres continuar?", text_values)
+        self.assertNotIn("\u00bfQuieres continuar?", text_values)
+
+    def test_resource_projected_total_for_new_entry_uses_draft_delta(self) -> None:
+        state = _build_state(selected_week=1)
+        _set_single_entry_resources(
+            state,
+            persisted_resource_deltas={},
+            campaign_resource_totals={"lumber": 0},
+            draft_resource_deltas={"lumber": 2},
+        )
+
+        panel = build_center_panel(state.build_view_data(), state)
+        row = _find_resource_row(panel, resource_key="lumber")
+
+        self.assertEqual(2, row.delta_value)
+        self.assertEqual(2, row.projected_total)
+        self.assertEqual("(2)", _find_projected_total_text(row))
+
+    def test_resource_projected_total_does_not_double_count_persisted_delta(self) -> None:
+        state = _build_state(selected_week=1)
+        _set_single_entry_resources(
+            state,
+            persisted_resource_deltas={"lumber": 2},
+            campaign_resource_totals={"lumber": 2},
+        )
+
+        panel = build_center_panel(state.build_view_data(), state)
+        row = _find_resource_row(panel, resource_key="lumber")
+
+        self.assertEqual(2, row.delta_value)
+        self.assertEqual(2, row.projected_total)
+        self.assertEqual("(2)", _find_projected_total_text(row))
+
+    def test_resource_projected_total_updates_when_editing_persisted_delta(self) -> None:
+        state = _build_state(selected_week=1)
+        _set_single_entry_resources(
+            state,
+            persisted_resource_deltas={"lumber": 2},
+            campaign_resource_totals={"lumber": 2},
+            draft_resource_deltas={"lumber": 3},
+        )
+
+        panel = build_center_panel(state.build_view_data(), state)
+        row = _find_resource_row(panel, resource_key="lumber")
+
+        self.assertEqual(3, row.delta_value)
+        self.assertEqual(3, row.projected_total)
+        self.assertEqual("(3)", _find_projected_total_text(row))
+
+    def test_resource_projected_total_supports_clearing_persisted_delta(self) -> None:
+        state = _build_state(selected_week=1)
+        _set_single_entry_resources(
+            state,
+            persisted_resource_deltas={"lumber": 2},
+            campaign_resource_totals={"lumber": 2},
+            draft_resource_deltas={},
+        )
+
+        panel = build_center_panel(state.build_view_data(), state)
+        row = _find_resource_row(panel, resource_key="lumber")
+
+        self.assertEqual(0, row.delta_value)
+        self.assertEqual(0, row.projected_total)
+        self.assertEqual("(0)", _find_projected_total_text(row))
+
+    def test_resource_projected_total_keeps_nd_when_campaign_totals_are_unavailable(self) -> None:
+        state = _build_state(selected_week=1)
+        _set_single_entry_resources(
+            state,
+            persisted_resource_deltas={"lumber": 2},
+            campaign_resource_totals=None,
+        )
+
+        panel = build_center_panel(state.build_view_data(), state)
+        row = _find_resource_row(panel, resource_key="lumber")
+
+        self.assertEqual(2, row.delta_value)
+        self.assertIsNone(row.projected_total)
+        self.assertEqual("(N/D)", _find_projected_total_text(row))
+
+    def test_entry_cards_show_play_stop_toggle_from_active_entry(self) -> None:
+        state = _build_state(selected_week=1)
+        first_entry = _build_entry(entry_id="entry-1", label="Escenario 1")
+        second_entry = _build_entry(entry_id="entry-2", label="Escenario 2")
+        state.entry_panel_state.entries_for_selected_week = [first_entry, second_entry]
+        state.entry_panel_state.sessions_by_entry_ref = {
+            first_entry.ref: [],
+            second_entry.ref: [_build_session(session_id="sess-1", active=True)],
+        }
+        state.read_state.active_entry_ref = second_entry.ref
+        state.read_state.active_entry_label = second_entry.label
+        state.read_state.active_session_started_at_utc = (
+            datetime.now(timezone.utc) - timedelta(minutes=10)
+        )
+
+        panel = build_center_panel(state.build_view_data(), state)
+
+        self.assertEqual(_tooltips(panel).count("Iniciar sesión"), 1)
+        self.assertEqual(_tooltips(panel).count("Detener sesión"), 1)
+
+    def test_sessions_card_keeps_manual_actions_and_new_session_button(self) -> None:
+        state = _build_state(selected_week=1)
+        entry = _build_entry(entry_id="entry-1", label="Escenario 1")
+        state.entry_panel_state.entries_for_selected_week = [entry]
+        state.entry_panel_state.sessions_by_entry_ref = {
+            entry.ref: [_build_session(session_id="sess-1", active=False)],
+        }
+
+        panel = build_center_panel(state.build_view_data(), state)
+        labels = _button_labels(panel)
+        text_values = _text_values(panel)
+
+        self.assertIn("Nueva sesión", labels)
+        self.assertIn("Editar", labels)
+        self.assertIn("Borrar", labels)
+        self.assertIn("Total jugado", text_values)
+        self.assertIn("Sesiones", text_values)
 
 
 if __name__ == "__main__":

--- a/tests/test_main_shell_status_bar.py
+++ b/tests/test_main_shell_status_bar.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Iterator
+import unittest
+
+import flet as ft
+
+from tests.main_shell_test_support import install_data_stub
+
+install_data_stub()
+
+from frosthaven_campaign_journal.models import EntryRef
+from frosthaven_campaign_journal.ui.main_shell.state.shell_state import MainShellState
+from frosthaven_campaign_journal.ui.main_shell.view.status_bar import build_status_bar
+
+
+def _iter_controls(control: ft.Control | None) -> Iterator[ft.Control]:
+    if control is None:
+        return
+
+    yield control
+
+    content = getattr(control, "content", None)
+    if isinstance(content, ft.Control):
+        yield from _iter_controls(content)
+
+    controls = getattr(control, "controls", None)
+    if controls is not None:
+        for child in controls:
+            yield from _iter_controls(child)
+
+
+def _text_values(control: ft.Control) -> list[str]:
+    values: list[str] = []
+    for item in _iter_controls(control):
+        if isinstance(item, ft.Text):
+            values.append(item.value)
+    return values
+
+
+class MainShellStatusBarTests(unittest.TestCase):
+    def test_status_bar_shows_active_session_subtitle_when_global_session_exists(self) -> None:
+        state = MainShellState()
+        state.read_state.active_entry_ref = EntryRef(year_number=1, week_number=6, entry_id="entry-1")
+        state.read_state.active_entry_label = "Escenario 12"
+        state.read_state.active_session_started_at_utc = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        status_bar = build_status_bar(state.build_view_data())
+
+        self.assertIn("Escenario 12 · Semana 6", _text_values(status_bar))
+
+    def test_status_bar_hides_active_session_box_without_active_session(self) -> None:
+        state = MainShellState()
+
+        status_bar = build_status_bar(state.build_view_data())
+
+        self.assertNotIn("Entrada activa", " ".join(_text_values(status_bar)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_timing.py
+++ b/tests/test_session_timing.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import unittest
+
+from tests.main_shell_test_support import install_data_stub
+
+install_data_stub()
+
+from frosthaven_campaign_journal.ui.main_shell.view.session_timing import (
+    build_active_session_subtitle,
+    format_session_duration_hms,
+    format_session_summary_date,
+    format_session_summary_range,
+)
+
+
+class SessionTimingFormattingTests(unittest.TestCase):
+    def test_format_session_duration_hms_uses_live_now_for_active_session(self) -> None:
+        started = datetime(2026, 3, 6, 20, 0, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 3, 6, 22, 24, 31, tzinfo=timezone.utc)
+
+        value = format_session_duration_hms(started_at_utc=started, now=now)
+
+        self.assertEqual("02:24:31", value)
+
+    def test_build_active_session_subtitle_includes_week_number(self) -> None:
+        value = build_active_session_subtitle(
+            entry_label="Escenario 12",
+            week_number=7,
+        )
+
+        self.assertEqual("Escenario 12 · Semana 7", value)
+
+    def test_build_active_session_subtitle_falls_back_when_label_missing(self) -> None:
+        value = build_active_session_subtitle(
+            entry_label=None,
+            week_number=5,
+        )
+
+        self.assertEqual("Entrada activa · Semana 5", value)
+
+    def test_format_session_summary_for_finished_session(self) -> None:
+        started = datetime(2026, 2, 9, 21, 41, 0, tzinfo=timezone.utc)
+        ended = datetime(2026, 2, 10, 0, 5, 31, tzinfo=timezone.utc)
+
+        self.assertEqual("09/02/26", format_session_summary_date(started))
+        self.assertEqual(
+            f"{started.astimezone().strftime('%H:%M')} - {ended.astimezone().strftime('%H:%M')}",
+            format_session_summary_range(
+                started_at_utc=started,
+                ended_at_utc=ended,
+            ),
+        )
+        self.assertEqual(
+            "02:24:31",
+            format_session_duration_hms(
+                started_at_utc=started,
+                ended_at_utc=ended,
+            ),
+        )
+
+    def test_format_session_summary_for_active_session(self) -> None:
+        started = datetime(2026, 2, 9, 21, 41, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 2, 10, 0, 5, 31, tzinfo=timezone.utc)
+
+        self.assertEqual(
+            f"{started.astimezone().strftime('%H:%M')} - activa",
+            format_session_summary_range(started_at_utc=started),
+        )
+        self.assertEqual(
+            "02:24:31",
+            format_session_duration_hms(started_at_utc=started, now=now),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Resumen
- mover el control r?pido `play/stop` al header de cada tarjeta de `Entry`
- compactar la caja `Sesiones` con total jugado, bot?n `Nueva sesi?n` y filas resumen editables
- recuperar en la barra inferior el resumen de sesi?n activa global con reloj vivo y subt?tulo contextual
- integrar el ajuste de total proyectado de recursos en la tarjeta de entry

## Validaci?n
- [x] `PYTHONPATH=src pipenv run python -m unittest discover -s tests -p "test_*.py"`
- [x] Validaci?n Flet web no mutativa en `http://127.0.0.1:8550`
- [x] Documentaci?n oficial actualizada (`decision-log`, `active-session-flow`, `context-governance`, `CHANGELOG`)

Closes #103
