### PR TITLE
feat(main_shell): unificar diálogos modales de main_shell

### DIFF
--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -1268,3 +1268,29 @@
   `scripts/build-android-with-mobile-secrets.ps1`,
   `docs/repo-workflow.md`, `docs/system-map.md`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/114`
+
+### DEC-0056
+
+- `date`: 2026-03-09
+- `status`: accepted
+- `problem`: los formularios de `entry`, notas y sesión seguían ocupando espacio
+  en el visor semanal como bloques `inline`, y la tarjeta de `Entry` no
+  diferenciaba si una entrada ya tenía notas guardadas.
+- `decision`: mover los tres formularios persistentes a un modal declarativo
+  renderizado desde `ui/app_root.py`, mantener un único botón de notas por
+  tarjeta que abre el editor modal para leer/escribir, y señalar presencia de
+  notas con cambio de color del icono (`COLOR_ACCENT_BG` cuando hay contenido,
+  `COLOR_WHITE` cuando no lo hay).
+- `rationale`: libera espacio del visor para lectura/acciones, unifica el patrón
+  de edición persistente sin acoplar estado a `Page`, y permite detectar de un
+  vistazo qué entradas ya contienen notas.
+- `impact`: `center_panel.py` deja de renderizar formularios `inline`;
+  `center_forms.py` pasa a construir el modal activo; `app_root.py` monta la
+  capa modal sobre la shell; y `center_focus.py` ajusta tooltip/color del botón
+  de notas según `Entry.notes`.
+- `references`: `src/frosthaven_campaign_journal/ui/app_root.py`,
+  `src/frosthaven_campaign_journal/ui/main_shell/view/center_panel.py`,
+  `src/frosthaven_campaign_journal/ui/main_shell/view/center_forms.py`,
+  `src/frosthaven_campaign_journal/ui/main_shell/view/center_focus.py`,
+  `docs/ui-main-shell-architecture-mvs.md`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/102`

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -1294,3 +1294,30 @@
   `src/frosthaven_campaign_journal/ui/main_shell/view/center_focus.py`,
   `docs/ui-main-shell-architecture-mvs.md`,
   `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/102`
+
+### DEC-0057
+
+- `date`: 2026-03-09
+- `status`: accepted
+- `problem`: tras mover formularios a modal, seguían coexistiendo dos patrones
+  de diálogo en `main_shell`: confirmaciones nativas con `AlertDialog` y
+  formularios/notas en overlay propio, además de una cabecera con `X` que
+  rompía la consistencia visual y desaprovechaba espacio útil en notas.
+- `decision`: unificar confirmaciones, formularios de `entry`, formularios de
+  sesión y editor de notas bajo un único shell modal declarativo compartido,
+  sin botón `X`, con acciones alineadas abajo a la derecha, estilo único de
+  botones y título opcional según el caso.
+- `rationale`: reduce deuda visual, elimina divergencia entre overlays nativos
+  e internos, y permite que notas use el cuerpo completo del diálogo sin
+  affordances redundantes.
+- `impact`: se añade un componente común de diálogo en
+  `ui/common/components/dialogs.py`; `app_root.py` deja de abrir
+  `AlertDialog`; `MainShellViewData` incorpora `ConfirmationDialogViewState`;
+  `modal_overlay.py` centraliza prioridad/ensamblado del diálogo visible; y
+  `center_forms.py` pasa a construir solo cuerpos declarativos sin shell.
+- `references`: `src/frosthaven_campaign_journal/ui/common/components/dialogs.py`,
+  `src/frosthaven_campaign_journal/ui/app_root.py`,
+  `src/frosthaven_campaign_journal/ui/main_shell/model.py`,
+  `src/frosthaven_campaign_journal/ui/main_shell/view/modal_overlay.py`,
+  `docs/ui-main-shell-architecture-mvs.md`,
+  `https://github.com/KikoNet13/frosthaven-campaign-journal/issues/102`

--- a/docs/ui-main-shell-architecture-mvs.md
+++ b/docs/ui-main-shell-architecture-mvs.md
@@ -4,7 +4,7 @@
 
 - Se mantiene estructura MVS con estado observable único en `MainShellState`.
 - El runtime sigue siendo declarativo con `page.render(build_app_root, page)`.
-- Los formularios de `entry`, notas y sesión continúan inline en el panel central.
+- Los formularios de `entry`, notas y sesión se renderizan como modal declarativo desde el root.
 - Los mensajes informativos pasan a `SnackBar` flotante.
 - Las preguntas de confirmación pasan a `AlertDialog` modal.
 - El bridge a overlays vive solo en `ui/app_root.py`; el estado no se acopla a `Page`.
@@ -26,7 +26,7 @@ src/frosthaven_campaign_journal/ui/
 
 | Archivo | Tipo | Responsabilidad |
 | --- | --- | --- |
-| `ui/app_root.py` | Root bridge | Observa `toast_state` y `confirmation_state`, y abre/cierra `SnackBar` y `AlertDialog`. |
+| `ui/app_root.py` | Root bridge | Observa `toast_state` y `confirmation_state`, renderiza modales de formulario y abre/cierra `SnackBar` y `AlertDialog`. |
 | `ui/main_shell/model.py` | MODEL | Contratos de render declarativos del panel principal. |
 | `ui/main_shell/state/` | STATE | Estado observable, handlers de UI, lecturas y escrituras. |
 | `ui/main_shell/view/` | VIEW | Render puro del shell y binding directo a handlers del estado. |
@@ -34,15 +34,15 @@ src/frosthaven_campaign_journal/ui/
 ## 4) Flujo declarativo actual
 
 1. El root crea estado con `ft.use_state(MainShellState.create)`.
-1. La vista llama `state.build_view_data()` y renderiza solo contenido inline.
+1. El root construye `view_data`, renderiza la shell principal y monta encima el modal activo si existe.
 1. Los handlers `on_*` mutan `local_state`, `read_state`, `entry_panel_state` y estado transitorio de UI.
 1. `toast_state` y `confirmation_state` emiten `event_id` nuevos en cada evento.
-1. `app_root.py` detecta esos `event_id` con `ft.use_effect` + `ft.use_ref` y abre el overlay correspondiente.
+1. `app_root.py` detecta esos `event_id` con `ft.use_effect` + `ft.use_ref` y abre el overlay efímero correspondiente.
 1. El estado sigue siendo la fuente de verdad; el root solo traduce eventos a overlays de Flet.
 
 ## 5) Estado declarativo de UI
 
-### Inline
+### Modales declarativos
 
 - `EntryFormViewState`
 - `EntryNotesEditorViewState`
@@ -62,6 +62,10 @@ El `event_id` evita que dos emisiones sucesivas con el mismo texto o payload se 
   - auto-dismiss
   - icono de cierre
   - margen inferior suficiente para no solapar bottom bar ni FAB
+- Modal de formularios
+  - scrim + panel centrado renderizados desde `ui/app_root.py`
+  - un único modal abierto a la vez
+  - `Cancelar`/`Guardar` siguen viviendo en los handlers del estado
 - `AlertDialog`
   - `modal=True`
   - usa `title`, `body` y `confirm_label` ya definidos en estado
@@ -74,4 +78,5 @@ El `event_id` evita que dos emisiones sucesivas con el mismo texto o payload se 
 1. Estado observable único de pantalla (`MainShellState`).
 1. Ningún mixin de estado conoce `Page` ni abre overlays directamente.
 1. Los banners inline se reservan para `warning` y `error`.
+1. Los formularios persistentes no se renderizan dentro del visor semanal.
 1. Las confirmaciones y mensajes informativos transitorios se resuelven en el root.

--- a/docs/ui-main-shell-architecture-mvs.md
+++ b/docs/ui-main-shell-architecture-mvs.md
@@ -4,9 +4,8 @@
 
 - Se mantiene estructura MVS con estado observable único en `MainShellState`.
 - El runtime sigue siendo declarativo con `page.render(build_app_root, page)`.
-- Los formularios de `entry`, notas y sesión se renderizan como modal declarativo desde el root.
+- Los formularios de `entry`, notas, sesión y confirmaciones comparten un shell modal declarativo desde el root.
 - Los mensajes informativos pasan a `SnackBar` flotante.
-- Las preguntas de confirmación pasan a `AlertDialog` modal.
 - El bridge a overlays vive solo en `ui/app_root.py`; el estado no se acopla a `Page`.
 - No se usa `page.update()` ni `control.update()` en la capa `ui`.
 
@@ -26,7 +25,7 @@ src/frosthaven_campaign_journal/ui/
 
 | Archivo | Tipo | Responsabilidad |
 | --- | --- | --- |
-| `ui/app_root.py` | Root bridge | Observa `toast_state` y `confirmation_state`, renderiza modales de formulario y abre/cierra `SnackBar` y `AlertDialog`. |
+| `ui/app_root.py` | Root bridge | Observa `toast_state`, construye `view_data` y monta `SnackBar` + shell modal compartido sobre la shell principal. |
 | `ui/main_shell/model.py` | MODEL | Contratos de render declarativos del panel principal. |
 | `ui/main_shell/state/` | STATE | Estado observable, handlers de UI, lecturas y escrituras. |
 | `ui/main_shell/view/` | VIEW | Render puro del shell y binding directo a handlers del estado. |
@@ -37,13 +36,14 @@ src/frosthaven_campaign_journal/ui/
 1. El root construye `view_data`, renderiza la shell principal y monta encima el modal activo si existe.
 1. Los handlers `on_*` mutan `local_state`, `read_state`, `entry_panel_state` y estado transitorio de UI.
 1. `toast_state` y `confirmation_state` emiten `event_id` nuevos en cada evento.
-1. `app_root.py` detecta esos `event_id` con `ft.use_effect` + `ft.use_ref` y abre el overlay efímero correspondiente.
-1. El estado sigue siendo la fuente de verdad; el root solo traduce eventos a overlays de Flet.
+1. `app_root.py` usa `ft.use_effect` solo para `SnackBar`; confirmaciones y formularios se traducen a `view_data` y se renderizan de forma declarativa en el shell modal compartido.
+1. El estado sigue siendo la fuente de verdad; el root solo traduce eventos a overlays de Flet cuando el framework lo exige (`SnackBar`).
 
 ## 5) Estado declarativo de UI
 
 ### Modales declarativos
 
+- `ConfirmationDialogViewState`
 - `EntryFormViewState`
 - `EntryNotesEditorViewState`
 - `SessionFormViewState`
