### PR TITLE
fix: corregir cronómetro vivo de sesión activa

### DIFF
--- a/src/frosthaven_campaign_journal/ui/common/components/labeled_group_box.py
+++ b/src/frosthaven_campaign_journal/ui/common/components/labeled_group_box.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import flet as ft
 
 
-@ft.control
+@ft.control(isolated=True)
 class LabeledGroupBox(ft.Stack):
     label: str = ""
     content: ft.Control | None = None

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/session_timing.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/session_timing.py
@@ -87,7 +87,7 @@ def build_session_duration_text(
     )
 
 
-@ft.control
+@ft.control(isolated=True)
 class SessionDurationText(ft.Text):
     started_at_utc: object | None = None
     ended_at_utc: object | None = None
@@ -119,6 +119,13 @@ class SessionDurationText(ft.Text):
     def will_unmount(self) -> None:
         self._stop_ticker()
         super().will_unmount()
+
+    def _migrate_state(self, other: ft.BaseControl) -> None:
+        super()._migrate_state(other)
+        if isinstance(other, SessionDurationText):
+            other._stop_ticker()
+        self._ticker_future = None
+        self._ticker_running = False
 
     def _apply_display_value(self) -> None:
         self.value = self._display_value
@@ -154,7 +161,7 @@ class SessionDurationText(ft.Text):
                 )
                 if self._display_value != next_value:
                     self._display_value = next_value
-                    self._before_update_safe()
+                    self._apply_display_value()
                     self.update()
         except asyncio.CancelledError:
             pass

--- a/tests/test_labeled_group_box.py
+++ b/tests/test_labeled_group_box.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import unittest
+
+import flet as ft
+
+from frosthaven_campaign_journal.ui.common.components import LabeledGroupBox
+
+
+class LabeledGroupBoxTests(unittest.TestCase):
+    def test_labeled_group_box_is_isolated_and_preserves_content_on_update(self) -> None:
+        content = ft.Text("contenido")
+        box = LabeledGroupBox(
+            label="Caja",
+            content=content,
+            bgcolor="#efefef",
+            border_color="#999999",
+            label_bgcolor="#ffffff",
+            label_border_color="#999999",
+            label_text_color="#111111",
+        )
+
+        self.assertTrue(box.is_isolated())
+        self.assertIs(content, box.controls[0].content)
+
+        box.label = "Caja actualizada"
+        box.before_update()
+
+        self.assertIs(content, box.controls[0].content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_timing.py
+++ b/tests/test_session_timing.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from concurrent.futures import Future
 from datetime import datetime, timezone
 import unittest
+from unittest.mock import Mock, PropertyMock, patch
 
 import flet as ft
 
@@ -92,6 +94,74 @@ class SessionTimingFormattingTests(unittest.TestCase):
         self.assertIsInstance(control, ft.Text)
         self.assertEqual("02:24:31", control.value)
         self.assertEqual(18, control.size)
+        self.assertTrue(control.is_isolated())
+
+
+class SessionTimingTickerTests(unittest.TestCase):
+    def test_live_session_starts_ticker_on_mount(self) -> None:
+        control = SessionDurationText(
+            started_at_utc=datetime(2026, 2, 9, 21, 41, 0, tzinfo=timezone.utc),
+            size=18,
+            color="#ffffff",
+        )
+        page = Mock()
+        ticker_future = Mock(spec=Future)
+        ticker_future.done.return_value = False
+        page.run_task.return_value = ticker_future
+
+        with patch.object(SessionDurationText, "page", new_callable=PropertyMock, return_value=page):
+            control.did_mount()
+
+        page.run_task.assert_called_once()
+        self.assertIs(control._ticker_future, ticker_future)
+        self.assertTrue(control._ticker_running)
+
+    def test_finished_session_does_not_start_ticker_on_mount(self) -> None:
+        control = SessionDurationText(
+            started_at_utc=datetime(2026, 2, 9, 21, 41, 0, tzinfo=timezone.utc),
+            ended_at_utc=datetime(2026, 2, 10, 0, 5, 31, tzinfo=timezone.utc),
+            size=18,
+            color="#ffffff",
+        )
+
+        with patch.object(control, "_is_attached_to_page", return_value=True):
+            control.did_mount()
+
+        self.assertIsNone(control._ticker_future)
+        self.assertFalse(control._ticker_running)
+
+    def test_migrate_state_restarts_ticker_for_live_session(self) -> None:
+        started = datetime(2026, 2, 9, 21, 41, 0, tzinfo=timezone.utc)
+        previous_control = SessionDurationText(
+            started_at_utc=started,
+            size=18,
+            color="#ffffff",
+        )
+        previous_future = Mock(spec=Future)
+        previous_future.done.return_value = False
+        previous_control._ticker_future = previous_future
+        previous_control._ticker_running = True
+
+        migrated_control = SessionDurationText(
+            started_at_utc=started,
+            size=18,
+            color="#ffffff",
+        )
+        page = Mock()
+        new_future = Mock(spec=Future)
+        new_future.done.return_value = False
+        page.run_task.return_value = new_future
+
+        with patch.object(SessionDurationText, "page", new_callable=PropertyMock, return_value=page):
+            migrated_control._migrate_state(previous_control)
+            migrated_control.before_update()
+
+        previous_future.cancel.assert_called_once()
+        page.run_task.assert_called_once()
+        self.assertEqual(previous_control._i, migrated_control._i)
+        self.assertFalse(previous_control._ticker_running)
+        self.assertTrue(migrated_control._ticker_running)
+        self.assertIs(migrated_control._ticker_future, new_future)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Resumen\n- aislar SessionDurationText para que gestione su propio refresco periódico\n- reiniciar el ticker tras la migración del control durante la reconciliación de Flet\n- añadir regresiones para ticker activo, sesión cerrada y recomposición\n\n## Issue\n- Closes #118\n\n## Checklist de calidad\n- [x] Cambio limitado a la unidad del cronómetro\n- [x] Sin tocar layout ni contratos públicos\n- [x] Pruebas ejecutadas: PYTHONPATH=src .venv\\Scripts\\python.exe -m unittest tests.test_session_timing tests.test_main_shell_status_bar\n- [ ] Validación UI web manual