### PR TITLE
feat(main-shell): compactar acciones de sesión y reforzar temporizador activo (#115)

### DIFF
--- a/src/frosthaven_campaign_journal/ui/main_shell/view/center_focus.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/center_focus.py
@@ -489,15 +489,17 @@ def _build_entry_sessions_card(
                         ),
                     ],
                 ),
-                ft.FilledButton(
-                    "Nueva sesión",
+                ft.IconButton(
+                    icon=ft.Icons.ADD_CIRCLE_OUTLINE,
+                    icon_size=20,
+                    icon_color=COLOR_TEXT_PRIMARY,
+                    tooltip="Nueva sesión",
                     on_click=(
                         lambda _event, entry_ref=card.entry.ref: state.on_open_manual_create_session_for_entry(
                             entry_ref
                         )
                     ),
                     disabled=is_session_busy,
-                    height=32,
                 ),
             ],
         ),
@@ -576,8 +578,11 @@ def _build_session_row(
                     spacing=4,
                     wrap=True,
                     controls=[
-                        ft.OutlinedButton(
-                            "Editar",
+                        ft.IconButton(
+                            icon=ft.Icons.EDIT_OUTLINED,
+                            icon_size=18,
+                            icon_color=COLOR_TEXT_PRIMARY,
+                            tooltip="Editar sesión",
                             on_click=(
                                 lambda _event, ref=entry_ref, session_id=session.session_id: state.on_open_manual_edit_session_for_entry(
                                     ref,
@@ -585,10 +590,12 @@ def _build_session_row(
                                 )
                             ),
                             disabled=is_pending,
-                            height=30,
                         ),
-                        ft.OutlinedButton(
-                            "Borrar",
+                        ft.IconButton(
+                            icon=ft.Icons.DELETE_OUTLINE,
+                            icon_size=18,
+                            icon_color=COLOR_DESTRUCTIVE_ICON,
+                            tooltip="Borrar sesión",
                             on_click=(
                                 lambda _event, ref=entry_ref, session_id=session.session_id: state.on_open_manual_delete_session_for_entry(
                                     ref,
@@ -596,7 +603,6 @@ def _build_session_row(
                                 )
                             ),
                             disabled=is_pending,
-                            height=30,
                         ),
                     ],
                 ),

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/session_timing.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/session_timing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from concurrent.futures import Future
 from datetime import datetime, timezone
 
 import flet as ft
@@ -76,68 +77,93 @@ def build_session_duration_text(
     color: str,
     text_align: ft.TextAlign = ft.TextAlign.LEFT,
 ) -> ft.Control:
-    try:
-        return SessionDurationText(
-            started_at_utc=started_at_utc,
-            ended_at_utc=ended_at_utc,
-            size=size,
-            weight=weight,
-            color=color,
-            text_align=text_align,
-        )
-    except RuntimeError:
-        return ft.Text(
-            value=format_session_duration_hms(
-                started_at_utc=started_at_utc,
-                ended_at_utc=ended_at_utc,
-            ),
-            size=size,
-            weight=weight,
-            color=color,
-            text_align=text_align,
-            no_wrap=True,
-        )
-
-
-@ft.component
-def SessionDurationText(
-    *,
-    started_at_utc: object | None,
-    ended_at_utc: object | None = None,
-    size: int,
-    weight: ft.FontWeight = ft.FontWeight.W_700,
-    color: str,
-    text_align: ft.TextAlign = ft.TextAlign.LEFT,
-) -> ft.Control:
-    tick, set_tick = ft.use_state(0)
-
-    def _setup():
-        if coerce_datetime(started_at_utc) is None or coerce_datetime(ended_at_utc) is not None:
-            return None
-
-        async def _tick() -> None:
-            while True:
-                await asyncio.sleep(1)
-                set_tick(lambda current: current + 1)
-
-        task = ft.context.page.run_task(_tick)
-
-        def _cleanup() -> None:
-            task.cancel()
-
-        return _cleanup
-
-    ft.use_effect(_setup, dependencies=[started_at_utc, ended_at_utc])
-    _ = tick
-
-    return ft.Text(
-        value=format_session_duration_hms(
-            started_at_utc=started_at_utc,
-            ended_at_utc=ended_at_utc,
-        ),
+    return SessionDurationText(
+        started_at_utc=started_at_utc,
+        ended_at_utc=ended_at_utc,
         size=size,
         weight=weight,
         color=color,
         text_align=text_align,
-        no_wrap=True,
     )
+
+
+@ft.control
+class SessionDurationText(ft.Text):
+    started_at_utc: object | None = None
+    ended_at_utc: object | None = None
+
+    def init(self) -> None:
+        super().init()
+        self.no_wrap = True
+        self._ticker_future: Future[None] | None = None
+        self._ticker_running = False
+        self._display_value = format_session_duration_hms(
+            started_at_utc=self.started_at_utc,
+            ended_at_utc=self.ended_at_utc,
+        )
+        self._apply_display_value()
+
+    def did_mount(self) -> None:
+        super().did_mount()
+        self._sync_ticker()
+
+    def before_update(self) -> None:
+        self.no_wrap = True
+        self._display_value = format_session_duration_hms(
+            started_at_utc=self.started_at_utc,
+            ended_at_utc=self.ended_at_utc,
+        )
+        self._apply_display_value()
+        self._sync_ticker()
+
+    def will_unmount(self) -> None:
+        self._stop_ticker()
+        super().will_unmount()
+
+    def _apply_display_value(self) -> None:
+        self.value = self._display_value
+
+    def _is_live_session(self) -> bool:
+        return (
+            coerce_datetime(self.started_at_utc) is not None
+            and coerce_datetime(self.ended_at_utc) is None
+        )
+
+    def _sync_ticker(self) -> None:
+        if not self._is_attached_to_page() or not self._is_live_session():
+            self._stop_ticker()
+            return
+        if self._ticker_future is not None and not self._ticker_future.done():
+            return
+        self._ticker_running = True
+        self._ticker_future = self.page.run_task(self._run_ticker)
+
+    def _stop_ticker(self) -> None:
+        self._ticker_running = False
+        if self._ticker_future is not None and not self._ticker_future.done():
+            self._ticker_future.cancel()
+        self._ticker_future = None
+
+    async def _run_ticker(self) -> None:
+        try:
+            while self._ticker_running and self._is_live_session():
+                await asyncio.sleep(1)
+                next_value = format_session_duration_hms(
+                    started_at_utc=self.started_at_utc,
+                    ended_at_utc=self.ended_at_utc,
+                )
+                if self._display_value != next_value:
+                    self._display_value = next_value
+                    self._before_update_safe()
+                    self.update()
+        except asyncio.CancelledError:
+            pass
+        except RuntimeError:
+            self._stop_ticker()
+
+    def _is_attached_to_page(self) -> bool:
+        try:
+            self.page
+        except RuntimeError:
+            return False
+        return True

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/status_bar.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/status_bar.py
@@ -78,7 +78,7 @@ def _build_resource_group_box(
     else:
         columns_control = ft.Row(
             spacing=10,
-            vertical_alignment=ft.CrossAxisAlignment.START,
+            vertical_alignment=ft.CrossAxisAlignment.CENTER,
             controls=column_controls,
         )
 
@@ -91,7 +91,8 @@ def _build_resource_group_box(
         label_bgcolor=COLOR_STATUS_LABEL_BG,
         label_border_color=COLOR_STATUS_LABEL_BORDER,
         label_text_color=COLOR_STATUS_LABEL_TEXT,
-        padding=ft.Padding(left=8, top=9, right=8, bottom=4),
+        padding=ft.Padding(left=12, top=14, right=12, bottom=10),
+        # padding=ft.Padding(left=8, top=9, right=8, bottom=4),
     )
 
 
@@ -145,27 +146,29 @@ def _build_active_session_box(data: MainShellViewData) -> ft.Control | None:
         padding=ft.Padding(left=12, top=10, right=12, bottom=10),
         content=ft.Column(
             spacing=2,
+            horizontal_alignment=ft.CrossAxisAlignment.CENTER,
+            alignment=ft.MainAxisAlignment.CENTER,
             controls=[
-                ft.Row(
-                    spacing=8,
-                    vertical_alignment=ft.CrossAxisAlignment.CENTER,
-                    controls=[
-                        ft.Icon(
-                            ft.Icons.TIMER_OUTLINED,
-                            size=20,
-                            color=COLOR_TEXT_PRIMARY,
-                        ),
-                        build_session_duration_text(
-                            started_at_utc=data.active_session_started_at_utc,
-                            size=26,
-                            weight=ft.FontWeight.W_700,
-                            color=COLOR_TEXT_PRIMARY,
-                        ),
-                    ],
+                # ft.Row(
+                #     spacing=4,
+                #     vertical_alignment=ft.CrossAxisAlignment.CENTER,
+                #     controls=[
+                #         ft.Icon(
+                #             ft.Icons.TIMER_OUTLINED,
+                #             size=32,
+                #             color=COLOR_TEXT_PRIMARY,
+                #         ),
+                #     ],
+                # ),
+                build_session_duration_text(
+                    started_at_utc=data.active_session_started_at_utc,
+                    size=32,
+                    weight=ft.FontWeight.W_700,
+                    color=COLOR_TEXT_PRIMARY,
                 ),
                 ft.Text(
                     subtitle,
-                    size=11,
+                    size=12,
                     color=COLOR_TEXT_MUTED,
                     no_wrap=True,
                     overflow=ft.TextOverflow.ELLIPSIS,

--- a/tests/test_main_shell_center_panel.py
+++ b/tests/test_main_shell_center_panel.py
@@ -109,13 +109,21 @@ def _text_values(control: ft.Control) -> list[str]:
     return [item.value for item in _iter_controls(control) if isinstance(item, ft.Text)]
 
 
-def _button_labels(control: ft.Control) -> list[str]:
-    labels: list[str] = []
-    for item in _iter_controls(control):
-        content = getattr(item, "content", None)
-        if isinstance(content, str):
-            labels.append(content)
-    return labels
+def _find_control_by_tooltip(control: ft.Control, tooltip: str) -> ft.Control:
+    matches = _controls_by_tooltip(control, tooltip)
+    if len(matches) != 1:
+        raise AssertionError(
+            f"Se esperaba un control con tooltip={tooltip!r} y se encontraron {len(matches)}."
+        )
+    return matches[0]
+
+
+def _controls_by_tooltip(control: ft.Control, tooltip: str) -> list[ft.Control]:
+    return [
+        item
+        for item in _iter_controls(control)
+        if getattr(item, "tooltip", None) == tooltip
+    ]
 
 
 def _tooltips(control: ft.Control) -> list[str]:
@@ -299,7 +307,7 @@ class MainShellCenterPanelTests(unittest.TestCase):
         self.assertEqual(_tooltips(panel).count("Iniciar sesión"), 1)
         self.assertEqual(_tooltips(panel).count("Detener sesión"), 1)
 
-    def test_sessions_card_keeps_manual_actions_and_new_session_button(self) -> None:
+    def test_sessions_card_uses_icon_tooltips_for_manual_actions(self) -> None:
         state = _build_state(selected_week=1)
         entry = _build_entry(entry_id="entry-1", label="Escenario 1")
         state.entry_panel_state.entries_for_selected_week = [entry]
@@ -308,14 +316,40 @@ class MainShellCenterPanelTests(unittest.TestCase):
         }
 
         panel = build_center_panel(state.build_view_data(), state)
-        labels = _button_labels(panel)
+        tooltips = _tooltips(panel)
         text_values = _text_values(panel)
 
-        self.assertIn("Nueva sesión", labels)
-        self.assertIn("Editar", labels)
-        self.assertIn("Borrar", labels)
+        self.assertIn("Nueva sesión", tooltips)
+        self.assertIn("Editar sesión", tooltips)
+        self.assertIn("Borrar sesión", tooltips)
         self.assertIn("Total jugado", text_values)
         self.assertIn("Sesiones", text_values)
+
+    def test_session_action_icons_are_disabled_while_session_write_is_pending(self) -> None:
+        state = _build_state(selected_week=1)
+        entry = _build_entry(entry_id="entry-1", label="Escenario 1")
+        state.entry_panel_state.entries_for_selected_week = [entry]
+        state.entry_panel_state.sessions_by_entry_ref = {
+            entry.ref: [_build_session(session_id="sess-1", active=False)],
+        }
+        state.entry_panel_state.session_write_pending = True
+        state.entry_panel_state.session_write_pending_by_entry_ref[entry.ref] = True
+
+        panel = build_center_panel(state.build_view_data(), state)
+
+        for tooltip in (
+            "Iniciar sesión",
+            "Nueva sesión",
+            "Editar sesión",
+            "Borrar sesión",
+        ):
+            controls = _controls_by_tooltip(panel, tooltip)
+            self.assertGreaterEqual(
+                len(controls), 1, msg=f"Se esperaba al menos un control con tooltip={tooltip!r}."
+            )
+            for control in controls:
+                self.assertIsInstance(control, ft.IconButton)
+                self.assertTrue(control.disabled, msg=f"{tooltip!r} debería estar deshabilitado.")
 
 
 if __name__ == "__main__":

--- a/tests/test_main_shell_status_bar.py
+++ b/tests/test_main_shell_status_bar.py
@@ -64,7 +64,7 @@ class MainShellStatusBarTests(unittest.TestCase):
 
         self.assertIn("Sesión actual", text_values)
         self.assertIn("Escenario 12 · Semana 6", text_values)
-        self.assertEqual(26, timer_text.size)
+        self.assertEqual(32, timer_text.size)
 
     def test_status_bar_hides_active_session_box_without_active_session(self) -> None:
         state = MainShellState()

--- a/tests/test_session_timing.py
+++ b/tests/test_session_timing.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 from datetime import datetime, timezone
 import unittest
 
+import flet as ft
+
 from tests.main_shell_test_support import install_data_stub
 
 install_data_stub()
 
 from frosthaven_campaign_journal.ui.main_shell.view.session_timing import (
+    SessionDurationText,
     build_active_session_subtitle,
+    build_session_duration_text,
     format_session_duration_hms,
     format_session_summary_date,
     format_session_summary_range,
@@ -72,6 +76,22 @@ class SessionTimingFormattingTests(unittest.TestCase):
             "02:24:31",
             format_session_duration_hms(started_at_utc=started, now=now),
         )
+
+    def test_build_session_duration_text_returns_live_text_control(self) -> None:
+        started = datetime(2026, 2, 9, 21, 41, 0, tzinfo=timezone.utc)
+        ended = datetime(2026, 2, 10, 0, 5, 31, tzinfo=timezone.utc)
+
+        control = build_session_duration_text(
+            started_at_utc=started,
+            ended_at_utc=ended,
+            size=18,
+            color="#ffffff",
+        )
+
+        self.assertIsInstance(control, SessionDurationText)
+        self.assertIsInstance(control, ft.Text)
+        self.assertEqual("02:24:31", control.value)
+        self.assertEqual(18, control.size)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Resumen

- compacta las acciones manuales de sesión en la tarjeta de `Entry` usando iconos con tooltip
- convierte `SessionDurationText` en un control vivo reutilizable para estabilizar el temporizador activo
- ajusta la caja inferior de sesión activa y actualiza los tests de vista/unidad asociados

## Validación

- `$env:PYTHONPATH='src'; pipenv run python -m unittest tests.test_session_timing tests.test_main_shell_center_panel tests.test_main_shell_status_bar`