@@ -51,7 +51,7 @@ src/frosthaven_campaign_journal/ui/
 ### Overlays transitorios
 
 - `ToastState(message, event_id)`
-- `ConfirmationState(..., event_id)`
+- `ConfirmationState(..., event_id)` como fuente de verdad para producir `ConfirmationDialogViewState`
 
 El `event_id` evita que dos emisiones sucesivas con el mismo texto o payload se pierdan.
 
@@ -62,15 +62,12 @@ El `event_id` evita que dos emisiones sucesivas con el mismo texto o payload se 
   - auto-dismiss
   - icono de cierre
   - margen inferior suficiente para no solapar bottom bar ni FAB
-- Modal de formularios
+- Shell modal compartido
   - scrim + panel centrado renderizados desde `ui/app_root.py`
-  - un único modal abierto a la vez
-  - `Cancelar`/`Guardar` siguen viviendo en los handlers del estado
-- `AlertDialog`
-  - `modal=True`
-  - usa `title`, `body` y `confirm_label` ya definidos en estado
-  - botón de confirmar con la paleta del FAB
-  - botón de cancelar outlined con la misma paleta
+  - un único diálogo visible a la vez con prioridad: confirmación -> entry -> notas -> sesión
+  - sin botón `X`; cierre explícito por acciones
+  - botones outlined/filled compartidos y alineados abajo a la derecha
+  - título opcional: presente en confirmaciones/entry/sesión y omitido en notas
 
 ## 7) Guardrails de arquitectura
 
@@ -79,4 +76,5 @@ El `event_id` evita que dos emisiones sucesivas con el mismo texto o payload se 
 1. Ningún mixin de estado conoce `Page` ni abre overlays directamente.
 1. Los banners inline se reservan para `warning` y `error`.
 1. Los formularios persistentes no se renderizan dentro del visor semanal.
-1. Las confirmaciones y mensajes informativos transitorios se resuelven en el root.
+1. Las confirmaciones y formularios comparten el mismo shell modal declarativo en el root.
+1. Los mensajes informativos transitorios se resuelven en el root mediante `SnackBar`.

--- a/src/frosthaven_campaign_journal/ui/app_root.py
+++ b/src/frosthaven_campaign_journal/ui/app_root.py
@@ -13,6 +13,7 @@ from frosthaven_campaign_journal.ui.common.theme.colors import (
 )
 from frosthaven_campaign_journal.ui.common.theme.layout import BOTTOM_BAR_HEIGHT
 from frosthaven_campaign_journal.ui.main_shell import MainShellState, build_main_shell_view
+from frosthaven_campaign_journal.ui.main_shell.view.center_forms import build_form_modal_overlay
 
 _SNACKBAR_SIDE_MARGIN = 16
 _SNACKBAR_BOTTOM_MARGIN = BOTTOM_BAR_HEIGHT + 24
@@ -149,10 +150,19 @@ def build_app_root(page: ft.Page) -> ft.Control:
 
     ft.use_effect(_sync_confirmation_dialog, dependencies=[shell_state.confirmation_state.event_id])
 
+    data = shell_state.build_view_data()
+    stack_controls: list[ft.Control] = [build_main_shell_view(shell_state, data=data)]
+    modal_overlay = build_form_modal_overlay(data, shell_state)
+    if modal_overlay is not None:
+        stack_controls.append(modal_overlay)
+
     return ft.Container(
         expand=True,
         content=ft.SafeArea(
             expand=True,
-            content=build_main_shell_view(shell_state),
+            content=ft.Stack(
+                expand=True,
+                controls=stack_controls,
+            ),
         ),
     )

--- a/src/frosthaven_campaign_journal/ui/app_root.py
+++ b/src/frosthaven_campaign_journal/ui/app_root.py
@@ -3,37 +3,24 @@ from __future__ import annotations
 import flet as ft
 
 from frosthaven_campaign_journal.ui.common.theme.colors import (
-    COLOR_ACCENT_BG,
     COLOR_BANNER_INFO_BG,
     COLOR_BANNER_INFO_TEXT,
-    COLOR_PANEL_INNER_BG,
-    COLOR_TEXT_HEADING,
-    COLOR_TEXT_PRIMARY,
-    COLOR_WHITE,
 )
 from frosthaven_campaign_journal.ui.common.theme.layout import BOTTOM_BAR_HEIGHT
 from frosthaven_campaign_journal.ui.main_shell import MainShellState, build_main_shell_view
-from frosthaven_campaign_journal.ui.main_shell.view.center_forms import build_form_modal_overlay
+from frosthaven_campaign_journal.ui.main_shell.view.modal_overlay import (
+    build_main_shell_modal_overlay,
+)
 
 _SNACKBAR_SIDE_MARGIN = 16
 _SNACKBAR_BOTTOM_MARGIN = BOTTOM_BAR_HEIGHT + 24
 
 
-def _close_overlay(overlay: ft.AlertDialog | ft.SnackBar | None) -> None:
+def _close_overlay(overlay: ft.SnackBar | None) -> None:
     if overlay is None or not overlay.open:
         return
     overlay.open = False
     overlay.update()
-
-
-def _build_dialog_button_style(*, filled: bool) -> ft.ButtonStyle:
-    return ft.ButtonStyle(
-        bgcolor=COLOR_ACCENT_BG if filled else None,
-        color=COLOR_WHITE if filled else COLOR_ACCENT_BG,
-        side=None if filled else ft.BorderSide(1.25, COLOR_ACCENT_BG),
-        shape=ft.RoundedRectangleBorder(radius=12),
-        padding=ft.Padding(left=16, top=12, right=16, bottom=12),
-    )
 
 
 @ft.component
@@ -41,8 +28,6 @@ def build_app_root(page: ft.Page) -> ft.Control:
     shell_state, _ = ft.use_state(MainShellState.create)
     active_toast = ft.use_ref(None)
     last_toast_event_id = ft.use_ref(None)
-    active_confirmation = ft.use_ref(None)
-    last_confirmation_event_id = ft.use_ref(None)
 
     def _sync_info_toast() -> None:
         toast = shell_state.toast_state
@@ -85,74 +70,9 @@ def build_app_root(page: ft.Page) -> ft.Control:
 
     ft.use_effect(_sync_info_toast, dependencies=[shell_state.toast_state.event_id])
 
-    def _sync_confirmation_dialog() -> None:
-        confirmation = shell_state.confirmation_state
-        if (
-            confirmation.key is None
-            or confirmation.event_id is None
-            or confirmation.event_id == last_confirmation_event_id.current
-        ):
-            return
-
-        last_confirmation_event_id.current = confirmation.event_id
-        _close_overlay(active_confirmation.current)
-        handled = {"value": False}
-
-        def _handle_cancel(_event: ft.ControlEvent | None = None) -> None:
-            handled["value"] = True
-            _close_overlay(dialog)
-            shell_state.on_cancel_pending_action()
-
-        def _handle_confirm(_event: ft.ControlEvent | None = None) -> None:
-            handled["value"] = True
-            _close_overlay(dialog)
-            shell_state.on_confirm_pending_action()
-
-        def _on_dismiss(_event: ft.ControlEvent) -> None:
-            if active_confirmation.current is dialog:
-                active_confirmation.current = None
-            if handled["value"]:
-                return
-            handled["value"] = True
-            if (
-                shell_state.confirmation_state.key == confirmation.key
-                and shell_state.confirmation_state.event_id == confirmation.event_id
-            ):
-                shell_state.on_cancel_pending_action()
-
-        dialog = ft.AlertDialog(
-            modal=True,
-            bgcolor=COLOR_PANEL_INNER_BG,
-            title=ft.Text(
-                confirmation.title,
-                size=18,
-                weight=ft.FontWeight.W_600,
-                color=COLOR_TEXT_HEADING,
-            ),
-            content=ft.Text(confirmation.body, size=14, color=COLOR_TEXT_PRIMARY),
-            actions=[
-                ft.OutlinedButton(
-                    "Cancelar",
-                    style=_build_dialog_button_style(filled=False),
-                    on_click=_handle_cancel,
-                ),
-                ft.FilledButton(
-                    confirmation.confirm_label,
-                    style=_build_dialog_button_style(filled=True),
-                    on_click=_handle_confirm,
-                ),
-            ],
-            actions_alignment=ft.MainAxisAlignment.END,
-            on_dismiss=_on_dismiss,
-        )
-        active_confirmation.current = dialog
-        page.show_dialog(dialog)
-
-    ft.use_effect(_sync_confirmation_dialog, dependencies=[shell_state.confirmation_state.event_id])
-
     data = shell_state.build_view_data()
     stack_controls: list[ft.Control] = [build_main_shell_view(shell_state, data=data)]
-    modal_overlay = build_form_modal_overlay(data, shell_state)
+    modal_overlay = build_main_shell_modal_overlay(data, shell_state)
     if modal_overlay is not None:
         stack_controls.append(modal_overlay)
 

--- a/src/frosthaven_campaign_journal/ui/common/components/__init__.py
+++ b/src/frosthaven_campaign_journal/ui/common/components/__init__.py
@@ -1,10 +1,13 @@
+from .dialogs import build_dialog_button_style, build_modal_dialog_shell
 from .labeled_group_box import LabeledGroupBox
 from .surfaces import BannerTone, build_banner, build_inner_surface, build_panel
 
 __all__ = [
     "BannerTone",
     "LabeledGroupBox",
+    "build_dialog_button_style",
     "build_banner",
     "build_inner_surface",
+    "build_modal_dialog_shell",
     "build_panel",
 ]

--- a/src/frosthaven_campaign_journal/ui/common/components/dialogs.py
+++ b/src/frosthaven_campaign_journal/ui/common/components/dialogs.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import flet as ft
+
+from frosthaven_campaign_journal.ui.common.theme.colors import (
+    COLOR_ACCENT_BG,
+    COLOR_PANEL_BG,
+    COLOR_PANEL_BORDER,
+    COLOR_TEXT_HEADING,
+    COLOR_WHITE,
+)
+
+_MODAL_WIDTH = 560
+_MODAL_BACKDROP = ft.Colors.with_opacity(0.42, ft.Colors.BLACK)
+
+
+def build_dialog_button_style(*, filled: bool) -> ft.ButtonStyle:
+    return ft.ButtonStyle(
+        bgcolor=COLOR_ACCENT_BG if filled else None,
+        color=COLOR_WHITE if filled else COLOR_ACCENT_BG,
+        side=None if filled else ft.BorderSide(1.25, COLOR_ACCENT_BG),
+        shape=ft.RoundedRectangleBorder(radius=12),
+        padding=ft.Padding(left=16, top=12, right=16, bottom=12),
+    )
+
+
+def build_modal_dialog_shell(
+    *,
+    body: ft.Control,
+    actions: Sequence[ft.Control],
+    title: str | None = None,
+    width: int = _MODAL_WIDTH,
+    height: int | None = None,
+    body_expand: bool = False,
+) -> ft.Control:
+    controls: list[ft.Control] = []
+    if title:
+        controls.append(
+            ft.Text(
+                title,
+                size=18,
+                weight=ft.FontWeight.W_600,
+                color=COLOR_TEXT_HEADING,
+            )
+        )
+    controls.append(ft.Container(expand=body_expand, content=body))
+    if actions:
+        controls.append(
+            ft.Row(
+                alignment=ft.MainAxisAlignment.END,
+                spacing=8,
+                controls=list(actions),
+            )
+        )
+
+    return ft.Container(
+        expand=True,
+        bgcolor=_MODAL_BACKDROP,
+        alignment=ft.Alignment.CENTER,
+        padding=ft.Padding.all(24),
+        content=ft.Container(
+            width=width,
+            height=height,
+            padding=ft.Padding.all(16),
+            bgcolor=COLOR_PANEL_BG,
+            border_radius=12,
+            border=ft.Border.all(1, COLOR_PANEL_BORDER),
+            content=ft.Column(
+                expand=body_expand,
+                spacing=12,
+                controls=controls,
+            ),
+        ),
+    )

--- a/src/frosthaven_campaign_journal/ui/main_shell/model.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/model.py
@@ -59,9 +59,18 @@ class MainShellViewData:
     read_error_message: str | None
     read_warning_message: str | None
     env_name: str
+    confirmation_dialog: "ConfirmationDialogViewState | None"
     entry_form: "EntryFormViewState | None"
     entry_notes_editor: "EntryNotesEditorViewState | None"
     session_form: "SessionFormViewState | None"
+
+
+@dataclass(frozen=True)
+class ConfirmationDialogViewState:
+    key: str
+    title: str
+    body: str
+    confirm_label: str
 
 
 @dataclass(frozen=True)

--- a/src/frosthaven_campaign_journal/ui/main_shell/state/navigation.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/state/navigation.py
@@ -37,7 +37,7 @@ class MainShellNavigationMixin:
             self.entry_panel_state.viewer_sessions_error_message = None
             self.entry_panel_state.sessions_by_entry_ref = {}
             self.entry_panel_state.sessions_error_by_entry_ref = {}
-            self.entry_notes_editor_state = None
+            self._clear_form_modal_states()
             self._clear_resource_draft_state()
             self._refresh_and_reload(
                 selected_year_override=self.local_state.selected_year,
@@ -67,7 +67,7 @@ class MainShellNavigationMixin:
             self.entry_panel_state.viewer_sessions_error_message = None
             self.entry_panel_state.sessions_by_entry_ref = {}
             self.entry_panel_state.sessions_error_by_entry_ref = {}
-            self.entry_notes_editor_state = None
+            self._clear_form_modal_states()
             self._clear_resource_draft_state()
             self._refresh_and_reload(
                 selected_year_override=self.local_state.selected_year,
@@ -98,7 +98,7 @@ class MainShellNavigationMixin:
             self.entry_panel_state.viewer_entry_snapshot = None
             self.entry_panel_state.viewer_sessions = []
             self.entry_panel_state.viewer_sessions_error_message = None
-            self.entry_notes_editor_state = None
+            self._clear_form_modal_states()
             self._clear_resource_draft_state()
             self._load_entries_for_selected_week()
 
@@ -113,7 +113,7 @@ class MainShellNavigationMixin:
         def _action() -> None:
             self.local_state.viewer_entry_ref = entry_ref
             self._clear_write_errors()
-            self.entry_notes_editor_state = None
+            self._clear_form_modal_states()
             self._load_viewer_entry_and_sessions()
 
         self._run_or_confirm_resource_draft_before_context_change(_action, action_label="cambiar de entrada")
@@ -173,7 +173,7 @@ class MainShellNavigationMixin:
                 self.entry_panel_state.viewer_sessions_error_message = None
                 self.entry_panel_state.sessions_by_entry_ref = {}
                 self.entry_panel_state.sessions_error_by_entry_ref = {}
-                self.entry_notes_editor_state = None
+                self._clear_form_modal_states()
                 self._clear_resource_draft_state()
                 self._refresh_and_reload(
                     selected_year_override=result.new_year_number,

--- a/src/frosthaven_campaign_journal/ui/main_shell/state/runtime_read.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/state/runtime_read.py
@@ -77,7 +77,7 @@ class MainShellRuntimeReadMixin:
             self.entry_panel_state.viewer_sessions_error_message = None
             self.entry_panel_state.sessions_by_entry_ref = {}
             self.entry_panel_state.sessions_error_by_entry_ref = {}
-            self.entry_notes_editor_state = None
+            self._clear_form_modal_states()
             self._clear_resource_draft_state()
 
         if snapshot.active_entry is None:

--- a/src/frosthaven_campaign_journal/ui/main_shell/state/runtime_support.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/state/runtime_support.py
@@ -10,6 +10,11 @@ from frosthaven_campaign_journal.ui.main_shell.state.types import ToastState
 
 
 class MainShellRuntimeSupportMixin:
+    def _clear_form_modal_states(self) -> None:
+        self.entry_form_state = None
+        self.entry_notes_editor_state = None
+        self.session_form_state = None
+
     def _normalize_resource_draft_values(self, raw_map: dict[str, int] | None) -> dict[str, int]:
         if not isinstance(raw_map, dict):
             return {}

--- a/src/frosthaven_campaign_journal/ui/main_shell/state/runtime_write.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/state/runtime_write.py
@@ -234,11 +234,7 @@ class MainShellRuntimeWriteMixin:
         reload_q5 = entry_ref_matches_selected_week(self.local_state, entry_ref)
 
         def _clear_after_delete(_result: EntryWriteResult) -> None:
-            if (
-                self.entry_notes_editor_state is not None
-                and self.entry_notes_editor_state.entry_ref == entry_ref
-            ):
-                self.entry_notes_editor_state = None
+            self._clear_form_modal_states()
             self.entry_panel_state.viewer_entry_snapshot = None
             self.entry_panel_state.viewer_sessions = []
             self.entry_panel_state.viewer_sessions_error_message = None

--- a/src/frosthaven_campaign_journal/ui/main_shell/state/sessions.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/state/sessions.py
@@ -68,6 +68,7 @@ class MainShellSessionActionsMixin:
 
     def on_open_manual_create_session_for_entry(self, entry_ref: EntryRef) -> None:
         now_date, now_time = to_local_strings(datetime.now(timezone.utc))
+        self._clear_form_modal_states()
         self.session_form_state = SessionFormState(
             mode="create",
             entry_ref=entry_ref,
@@ -125,6 +126,7 @@ class MainShellSessionActionsMixin:
         started_date, started_time = to_local_strings(started_at_utc)
         ended_date, ended_time = to_local_strings(ended_at_utc)
         is_active = ended_at_utc is None
+        self._clear_form_modal_states()
         self.session_form_state = SessionFormState(
             mode="edit",
             entry_ref=entry_ref,

--- a/src/frosthaven_campaign_journal/ui/main_shell/state/view_data.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/state/view_data.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 
 from frosthaven_campaign_journal.models import EntryRef, EntrySummary, ViewerSessionItem
 from frosthaven_campaign_journal.ui.main_shell.model import (
+    ConfirmationDialogViewState,
     EntryFormViewState,
     EntryNotesEditorViewState,
     MainShellViewData,
@@ -14,6 +15,14 @@ from frosthaven_campaign_journal.ui.main_shell.model import (
 
 class MainShellViewDataMixin:
     def build_view_data(self) -> MainShellViewData:
+        confirmation_view: ConfirmationDialogViewState | None = None
+        if self.confirmation_state.key is not None:
+            confirmation_view = ConfirmationDialogViewState(
+                key=self.confirmation_state.key,
+                title=self.confirmation_state.title,
+                body=self.confirmation_state.body,
+                confirm_label=self.confirmation_state.confirm_label,
+            )
         entry_form_view: EntryFormViewState | None = None
         if self.entry_form_state is not None:
             entry_form_view = EntryFormViewState(
@@ -97,6 +106,7 @@ class MainShellViewDataMixin:
             read_error_message=self.read_state.error_message,
             read_warning_message=self.read_state.warning_message,
             env_name=self.env_name,
+            confirmation_dialog=confirmation_view,
             entry_form=entry_form_view,
             entry_notes_editor=entry_notes_view,
             session_form=session_form_view,

--- a/src/frosthaven_campaign_journal/ui/main_shell/state/week_entry_resources.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/state/week_entry_resources.py
@@ -74,6 +74,7 @@ class MainShellWeekEntryResourceActionsMixin:
             self._set_entry_error("No hay semana seleccionada para crear una entrada.")
             self.notify()
             return
+        self._clear_form_modal_states()
         self.entry_form_state = EntryFormState(
             mode="create",
             entry_type="scenario",
@@ -97,6 +98,7 @@ class MainShellWeekEntryResourceActionsMixin:
             self.notify()
             return
         self.local_state.viewer_entry_ref = entry_ref
+        self._clear_form_modal_states()
         self.entry_form_state = EntryFormState(
             mode="edit",
             entry_type=selected_entry.entry_type,
@@ -282,6 +284,7 @@ class MainShellWeekEntryResourceActionsMixin:
             self.notify()
             return
         self.local_state.viewer_entry_ref = entry_ref
+        self._clear_form_modal_states()
         self.entry_notes_editor_state = EntryNotesEditorState(
             entry_ref=entry_ref,
             entry_label=selected_entry.label,

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/center_focus.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/center_focus.py
@@ -16,6 +16,7 @@ from frosthaven_campaign_journal.ui.common.resources import (
     iter_resource_ui_groups,
 )
 from frosthaven_campaign_journal.ui.common.theme.colors import (
+    COLOR_ACCENT_BG,
     COLOR_BOTTOM_BAR_BG,
     COLOR_DESTRUCTIVE_ICON,
     COLOR_DEFEAT_ICON,
@@ -182,6 +183,7 @@ def _build_entry_card_header(
 ) -> ft.Control:
     entry = card.entry
     outcome_icon = _build_entry_outcome_icon(entry)
+    entry_has_notes = _entry_has_notes(entry)
     title_controls: list[ft.Control] = [
         ft.Text(entry.label, size=18, weight=ft.FontWeight.BOLD, color=COLOR_WHITE)
     ]
@@ -205,8 +207,8 @@ def _build_entry_card_header(
         ft.IconButton(
             icon=ft.Icons.EDIT_NOTE,
             icon_size=18,
-            icon_color=COLOR_WHITE,
-            tooltip="Editar notas",
+            icon_color=(COLOR_ACCENT_BG if entry_has_notes else COLOR_WHITE),
+            tooltip=("Ver o editar notas" if entry_has_notes else "Añadir notas"),
             data=entry.ref,
             on_click=state.on_open_entry_notes_editor_click,
             disabled=card.entry_write_pending,
@@ -651,3 +653,7 @@ def _build_entry_card_status_texts(
     return _EntryCardStatusTexts(
         sessions_status=sessions_status,
     )
+
+
+def _entry_has_notes(entry: EntrySummary) -> bool:
+    return isinstance(entry.notes, str) and entry.notes.strip() != ""

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/center_forms.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/center_forms.py
@@ -2,202 +2,100 @@ from __future__ import annotations
 
 import flet as ft
 
-from frosthaven_campaign_journal.ui.common.components.surfaces import build_panel
-from frosthaven_campaign_journal.ui.common.theme.colors import (
-    COLOR_ACCENT_BG,
-    COLOR_ERROR_TEXT,
-    COLOR_TEXT_HEADING,
-    COLOR_WHITE,
-)
+from frosthaven_campaign_journal.ui.common.theme.colors import COLOR_ERROR_TEXT
 from frosthaven_campaign_journal.ui.main_shell.model import MainShellViewData
 from frosthaven_campaign_journal.ui.main_shell.state import MainShellState
 
-_MODAL_WIDTH = 560
-_MODAL_BACKDROP = ft.Colors.with_opacity(0.42, ft.Colors.BLACK)
 
-
-def _build_entry_form_editor(data: MainShellViewData, state: MainShellState) -> ft.Control:
+def build_entry_form_dialog_body(data: MainShellViewData, state: MainShellState) -> ft.Control:
     assert data.entry_form is not None
     is_scenario = data.entry_form.entry_type == "scenario"
-    return build_panel(
-        controls=[
-            ft.Text(
-                "Crear entrada" if data.entry_form.mode == "create" else "Editar entrada",
-                size=14,
-                weight=ft.FontWeight.BOLD,
-                color=COLOR_TEXT_HEADING,
-            ),
-            ft.Dropdown(
-                value=data.entry_form.entry_type,
-                options=[
-                    ft.dropdown.Option(key="scenario", text="Escenario"),
-                    ft.dropdown.Option(key="outpost", text="Puesto fronterizo"),
-                ],
-                on_select=state.on_entry_form_set_type,
-            ),
-            ft.TextField(
-                label="Referencia de escenario",
-                value=data.entry_form.scenario_ref_text,
-                on_change=state.on_entry_form_set_scenario_ref,
-                disabled=not is_scenario,
-                hint_text="Entero positivo" if is_scenario else "No aplica para puesto avanzado",
-            ),
-            ft.Row(
-                spacing=8,
-                controls=[
-                    ft.TextButton("Cancelar", on_click=state.on_cancel_entry_form),
-                    ft.FilledButton("Guardar", on_click=state.on_submit_entry_form),
-                ],
-            ),
-            ft.Text(data.entry_form.error_message or "", size=12, color=COLOR_ERROR_TEXT),
-        ],
-    )
-
-
-def _build_entry_notes_editor(data: MainShellViewData, state: MainShellState) -> ft.Control:
-    assert data.entry_notes_editor is not None
-    return build_panel(
-        controls=[
-            ft.Text(
-                f"Editar notas de entry: {data.entry_notes_editor.entry_label}",
-                size=14,
-                weight=ft.FontWeight.BOLD,
-                color=COLOR_TEXT_HEADING,
-            ),
-            ft.TextField(
-                value=data.entry_notes_editor.notes_value,
-                multiline=True,
-                min_lines=3,
-                max_lines=6,
-                on_change=state.on_entry_notes_change,
-            ),
-            ft.Row(
-                spacing=8,
-                controls=[
-                    ft.TextButton("Cancelar", on_click=state.on_cancel_entry_notes_editor),
-                    ft.FilledButton("Guardar notas", on_click=state.on_submit_entry_notes),
-                ],
-            ),
-            ft.Text(data.entry_notes_editor.error_message or "", size=12, color=COLOR_ERROR_TEXT),
-        ],
-    )
-
-
-def _build_session_form_editor(data: MainShellViewData, state: MainShellState) -> ft.Control:
-    assert data.session_form is not None
-    return build_panel(
-        controls=[
-            ft.Text(
-                "Crear sesión manual" if data.session_form.mode == "create" else "Editar sesión",
-                size=14,
-                weight=ft.FontWeight.BOLD,
-                color=COLOR_TEXT_HEADING,
-            ),
-            ft.Row(
-                spacing=8,
-                controls=[
-                    ft.TextField(
-                        label="Inicio (fecha)",
-                        hint_text="YYYY-MM-DD",
-                        value=data.session_form.started_date_local,
-                        on_change=state.on_session_form_set_started_date,
-                        width=180,
-                    ),
-                    ft.TextField(
-                        label="Inicio (hora)",
-                        hint_text="HH:MM",
-                        value=data.session_form.started_time_local,
-                        on_change=state.on_session_form_set_started_time,
-                        width=140,
-                    ),
-                ],
-            ),
-            ft.Row(
-                spacing=8,
-                controls=[
-                    ft.TextField(
-                        label="Fin (fecha)",
-                        hint_text="YYYY-MM-DD",
-                        value=data.session_form.ended_date_local,
-                        on_change=state.on_session_form_set_ended_date,
-                        width=180,
-                        disabled=data.session_form.active_without_end,
-                    ),
-                    ft.TextField(
-                        label="Fin (hora)",
-                        hint_text="HH:MM",
-                        value=data.session_form.ended_time_local,
-                        on_change=state.on_session_form_set_ended_time,
-                        width=140,
-                        disabled=data.session_form.active_without_end,
-                    ),
-                ],
-            ),
-            ft.Checkbox(
-                label="Sesión activa (sin fin)",
-                value=data.session_form.active_without_end,
-                on_change=state.on_session_form_toggle_active,
-            ),
-            ft.Row(
-                spacing=8,
-                controls=[
-                    ft.TextButton("Cancelar", on_click=state.on_cancel_session_form),
-                    ft.FilledButton("Guardar", on_click=state.on_submit_session_form),
-                ],
-            ),
-            ft.Text(data.session_form.error_message or "", size=12, color=COLOR_ERROR_TEXT),
-        ],
-    )
-
-
-def build_form_modal_overlay(data: MainShellViewData, state: MainShellState) -> ft.Control | None:
-    if data.entry_form is not None:
-        return _build_modal_overlay(
-            content=_build_entry_form_editor(data, state),
-            on_close=state.on_cancel_entry_form,
-        )
-    if data.entry_notes_editor is not None:
-        return _build_modal_overlay(
-            content=_build_entry_notes_editor(data, state),
-            on_close=state.on_cancel_entry_notes_editor,
-        )
-    if data.session_form is not None:
-        return _build_modal_overlay(
-            content=_build_session_form_editor(data, state),
-            on_close=state.on_cancel_session_form,
-        )
-    return None
-
-
-def _build_modal_overlay(*, content: ft.Control, on_close) -> ft.Control:
-    return ft.Container(
-        expand=True,
-        bgcolor=_MODAL_BACKDROP,
-        alignment=ft.Alignment.CENTER,
-        padding=ft.Padding(left=24, top=24, right=24, bottom=24),
-        content=ft.Container(
-            width=_MODAL_WIDTH,
-            content=ft.Column(
-                tight=True,
-                spacing=8,
-                controls=[
-                    ft.Row(
-                        alignment=ft.MainAxisAlignment.END,
-                        controls=[
-                            ft.IconButton(
-                                icon=ft.Icons.CLOSE,
-                                icon_color=COLOR_WHITE,
-                                tooltip="Cerrar diálogo",
-                                style=ft.ButtonStyle(
-                                    bgcolor=COLOR_ACCENT_BG,
-                                    shape=ft.RoundedRectangleBorder(radius=12),
-                                ),
-                                on_click=on_close,
-                            )
-                        ],
-                    ),
-                    content,
-                ],
-            ),
+    controls: list[ft.Control] = [
+        ft.Dropdown(
+            value=data.entry_form.entry_type,
+            options=[
+                ft.dropdown.Option(key="scenario", text="Escenario"),
+                ft.dropdown.Option(key="outpost", text="Puesto fronterizo"),
+            ],
+            on_select=state.on_entry_form_set_type,
         ),
-    )
+        ft.TextField(
+            label="Referencia de escenario",
+            value=data.entry_form.scenario_ref_text,
+            on_change=state.on_entry_form_set_scenario_ref,
+            disabled=not is_scenario,
+            hint_text="Entero positivo" if is_scenario else "No aplica para puesto avanzado",
+        ),
+    ]
+    if data.entry_form.error_message:
+        controls.append(ft.Text(data.entry_form.error_message, size=12, color=COLOR_ERROR_TEXT))
+    return ft.Column(spacing=12, tight=True, controls=controls)
+
+
+def build_entry_notes_dialog_body(data: MainShellViewData, state: MainShellState) -> ft.Control:
+    assert data.entry_notes_editor is not None
+    controls: list[ft.Control] = [
+        ft.TextField(
+            value=data.entry_notes_editor.notes_value,
+            multiline=True,
+            expand=True,
+            on_change=state.on_entry_notes_change,
+        )
+    ]
+    if data.entry_notes_editor.error_message:
+        controls.append(ft.Text(data.entry_notes_editor.error_message, size=12, color=COLOR_ERROR_TEXT))
+    return ft.Column(expand=True, spacing=12, controls=controls)
+
+
+def build_session_form_dialog_body(data: MainShellViewData, state: MainShellState) -> ft.Control:
+    assert data.session_form is not None
+    controls: list[ft.Control] = [
+        ft.Row(
+            spacing=8,
+            controls=[
+                ft.TextField(
+                    label="Inicio (fecha)",
+                    hint_text="YYYY-MM-DD",
+                    value=data.session_form.started_date_local,
+                    on_change=state.on_session_form_set_started_date,
+                    width=180,
+                ),
+                ft.TextField(
+                    label="Inicio (hora)",
+                    hint_text="HH:MM",
+                    value=data.session_form.started_time_local,
+                    on_change=state.on_session_form_set_started_time,
+                    width=140,
+                ),
+            ],
+        ),
+        ft.Row(
+            spacing=8,
+            controls=[
+                ft.TextField(
+                    label="Fin (fecha)",
+                    hint_text="YYYY-MM-DD",
+                    value=data.session_form.ended_date_local,
+                    on_change=state.on_session_form_set_ended_date,
+                    width=180,
+                    disabled=data.session_form.active_without_end,
+                ),
+                ft.TextField(
+                    label="Fin (hora)",
+                    hint_text="HH:MM",
+                    value=data.session_form.ended_time_local,
+                    on_change=state.on_session_form_set_ended_time,
+                    width=140,
+                    disabled=data.session_form.active_without_end,
+                ),
+            ],
+        ),
+        ft.Checkbox(
+            label="Sesión activa (sin fin)",
+            value=data.session_form.active_without_end,
+            on_change=state.on_session_form_toggle_active,
+        ),
+    ]
+    if data.session_form.error_message:
+        controls.append(ft.Text(data.session_form.error_message, size=12, color=COLOR_ERROR_TEXT))
+    return ft.Column(spacing=12, tight=True, controls=controls)

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/center_forms.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/center_forms.py
@@ -38,19 +38,27 @@ def build_entry_notes_dialog_body(
 ) -> ft.Control:
     assert data.entry_notes_editor is not None
     controls: list[ft.Control] = [
-        ft.Container(
+        ft.Row(
             expand=True,
-            content=ft.TextField(
-                value=data.entry_notes_editor.notes_value,
-                multiline=True,
-                fit_parent_size=True,
-                on_change=state.on_entry_notes_change,
-            ),
+            controls=[
+                ft.TextField(
+                    value=data.entry_notes_editor.notes_value,
+                    multiline=True,
+                    fit_parent_size=True,
+                    expand=True,
+                    on_change=state.on_entry_notes_change,
+                )
+            ],
         )
     ]
     if data.entry_notes_editor.error_message:
         controls.append(ft.Text(data.entry_notes_editor.error_message, size=12, color=COLOR_ERROR_TEXT))
-    return ft.Column(expand=True, spacing=12, controls=controls)
+    return ft.Column(
+        expand=True,
+        spacing=12,
+        horizontal_alignment=ft.CrossAxisAlignment.STRETCH,
+        controls=controls,
+    )
 
 
 def build_session_form_dialog_body(data: MainShellViewData, state: MainShellState) -> ft.Control:

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/center_forms.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/center_forms.py
@@ -4,11 +4,16 @@ import flet as ft
 
 from frosthaven_campaign_journal.ui.common.components.surfaces import build_panel
 from frosthaven_campaign_journal.ui.common.theme.colors import (
+    COLOR_ACCENT_BG,
     COLOR_ERROR_TEXT,
     COLOR_TEXT_HEADING,
+    COLOR_WHITE,
 )
 from frosthaven_campaign_journal.ui.main_shell.model import MainShellViewData
 from frosthaven_campaign_journal.ui.main_shell.state import MainShellState
+
+_MODAL_WIDTH = 560
+_MODAL_BACKDROP = ft.Colors.with_opacity(0.42, ft.Colors.BLACK)
 
 
 def _build_entry_form_editor(data: MainShellViewData, state: MainShellState) -> ft.Control:
@@ -28,7 +33,7 @@ def _build_entry_form_editor(data: MainShellViewData, state: MainShellState) -> 
                     ft.dropdown.Option(key="scenario", text="Escenario"),
                     ft.dropdown.Option(key="outpost", text="Puesto fronterizo"),
                 ],
-                on_change=state.on_entry_form_set_type,
+                on_select=state.on_entry_form_set_type,
             ),
             ft.TextField(
                 label="Referencia de escenario",
@@ -142,4 +147,57 @@ def _build_session_form_editor(data: MainShellViewData, state: MainShellState) -
             ),
             ft.Text(data.session_form.error_message or "", size=12, color=COLOR_ERROR_TEXT),
         ],
+    )
+
+
+def build_form_modal_overlay(data: MainShellViewData, state: MainShellState) -> ft.Control | None:
+    if data.entry_form is not None:
+        return _build_modal_overlay(
+            content=_build_entry_form_editor(data, state),
+            on_close=state.on_cancel_entry_form,
+        )
+    if data.entry_notes_editor is not None:
+        return _build_modal_overlay(
+            content=_build_entry_notes_editor(data, state),
+            on_close=state.on_cancel_entry_notes_editor,
+        )
+    if data.session_form is not None:
+        return _build_modal_overlay(
+            content=_build_session_form_editor(data, state),
+            on_close=state.on_cancel_session_form,
+        )
+    return None
+
+
+def _build_modal_overlay(*, content: ft.Control, on_close) -> ft.Control:
+    return ft.Container(
+        expand=True,
+        bgcolor=_MODAL_BACKDROP,
+        alignment=ft.Alignment.CENTER,
+        padding=ft.Padding(left=24, top=24, right=24, bottom=24),
+        content=ft.Container(
+            width=_MODAL_WIDTH,
+            content=ft.Column(
+                tight=True,
+                spacing=8,
+                controls=[
+                    ft.Row(
+                        alignment=ft.MainAxisAlignment.END,
+                        controls=[
+                            ft.IconButton(
+                                icon=ft.Icons.CLOSE,
+                                icon_color=COLOR_WHITE,
+                                tooltip="Cerrar diálogo",
+                                style=ft.ButtonStyle(
+                                    bgcolor=COLOR_ACCENT_BG,
+                                    shape=ft.RoundedRectangleBorder(radius=12),
+                                ),
+                                on_click=on_close,
+                            )
+                        ],
+                    ),
+                    content,
+                ],
+            ),
+        ),
     )

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/center_forms.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/center_forms.py
@@ -6,8 +6,6 @@ from frosthaven_campaign_journal.ui.common.theme.colors import COLOR_ERROR_TEXT
 from frosthaven_campaign_journal.ui.main_shell.model import MainShellViewData
 from frosthaven_campaign_journal.ui.main_shell.state import MainShellState
 
-_NOTES_TEXT_FIELD_HEIGHT = 220
-
 
 def build_entry_form_dialog_body(data: MainShellViewData, state: MainShellState) -> ft.Control:
     assert data.entry_form is not None
@@ -37,18 +35,17 @@ def build_entry_form_dialog_body(data: MainShellViewData, state: MainShellState)
 def build_entry_notes_dialog_body(
     data: MainShellViewData,
     state: MainShellState,
-    *,
-    text_field_height: int = _NOTES_TEXT_FIELD_HEIGHT,
 ) -> ft.Control:
     assert data.entry_notes_editor is not None
     controls: list[ft.Control] = [
-        ft.TextField(
-            value=data.entry_notes_editor.notes_value,
-            multiline=True,
-            min_lines=1,
-            max_lines=None,
-            height=text_field_height,
-            on_change=state.on_entry_notes_change,
+        ft.Container(
+            expand=True,
+            content=ft.TextField(
+                value=data.entry_notes_editor.notes_value,
+                multiline=True,
+                fit_parent_size=True,
+                on_change=state.on_entry_notes_change,
+            ),
         )
     ]
     if data.entry_notes_editor.error_message:

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/center_forms.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/center_forms.py
@@ -6,6 +6,8 @@ from frosthaven_campaign_journal.ui.common.theme.colors import COLOR_ERROR_TEXT
 from frosthaven_campaign_journal.ui.main_shell.model import MainShellViewData
 from frosthaven_campaign_journal.ui.main_shell.state import MainShellState
 
+_NOTES_TEXT_FIELD_HEIGHT = 220
+
 
 def build_entry_form_dialog_body(data: MainShellViewData, state: MainShellState) -> ft.Control:
     assert data.entry_form is not None
@@ -32,13 +34,20 @@ def build_entry_form_dialog_body(data: MainShellViewData, state: MainShellState)
     return ft.Column(spacing=12, tight=True, controls=controls)
 
 
-def build_entry_notes_dialog_body(data: MainShellViewData, state: MainShellState) -> ft.Control:
+def build_entry_notes_dialog_body(
+    data: MainShellViewData,
+    state: MainShellState,
+    *,
+    text_field_height: int = _NOTES_TEXT_FIELD_HEIGHT,
+) -> ft.Control:
     assert data.entry_notes_editor is not None
     controls: list[ft.Control] = [
         ft.TextField(
             value=data.entry_notes_editor.notes_value,
             multiline=True,
-            expand=True,
+            min_lines=1,
+            max_lines=None,
+            height=text_field_height,
             on_change=state.on_entry_notes_change,
         )
     ]

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/center_panel.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/center_panel.py
@@ -10,11 +10,6 @@ from frosthaven_campaign_journal.ui.main_shell.view.center_focus import (
     _build_focus_empty_mode,
     _build_focus_week_mode,
 )
-from frosthaven_campaign_journal.ui.main_shell.view.center_forms import (
-    _build_entry_form_editor,
-    _build_entry_notes_editor,
-    _build_session_form_editor,
-)
 from frosthaven_campaign_journal.ui.main_shell.view.center_helpers import _find_selected_week
 
 
@@ -29,13 +24,6 @@ def build_center_panel(data: MainShellViewData, state: MainShellState) -> ft.Con
         top_controls.append(build_banner(title="Error de semana", body=data.week_write_error_message, tone=BannerTone.ERROR))
     if data.entry_write_error_message:
         top_controls.append(build_banner(title="Error de entrada", body=data.entry_write_error_message, tone=BannerTone.ERROR))
-
-    if data.entry_form is not None:
-        top_controls.append(_build_entry_form_editor(data, state))
-    if data.entry_notes_editor is not None:
-        top_controls.append(_build_entry_notes_editor(data, state))
-    if data.session_form is not None:
-        top_controls.append(_build_session_form_editor(data, state))
 
     selected_week = _find_selected_week(data)
     focus_control = (

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/modal_overlay.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/modal_overlay.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import flet as ft
+
+from frosthaven_campaign_journal.ui.common.components.dialogs import (
+    build_dialog_button_style,
+    build_modal_dialog_shell,
+)
+from frosthaven_campaign_journal.ui.common.theme.colors import COLOR_TEXT_PRIMARY
+from frosthaven_campaign_journal.ui.main_shell.model import MainShellViewData
+from frosthaven_campaign_journal.ui.main_shell.state import MainShellState
+from frosthaven_campaign_journal.ui.main_shell.view.center_forms import (
+    build_entry_form_dialog_body,
+    build_entry_notes_dialog_body,
+    build_session_form_dialog_body,
+)
+
+_NOTES_DIALOG_HEIGHT = 320
+
+
+@dataclass
+class _DialogDefinition:
+    body: ft.Control
+    actions: list[ft.Control]
+    title: str | None = None
+    height: int | None = None
+    body_expand: bool = False
+
+
+def build_main_shell_modal_overlay(data: MainShellViewData, state: MainShellState) -> ft.Control | None:
+    dialog = _build_confirmation_dialog(data, state)
+    if dialog is None:
+        dialog = _build_entry_form_dialog(data, state)
+    if dialog is None:
+        dialog = _build_entry_notes_dialog(data, state)
+    if dialog is None:
+        dialog = _build_session_form_dialog(data, state)
+    if dialog is None:
+        return None
+    return build_modal_dialog_shell(
+        title=dialog.title,
+        body=dialog.body,
+        actions=dialog.actions,
+        height=dialog.height,
+        body_expand=dialog.body_expand,
+    )
+
+
+def _build_confirmation_dialog(data: MainShellViewData, state: MainShellState) -> _DialogDefinition | None:
+    if data.confirmation_dialog is None:
+        return None
+    return _DialogDefinition(
+        title=data.confirmation_dialog.title,
+        body=ft.Text(data.confirmation_dialog.body, size=14, color=COLOR_TEXT_PRIMARY),
+        actions=[
+            _build_dialog_button("Cancelar", filled=False, on_click=state.on_cancel_pending_action),
+            _build_dialog_button(
+                data.confirmation_dialog.confirm_label,
+                filled=True,
+                on_click=state.on_confirm_pending_action,
+            ),
+        ],
+    )
+
+
+def _build_entry_form_dialog(data: MainShellViewData, state: MainShellState) -> _DialogDefinition | None:
+    if data.entry_form is None:
+        return None
+    return _DialogDefinition(
+        title="Crear entrada" if data.entry_form.mode == "create" else "Editar entrada",
+        body=build_entry_form_dialog_body(data, state),
+        actions=[
+            _build_dialog_button("Cancelar", filled=False, on_click=state.on_cancel_entry_form),
+            _build_dialog_button("Guardar", filled=True, on_click=state.on_submit_entry_form),
+        ],
+    )
+
+
+def _build_entry_notes_dialog(data: MainShellViewData, state: MainShellState) -> _DialogDefinition | None:
+    if data.entry_notes_editor is None:
+        return None
+    return _DialogDefinition(
+        body=build_entry_notes_dialog_body(data, state),
+        actions=[
+            _build_dialog_button("Cancelar", filled=False, on_click=state.on_cancel_entry_notes_editor),
+            _build_dialog_button("Guardar", filled=True, on_click=state.on_submit_entry_notes),
+        ],
+        height=_NOTES_DIALOG_HEIGHT,
+        body_expand=True,
+    )
+
+
+def _build_session_form_dialog(data: MainShellViewData, state: MainShellState) -> _DialogDefinition | None:
+    if data.session_form is None:
+        return None
+    return _DialogDefinition(
+        title="Crear sesión manual" if data.session_form.mode == "create" else "Editar sesión",
+        body=build_session_form_dialog_body(data, state),
+        actions=[
+            _build_dialog_button("Cancelar", filled=False, on_click=state.on_cancel_session_form),
+            _build_dialog_button("Guardar", filled=True, on_click=state.on_submit_session_form),
+        ],
+    )
+
+
+def _build_dialog_button(label: str, *, filled: bool, on_click) -> ft.Control:
+    button_cls = ft.FilledButton if filled else ft.OutlinedButton
+    return button_cls(
+        label,
+        style=build_dialog_button_style(filled=filled),
+        on_click=on_click,
+    )

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/modal_overlay.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/modal_overlay.py
@@ -18,6 +18,7 @@ from frosthaven_campaign_journal.ui.main_shell.view.center_forms import (
 )
 
 _NOTES_DIALOG_HEIGHT = 320
+_NOTES_TEXT_FIELD_HEIGHT = 220
 
 
 @dataclass
@@ -82,7 +83,11 @@ def _build_entry_notes_dialog(data: MainShellViewData, state: MainShellState) ->
     if data.entry_notes_editor is None:
         return None
     return _DialogDefinition(
-        body=build_entry_notes_dialog_body(data, state),
+        body=build_entry_notes_dialog_body(
+            data,
+            state,
+            text_field_height=_NOTES_TEXT_FIELD_HEIGHT,
+        ),
         actions=[
             _build_dialog_button("Cancelar", filled=False, on_click=state.on_cancel_entry_notes_editor),
             _build_dialog_button("Guardar", filled=True, on_click=state.on_submit_entry_notes),

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/modal_overlay.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/modal_overlay.py
@@ -18,7 +18,6 @@ from frosthaven_campaign_journal.ui.main_shell.view.center_forms import (
 )
 
 _NOTES_DIALOG_HEIGHT = 320
-_NOTES_TEXT_FIELD_HEIGHT = 220
 
 
 @dataclass
@@ -83,11 +82,7 @@ def _build_entry_notes_dialog(data: MainShellViewData, state: MainShellState) ->
     if data.entry_notes_editor is None:
         return None
     return _DialogDefinition(
-        body=build_entry_notes_dialog_body(
-            data,
-            state,
-            text_field_height=_NOTES_TEXT_FIELD_HEIGHT,
-        ),
+        body=build_entry_notes_dialog_body(data, state),
         actions=[
             _build_dialog_button("Cancelar", filled=False, on_click=state.on_cancel_entry_notes_editor),
             _build_dialog_button("Guardar", filled=True, on_click=state.on_submit_entry_notes),

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/shell_view.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/shell_view.py
@@ -24,8 +24,13 @@ _FAB_MENU_TEXT_STYLE = ft.TextStyle(color=COLOR_WHITE, size=15, weight=ft.FontWe
 _FAB_TRIGGER_SIZE = 56
 
 
-def build_main_shell_view(state: MainShellState) -> ft.Control:
-    data = state.build_view_data()
+def build_main_shell_view(
+    state: MainShellState,
+    *,
+    data: MainShellViewData | None = None,
+) -> ft.Control:
+    if data is None:
+        data = state.build_view_data()
     return ft.Pagelet(
         expand=True,
         appbar=ft.AppBar(

--- a/tests/test_main_shell_center_panel.py
+++ b/tests/test_main_shell_center_panel.py
@@ -19,7 +19,16 @@ from frosthaven_campaign_journal.models import (
 from frosthaven_campaign_journal.ui.common.resources.resource_delta_row import (
     ResourceDeltaRow,
 )
+from frosthaven_campaign_journal.ui.common.theme.colors import (
+    COLOR_ACCENT_BG,
+    COLOR_WHITE,
+)
 from frosthaven_campaign_journal.ui.main_shell.state.shell_state import MainShellState
+from frosthaven_campaign_journal.ui.main_shell.state.types import (
+    EntryFormState,
+    EntryNotesEditorState,
+    SessionFormState,
+)
 from frosthaven_campaign_journal.ui.main_shell.view.center_panel import (
     build_center_panel,
 )
@@ -69,12 +78,13 @@ def _set_single_entry_resources(
     return entry_ref
 
 
-def _build_entry(*, entry_id: str, label: str) -> EntrySummary:
+def _build_entry(*, entry_id: str, label: str, notes: str | None = None) -> EntrySummary:
     return EntrySummary(
         ref=EntryRef(year_number=1, week_number=1, entry_id=entry_id),
         label=label,
         entry_type="scenario",
         scenario_ref=1,
+        notes=notes,
         resource_deltas={},
     )
 
@@ -209,6 +219,37 @@ class MainShellCenterPanelTests(unittest.TestCase):
         self.assertNotIn("Cerrar semana", text_values)
         self.assertNotIn("\u00bfQuieres continuar?", text_values)
 
+    def test_center_panel_does_not_render_form_editors_inline(self) -> None:
+        state = _build_state(selected_week=1)
+        entry_ref = EntryRef(year_number=1, week_number=1, entry_id="entry-1")
+        state.entry_form_state = EntryFormState(
+            mode="create",
+            entry_type="scenario",
+            scenario_ref_text="",
+        )
+        state.entry_notes_editor_state = EntryNotesEditorState(
+            entry_ref=entry_ref,
+            entry_label="Escenario 1",
+            notes_value="Notas ya cargadas",
+        )
+        state.session_form_state = SessionFormState(
+            mode="create",
+            entry_ref=entry_ref,
+            session_id=None,
+            started_date_local="2026-03-09",
+            started_time_local="10:00",
+            ended_date_local="",
+            ended_time_local="",
+            active_without_end=False,
+        )
+
+        panel = build_center_panel(state.build_view_data(), state)
+        text_values = _text_values(panel)
+
+        self.assertNotIn("Crear entrada", text_values)
+        self.assertNotIn("Editar notas de entry: Escenario 1", text_values)
+        self.assertNotIn("Crear sesión manual", text_values)
+
     def test_resource_projected_total_for_new_entry_uses_draft_delta(self) -> None:
         state = _build_state(selected_week=1)
         _set_single_entry_resources(
@@ -324,6 +365,30 @@ class MainShellCenterPanelTests(unittest.TestCase):
         self.assertIn("Borrar sesión", tooltips)
         self.assertIn("Total jugado", text_values)
         self.assertIn("Sesiones", text_values)
+
+    def test_notes_button_uses_add_tooltip_and_white_color_when_entry_has_no_notes(self) -> None:
+        state = _build_state(selected_week=1)
+        entry = _build_entry(entry_id="entry-1", label="Escenario 1", notes=None)
+        state.entry_panel_state.entries_for_selected_week = [entry]
+        state.entry_panel_state.sessions_by_entry_ref = {entry.ref: []}
+
+        panel = build_center_panel(state.build_view_data(), state)
+        notes_button = _find_control_by_tooltip(panel, "Añadir notas")
+
+        self.assertIsInstance(notes_button, ft.IconButton)
+        self.assertEqual(COLOR_WHITE, notes_button.icon_color)
+
+    def test_notes_button_uses_edit_tooltip_and_accent_color_when_entry_has_notes(self) -> None:
+        state = _build_state(selected_week=1)
+        entry = _build_entry(entry_id="entry-1", label="Escenario 1", notes="Ya hay notas")
+        state.entry_panel_state.entries_for_selected_week = [entry]
+        state.entry_panel_state.sessions_by_entry_ref = {entry.ref: []}
+
+        panel = build_center_panel(state.build_view_data(), state)
+        notes_button = _find_control_by_tooltip(panel, "Ver o editar notas")
+
+        self.assertIsInstance(notes_button, ft.IconButton)
+        self.assertEqual(COLOR_ACCENT_BG, notes_button.icon_color)
 
     def test_session_action_icons_are_disabled_while_session_write_is_pending(self) -> None:
         state = _build_state(selected_week=1)

--- a/tests/test_main_shell_modal_overlay.py
+++ b/tests/test_main_shell_modal_overlay.py
@@ -76,6 +76,10 @@ def _text_fields(control: ft.Control) -> list[ft.TextField]:
     return [item for item in _iter_controls(control) if isinstance(item, ft.TextField)]
 
 
+def _containers(control: ft.Control) -> list[ft.Container]:
+    return [item for item in _iter_controls(control) if isinstance(item, ft.Container)]
+
+
 def _tooltips(control: ft.Control) -> list[str]:
     values: list[str] = []
     for item in _iter_controls(control):
@@ -124,7 +128,8 @@ class MainShellModalOverlayTests(unittest.TestCase):
         self.assertNotIn("Cerrar diálogo", _tooltips(overlay))
         self.assertEqual(["Cancelar", "Guardar"], _button_labels(overlay))
         self.assertEqual(1, len(_text_fields(overlay)))
-        self.assertEqual(220, _text_fields(overlay)[0].height)
+        self.assertTrue(_text_fields(overlay)[0].fit_parent_size)
+        self.assertTrue(any(container.expand for container in _containers(overlay)))
         self.assertGreaterEqual(len(_rows_with_alignment(overlay, ft.MainAxisAlignment.END)), 1)
 
         state.on_cancel_entry_notes_editor()

--- a/tests/test_main_shell_modal_overlay.py
+++ b/tests/test_main_shell_modal_overlay.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import unittest
+from typing import Iterator
+
+import flet as ft
+
+from tests.main_shell_test_support import install_data_stub
+
+install_data_stub()
+
+from frosthaven_campaign_journal.data import EntryWriteResult
+from frosthaven_campaign_journal.models import EntryRef, EntrySummary, WeekSummary
+from frosthaven_campaign_journal.ui.main_shell.state.shell_state import MainShellState
+from frosthaven_campaign_journal.ui.main_shell.state.types import (
+    EntryFormState,
+    EntryNotesEditorState,
+    SessionFormState,
+)
+from frosthaven_campaign_journal.ui.main_shell.view.center_forms import (
+    build_form_modal_overlay,
+)
+
+
+def _build_state(*, selected_week: int | None = 1) -> MainShellState:
+    state = MainShellState()
+    state.notify = lambda: None
+    state.local_state.selected_year = 1
+    state.local_state.selected_week = selected_week
+    state.read_state.years = [1]
+    state.read_state.weeks_by_year = {
+        1: [
+            WeekSummary(year_number=1, week_number=1, is_closed=False, status_label="open"),
+            WeekSummary(year_number=1, week_number=2, is_closed=False, status_label="open"),
+        ]
+    }
+    return state
+
+
+def _build_entry(*, entry_id: str, label: str, notes: str | None = None) -> EntrySummary:
+    return EntrySummary(
+        ref=EntryRef(year_number=1, week_number=1, entry_id=entry_id),
+        label=label,
+        entry_type="scenario",
+        scenario_ref=1,
+        notes=notes,
+        resource_deltas={},
+    )
+
+
+def _iter_controls(control: ft.Control | None) -> Iterator[ft.Control]:
+    if control is None:
+        return
+
+    yield control
+
+    content = getattr(control, "content", None)
+    if isinstance(content, ft.Control):
+        yield from _iter_controls(content)
+
+    controls = getattr(control, "controls", None)
+    if controls is not None:
+        for child in controls:
+            yield from _iter_controls(child)
+
+
+def _text_values(control: ft.Control) -> list[str]:
+    return [item.value for item in _iter_controls(control) if isinstance(item, ft.Text)]
+
+
+def _text_field_values(control: ft.Control) -> list[str]:
+    return [item.value for item in _iter_controls(control) if isinstance(item, ft.TextField)]
+
+
+def _tooltips(control: ft.Control) -> list[str]:
+    values: list[str] = []
+    for item in _iter_controls(control):
+        tooltip = getattr(item, "tooltip", None)
+        if isinstance(tooltip, str) and tooltip:
+            values.append(tooltip)
+    return values
+
+
+class MainShellModalOverlayTests(unittest.TestCase):
+    def test_build_form_modal_overlay_returns_none_without_active_form(self) -> None:
+        state = _build_state()
+
+        self.assertIsNone(build_form_modal_overlay(state.build_view_data(), state))
+
+    def test_notes_modal_renders_loaded_value_and_close_action(self) -> None:
+        state = _build_state()
+        entry = _build_entry(entry_id="entry-1", label="Escenario 1", notes="Notas ya guardadas")
+        state.entry_panel_state.entries_for_selected_week = [entry]
+
+        state.on_open_entry_notes_editor(entry.ref)
+        overlay = build_form_modal_overlay(state.build_view_data(), state)
+
+        self.assertIsNotNone(overlay)
+        assert overlay is not None
+        self.assertIn("Editar notas de entry: Escenario 1", _text_values(overlay))
+        self.assertIn("Notas ya guardadas", _text_field_values(overlay))
+        self.assertIn("Cerrar diálogo", _tooltips(overlay))
+
+        state.on_cancel_entry_notes_editor()
+        self.assertIsNone(build_form_modal_overlay(state.build_view_data(), state))
+
+    def test_only_one_modal_state_is_active_at_a_time_and_overlay_tracks_current_form(self) -> None:
+        state = _build_state()
+        entry = _build_entry(entry_id="entry-1", label="Escenario 1", notes="Notas")
+        state.entry_panel_state.entries_for_selected_week = [entry]
+        state.entry_panel_state.sessions_by_entry_ref = {entry.ref: []}
+
+        state.on_open_entry_add_modal()
+        overlay = build_form_modal_overlay(state.build_view_data(), state)
+        self.assertIsNotNone(state.entry_form_state)
+        self.assertIsNone(state.entry_notes_editor_state)
+        self.assertIsNone(state.session_form_state)
+        assert overlay is not None
+        self.assertIn("Crear entrada", _text_values(overlay))
+
+        state.on_open_entry_notes_editor(entry.ref)
+        overlay = build_form_modal_overlay(state.build_view_data(), state)
+        self.assertIsNone(state.entry_form_state)
+        self.assertIsNotNone(state.entry_notes_editor_state)
+        self.assertIsNone(state.session_form_state)
+        assert overlay is not None
+        self.assertIn("Editar notas de entry: Escenario 1", _text_values(overlay))
+
+        state.on_open_manual_create_session_for_entry(entry.ref)
+        overlay = build_form_modal_overlay(state.build_view_data(), state)
+        self.assertIsNone(state.entry_form_state)
+        self.assertIsNone(state.entry_notes_editor_state)
+        self.assertIsNotNone(state.session_form_state)
+        assert overlay is not None
+        self.assertIn("Crear sesión manual", _text_values(overlay))
+
+    def test_context_change_clears_active_modal_states(self) -> None:
+        state = _build_state()
+        entry = _build_entry(entry_id="entry-1", label="Escenario 1", notes="Notas")
+        next_entry_ref = EntryRef(year_number=1, week_number=1, entry_id="entry-2")
+        state.entry_form_state = EntryFormState(
+            mode="edit",
+            entry_type="scenario",
+            scenario_ref_text="1",
+        )
+        state.entry_notes_editor_state = EntryNotesEditorState(
+            entry_ref=entry.ref,
+            entry_label=entry.label,
+            notes_value="Notas",
+        )
+        state.session_form_state = SessionFormState(
+            mode="create",
+            entry_ref=entry.ref,
+            session_id=None,
+            started_date_local="2026-03-09",
+            started_time_local="10:00",
+            ended_date_local="",
+            ended_time_local="",
+            active_without_end=False,
+        )
+        state._run_or_confirm_resource_draft_before_context_change = lambda action, action_label: action()
+        state._load_viewer_entry_and_sessions = lambda: None
+
+        state.on_select_entry(next_entry_ref)
+
+        self.assertEqual(next_entry_ref, state.local_state.viewer_entry_ref)
+        self.assertIsNone(state.entry_form_state)
+        self.assertIsNone(state.entry_notes_editor_state)
+        self.assertIsNone(state.session_form_state)
+
+    def test_delete_entry_clears_active_modal_states(self) -> None:
+        state = _build_state()
+        entry = _build_entry(entry_id="entry-1", label="Escenario 1", notes="Notas")
+        state.local_state.viewer_entry_ref = entry.ref
+        state.entry_form_state = EntryFormState(
+            mode="edit",
+            entry_type="scenario",
+            scenario_ref_text="1",
+        )
+        state.entry_notes_editor_state = EntryNotesEditorState(
+            entry_ref=entry.ref,
+            entry_label=entry.label,
+            notes_value="Notas",
+        )
+        state.session_form_state = SessionFormState(
+            mode="edit",
+            entry_ref=entry.ref,
+            session_id="sess-1",
+            started_date_local="2026-03-09",
+            started_time_local="10:00",
+            ended_date_local="2026-03-09",
+            ended_time_local="11:00",
+            active_without_end=False,
+        )
+
+        def _fake_run_entry_write(_action, **kwargs):
+            before_refresh = kwargs.get("before_refresh")
+            if before_refresh is not None:
+                before_refresh(EntryWriteResult(entry_ref=entry.ref))
+            return EntryWriteResult(entry_ref=entry.ref)
+
+        state._run_entry_write = _fake_run_entry_write
+
+        state._confirm_delete_entry(entry.ref)
+
+        self.assertIsNone(state.entry_form_state)
+        self.assertIsNone(state.entry_notes_editor_state)
+        self.assertIsNone(state.session_form_state)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_main_shell_modal_overlay.py
+++ b/tests/test_main_shell_modal_overlay.py
@@ -76,8 +76,8 @@ def _text_fields(control: ft.Control) -> list[ft.TextField]:
     return [item for item in _iter_controls(control) if isinstance(item, ft.TextField)]
 
 
-def _containers(control: ft.Control) -> list[ft.Container]:
-    return [item for item in _iter_controls(control) if isinstance(item, ft.Container)]
+def _rows(control: ft.Control) -> list[ft.Row]:
+    return [item for item in _iter_controls(control) if isinstance(item, ft.Row)]
 
 
 def _tooltips(control: ft.Control) -> list[str]:
@@ -129,7 +129,8 @@ class MainShellModalOverlayTests(unittest.TestCase):
         self.assertEqual(["Cancelar", "Guardar"], _button_labels(overlay))
         self.assertEqual(1, len(_text_fields(overlay)))
         self.assertTrue(_text_fields(overlay)[0].fit_parent_size)
-        self.assertTrue(any(container.expand for container in _containers(overlay)))
+        self.assertTrue(_text_fields(overlay)[0].expand)
+        self.assertTrue(any(row.expand for row in _rows(overlay)))
         self.assertGreaterEqual(len(_rows_with_alignment(overlay, ft.MainAxisAlignment.END)), 1)
 
         state.on_cancel_entry_notes_editor()

--- a/tests/test_main_shell_modal_overlay.py
+++ b/tests/test_main_shell_modal_overlay.py
@@ -17,8 +17,8 @@ from frosthaven_campaign_journal.ui.main_shell.state.types import (
     EntryNotesEditorState,
     SessionFormState,
 )
-from frosthaven_campaign_journal.ui.main_shell.view.center_forms import (
-    build_form_modal_overlay,
+from frosthaven_campaign_journal.ui.main_shell.view.modal_overlay import (
+    build_main_shell_modal_overlay,
 )
 
 
@@ -72,6 +72,10 @@ def _text_field_values(control: ft.Control) -> list[str]:
     return [item.value for item in _iter_controls(control) if isinstance(item, ft.TextField)]
 
 
+def _text_fields(control: ft.Control) -> list[ft.TextField]:
+    return [item for item in _iter_controls(control) if isinstance(item, ft.TextField)]
+
+
 def _tooltips(control: ft.Control) -> list[str]:
     values: list[str] = []
     for item in _iter_controls(control):
@@ -81,37 +85,100 @@ def _tooltips(control: ft.Control) -> list[str]:
     return values
 
 
+def _button_labels(control: ft.Control) -> list[str]:
+    labels: list[str] = []
+    for item in _iter_controls(control):
+        if isinstance(item, (ft.OutlinedButton, ft.FilledButton, ft.TextButton)):
+            content = getattr(item, "content", None)
+            if isinstance(content, str) and content:
+                labels.append(content)
+    return labels
+
+
+def _rows_with_alignment(control: ft.Control, alignment: ft.MainAxisAlignment) -> list[ft.Row]:
+    return [
+        item
+        for item in _iter_controls(control)
+        if isinstance(item, ft.Row) and item.alignment == alignment
+    ]
+
+
 class MainShellModalOverlayTests(unittest.TestCase):
-    def test_build_form_modal_overlay_returns_none_without_active_form(self) -> None:
+    def test_build_main_shell_modal_overlay_returns_none_without_active_dialog(self) -> None:
         state = _build_state()
 
-        self.assertIsNone(build_form_modal_overlay(state.build_view_data(), state))
+        self.assertIsNone(build_main_shell_modal_overlay(state.build_view_data(), state))
 
-    def test_notes_modal_renders_loaded_value_and_close_action(self) -> None:
+    def test_notes_modal_renders_loaded_value_without_title_or_close_action(self) -> None:
         state = _build_state()
         entry = _build_entry(entry_id="entry-1", label="Escenario 1", notes="Notas ya guardadas")
         state.entry_panel_state.entries_for_selected_week = [entry]
 
         state.on_open_entry_notes_editor(entry.ref)
-        overlay = build_form_modal_overlay(state.build_view_data(), state)
+        overlay = build_main_shell_modal_overlay(state.build_view_data(), state)
 
         self.assertIsNotNone(overlay)
         assert overlay is not None
-        self.assertIn("Editar notas de entry: Escenario 1", _text_values(overlay))
+        self.assertNotIn("Editar notas de entry: Escenario 1", _text_values(overlay))
         self.assertIn("Notas ya guardadas", _text_field_values(overlay))
-        self.assertIn("Cerrar diálogo", _tooltips(overlay))
+        self.assertNotIn("Cerrar diálogo", _tooltips(overlay))
+        self.assertEqual(["Cancelar", "Guardar"], _button_labels(overlay))
+        self.assertEqual(1, len(_text_fields(overlay)))
+        self.assertTrue(_text_fields(overlay)[0].expand)
+        self.assertGreaterEqual(len(_rows_with_alignment(overlay, ft.MainAxisAlignment.END)), 1)
 
         state.on_cancel_entry_notes_editor()
-        self.assertIsNone(build_form_modal_overlay(state.build_view_data(), state))
+        self.assertIsNone(build_main_shell_modal_overlay(state.build_view_data(), state))
 
-    def test_only_one_modal_state_is_active_at_a_time_and_overlay_tracks_current_form(self) -> None:
+    def test_confirmation_dialog_uses_shared_overlay_instead_of_alertdialog(self) -> None:
+        state = _build_state()
+        state._set_confirmation(
+            key="week_close",
+            title="Cerrar semana",
+            body="¿Quieres continuar?",
+            confirm_label="Cerrar",
+            payload=(1, 1),
+        )
+
+        overlay = build_main_shell_modal_overlay(state.build_view_data(), state)
+
+        self.assertIsNotNone(overlay)
+        assert overlay is not None
+        self.assertIn("Cerrar semana", _text_values(overlay))
+        self.assertIn("¿Quieres continuar?", _text_values(overlay))
+        self.assertEqual(["Cancelar", "Cerrar"], _button_labels(overlay))
+        self.assertFalse(any(isinstance(item, ft.AlertDialog) for item in _iter_controls(overlay)))
+
+    def test_confirmation_dialog_has_priority_over_active_form_dialog(self) -> None:
+        state = _build_state()
+        entry = _build_entry(entry_id="entry-1", label="Escenario 1", notes="Notas")
+        state.entry_panel_state.entries_for_selected_week = [entry]
+
+        state.on_open_entry_notes_editor(entry.ref)
+        state._set_confirmation(
+            key="entry_delete",
+            title="Eliminar entrada",
+            body="¿Seguro?",
+            confirm_label="Eliminar",
+            payload=entry.ref,
+        )
+
+        overlay = build_main_shell_modal_overlay(state.build_view_data(), state)
+
+        self.assertIsNotNone(overlay)
+        assert overlay is not None
+        self.assertIn("Eliminar entrada", _text_values(overlay))
+        self.assertNotIn("Notas", _text_field_values(overlay))
+        self.assertIsNotNone(state.entry_notes_editor_state)
+
+    def test_only_one_form_modal_state_is_active_at_a_time_and_overlay_tracks_current_form(self) -> None:
         state = _build_state()
         entry = _build_entry(entry_id="entry-1", label="Escenario 1", notes="Notas")
         state.entry_panel_state.entries_for_selected_week = [entry]
         state.entry_panel_state.sessions_by_entry_ref = {entry.ref: []}
 
         state.on_open_entry_add_modal()
-        overlay = build_form_modal_overlay(state.build_view_data(), state)
+        overlay = build_main_shell_modal_overlay(state.build_view_data(), state)
         self.assertIsNotNone(state.entry_form_state)
         self.assertIsNone(state.entry_notes_editor_state)
         self.assertIsNone(state.session_form_state)
@@ -119,15 +186,15 @@ class MainShellModalOverlayTests(unittest.TestCase):
         self.assertIn("Crear entrada", _text_values(overlay))
 
         state.on_open_entry_notes_editor(entry.ref)
-        overlay = build_form_modal_overlay(state.build_view_data(), state)
+        overlay = build_main_shell_modal_overlay(state.build_view_data(), state)
         self.assertIsNone(state.entry_form_state)
         self.assertIsNotNone(state.entry_notes_editor_state)
         self.assertIsNone(state.session_form_state)
         assert overlay is not None
-        self.assertIn("Editar notas de entry: Escenario 1", _text_values(overlay))
+        self.assertIn("Notas", _text_field_values(overlay))
 
         state.on_open_manual_create_session_for_entry(entry.ref)
-        overlay = build_form_modal_overlay(state.build_view_data(), state)
+        overlay = build_main_shell_modal_overlay(state.build_view_data(), state)
         self.assertIsNone(state.entry_form_state)
         self.assertIsNone(state.entry_notes_editor_state)
         self.assertIsNotNone(state.session_form_state)

--- a/tests/test_main_shell_modal_overlay.py
+++ b/tests/test_main_shell_modal_overlay.py
@@ -124,7 +124,7 @@ class MainShellModalOverlayTests(unittest.TestCase):
         self.assertNotIn("Cerrar diálogo", _tooltips(overlay))
         self.assertEqual(["Cancelar", "Guardar"], _button_labels(overlay))
         self.assertEqual(1, len(_text_fields(overlay)))
-        self.assertTrue(_text_fields(overlay)[0].expand)
+        self.assertEqual(220, _text_fields(overlay)[0].height)
         self.assertGreaterEqual(len(_rows_with_alignment(overlay, ft.MainAxisAlignment.END)), 1)
 
         state.on_cancel_entry_notes_editor()


### PR DESCRIPTION
## Resumen
- unificar confirmaciones, formularios de `entry`, notas y formularios de sesi?n bajo un shell modal declarativo compartido
- quitar la `X` de cierre y llevar todas las acciones al mismo patr?n visual abajo a la derecha
- dejar notas sin t?tulo y con `TextField` expandible ocupando el cuerpo del di?logo
- a?adir `ConfirmationDialogViewState`, refactorizar el ensamblado del overlay y actualizar documentaci?n/tests

## Issue
Refs #102

## Validaci?n
- [x] `$env:PYTHONPATH='src'; pipenv run python -m unittest discover -s tests -p 'test_*.py'`
- [x] `pipenv run python -m compileall src/frosthaven_campaign_journal`
- [x] Validaci?n visual Flet web en tablet/web con servidor activo de Kiko

## Notas
- `SnackBar` informativo se mantiene como overlay nativo; la unificaci?n aplica solo a di?logos/modales.
- Validaci?n visual final hecha por Kiko sobre el modal de notas y el patr?n com?n de di?logo.
