### PR TITLE
fix(main_shell): restaurar reactividad temporal y cronómetro activo

### DIFF
--- a/src/frosthaven_campaign_journal/ui/app_root.py
+++ b/src/frosthaven_campaign_journal/ui/app_root.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import asyncio
+from concurrent.futures import Future
+from typing import Callable
+
 import flet as ft
 
 from frosthaven_campaign_journal.ui.common.theme.colors import (
@@ -26,8 +30,10 @@ def _close_overlay(overlay: ft.SnackBar | None) -> None:
 @ft.component
 def build_app_root(page: ft.Page) -> ft.Control:
     shell_state, _ = ft.use_state(MainShellState.create)
+    _live_session_tick, set_live_session_tick = ft.use_state(0)
     active_toast = ft.use_ref(None)
     last_toast_event_id = ft.use_ref(None)
+    active_session_ticker = ft.use_ref(None)
 
     def _sync_info_toast() -> None:
         toast = shell_state.toast_state
@@ -69,6 +75,39 @@ def build_app_root(page: ft.Page) -> ft.Control:
         page.show_dialog(snackbar)
 
     ft.use_effect(_sync_info_toast, dependencies=[shell_state.toast_state.event_id])
+
+    def _sync_live_session_ticker() -> Callable[[], None] | None:
+        current_future: Future[None] | None = active_session_ticker.current
+        if current_future is not None and not current_future.done():
+            current_future.cancel()
+        active_session_ticker.current = None
+
+        if shell_state.read_state.active_session_started_at_utc is None:
+            return None
+
+        async def _run_live_session_ticker() -> None:
+            try:
+                while shell_state.read_state.active_session_started_at_utc is not None:
+                    await asyncio.sleep(1)
+                    set_live_session_tick(lambda current: current + 1)
+            except asyncio.CancelledError:
+                pass
+
+        future = page.run_task(_run_live_session_ticker)
+        active_session_ticker.current = future
+
+        def _cleanup_live_session_ticker() -> None:
+            cleanup_future: Future[None] | None = active_session_ticker.current
+            if cleanup_future is not None and not cleanup_future.done():
+                cleanup_future.cancel()
+            active_session_ticker.current = None
+
+        return _cleanup_live_session_ticker
+
+    ft.use_effect(
+        _sync_live_session_ticker,
+        dependencies=[shell_state.read_state.active_session_started_at_utc],
+    )
 
     data = shell_state.build_view_data()
     stack_controls: list[ft.Control] = [build_main_shell_view(shell_state, data=data)]

--- a/src/frosthaven_campaign_journal/ui/common/components/labeled_group_box.py
+++ b/src/frosthaven_campaign_journal/ui/common/components/labeled_group_box.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import flet as ft
 
 
-@ft.control(isolated=True)
+@ft.control
 class LabeledGroupBox(ft.Stack):
     label: str = ""
     content: ft.Control | None = None

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/session_timing.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/session_timing.py
@@ -72,12 +72,14 @@ def build_session_duration_text(
     *,
     started_at_utc: object | None,
     ended_at_utc: object | None = None,
+    key: str | None = None,
     size: int,
     weight: ft.FontWeight = ft.FontWeight.W_700,
     color: str,
     text_align: ft.TextAlign = ft.TextAlign.LEFT,
 ) -> ft.Control:
     return SessionDurationText(
+        key=key,
         started_at_utc=started_at_utc,
         ended_at_utc=ended_at_utc,
         size=size,
@@ -87,7 +89,7 @@ def build_session_duration_text(
     )
 
 
-@ft.control(isolated=True)
+@ft.control
 class SessionDurationText(ft.Text):
     started_at_utc: object | None = None
     ended_at_utc: object | None = None

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/shell_view.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/shell_view.py
@@ -9,7 +9,6 @@ from frosthaven_campaign_journal.ui.common.theme.colors import (
     COLOR_ACCENT_BG,
     COLOR_BOTTOM_BAR_BG,
     COLOR_CENTER_BG,
-    COLOR_TOP_BAR_BG,
     COLOR_WHITE,
 )
 from frosthaven_campaign_journal.ui.common.theme.layout import (
@@ -22,6 +21,8 @@ from frosthaven_campaign_journal.ui.main_shell.view.temporal_bar import build_to
 
 _FAB_MENU_TEXT_STYLE = ft.TextStyle(color=COLOR_WHITE, size=15, weight=ft.FontWeight.W_600)
 _FAB_TRIGGER_SIZE = 56
+_FAB_DOCK_MARGIN_RIGHT = 16
+_FAB_DOCK_MARGIN_BOTTOM = max(16, BOTTOM_BAR_HEIGHT - (_FAB_TRIGGER_SIZE // 2))
 
 
 def build_main_shell_view(
@@ -31,32 +32,53 @@ def build_main_shell_view(
 ) -> ft.Control:
     if data is None:
         data = state.build_view_data()
-    return ft.Pagelet(
-        expand=True,
-        appbar=ft.AppBar(
-            toolbar_height=TOP_BAR_HEIGHT,
-            automatically_imply_leading=False,
-            leading_width=0,
-            title_spacing=0,
-            elevation=0,
-            force_material_transparency=False,
-            bgcolor=COLOR_TOP_BAR_BG,
-            title=build_top_temporal_bar(data, state),
-        ),
-        bottom_appbar=ft.BottomAppBar(
-            height=BOTTOM_BAR_HEIGHT,
-            padding=ft.Padding(left=12, top=8, right=12, bottom=8),
-            elevation=0,
-            bgcolor=COLOR_BOTTOM_BAR_BG,
-            content=build_status_bar(data),
-        ),
-        floating_action_button=_build_week_actions_fab(data, state),
-        floating_action_button_location=ft.FloatingActionButtonLocation.END_DOCKED,
-        content=ft.Container(
+    stack_controls: list[ft.Control] = [
+        ft.Column(
             expand=True,
-            bgcolor=COLOR_CENTER_BG,
-            content=build_center_panel(data, state),
+            spacing=0,
+            controls=[
+                ft.Container(
+                    key="main-shell-top-bar",
+                    height=TOP_BAR_HEIGHT,
+                    content=build_top_temporal_bar(data, state),
+                ),
+                ft.Container(
+                    key="main-shell-center-panel",
+                    expand=True,
+                    bgcolor=COLOR_CENTER_BG,
+                    content=build_center_panel(data, state),
+                ),
+                ft.Container(
+                    key="main-shell-bottom-bar",
+                    height=BOTTOM_BAR_HEIGHT,
+                    padding=ft.Padding(left=12, top=8, right=12, bottom=8),
+                    bgcolor=COLOR_BOTTOM_BAR_BG,
+                    content=build_status_bar(data),
+                ),
+            ],
         ),
+    ]
+
+    week_actions_fab = _build_week_actions_fab(data, state)
+    if week_actions_fab is not None:
+        stack_controls.append(
+            ft.Container(
+                key="main-shell-fab-layer",
+                expand=True,
+                alignment=ft.Alignment(1, 1),
+                padding=ft.Padding(
+                    left=0,
+                    top=0,
+                    right=_FAB_DOCK_MARGIN_RIGHT,
+                    bottom=_FAB_DOCK_MARGIN_BOTTOM,
+                ),
+                content=week_actions_fab,
+            )
+        )
+
+    return ft.Stack(
+        expand=True,
+        controls=stack_controls,
     )
 
 

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/status_bar.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/status_bar.py
@@ -1,5 +1,7 @@
 ﻿from __future__ import annotations
 
+from datetime import datetime
+
 import flet as ft
 
 from frosthaven_campaign_journal.resource_catalog import ResourceCatalogItem
@@ -162,6 +164,7 @@ def _build_active_session_box(data: MainShellViewData) -> ft.Control | None:
                 # ),
                 build_session_duration_text(
                     started_at_utc=data.active_session_started_at_utc,
+                    key=_build_active_session_timer_key(data),
                     size=32,
                     weight=ft.FontWeight.W_700,
                     color=COLOR_TEXT_PRIMARY,
@@ -176,3 +179,21 @@ def _build_active_session_box(data: MainShellViewData) -> ft.Control | None:
             ],
         ),
     )
+
+
+def _build_active_session_timer_key(data: MainShellViewData) -> str:
+    parts = ["active-session"]
+    if data.active_entry_ref is not None:
+        parts.extend(
+            [
+                str(data.active_entry_ref.year_number),
+                str(data.active_entry_ref.week_number),
+                data.active_entry_ref.entry_id,
+            ]
+        )
+    started_at_utc = data.active_session_started_at_utc
+    if isinstance(started_at_utc, datetime):
+        parts.append(started_at_utc.isoformat())
+    else:
+        parts.append(repr(started_at_utc))
+    return "|".join(parts)

--- a/src/frosthaven_campaign_journal/ui/main_shell/view/temporal_bar.py
+++ b/src/frosthaven_campaign_journal/ui/main_shell/view/temporal_bar.py
@@ -161,6 +161,7 @@ def _build_week_season_block(
     season_label: str,
 ) -> ft.Control:
     return LabeledGroupBox(
+        key=f"season-{season_label.lower()}",
         label=season_label,
         content=ft.Row(
             spacing=4,
@@ -225,6 +226,7 @@ def _build_week_tile(
     else:
         text_color = COLOR_WEEK_TILE_CLOSED_TEXT if week.is_closed else COLOR_TEXT_PRIMARY
     return ft.Container(
+        key=f"week-{week.week_number}",
         width=40,
         height=36,
         bgcolor=bgcolor,

--- a/tests/test_labeled_group_box.py
+++ b/tests/test_labeled_group_box.py
@@ -8,7 +8,7 @@ from frosthaven_campaign_journal.ui.common.components import LabeledGroupBox
 
 
 class LabeledGroupBoxTests(unittest.TestCase):
-    def test_labeled_group_box_is_isolated_and_preserves_content_on_update(self) -> None:
+    def test_labeled_group_box_rebuilds_content_without_isolating_updates(self) -> None:
         content = ft.Text("contenido")
         box = LabeledGroupBox(
             label="Caja",
@@ -20,7 +20,7 @@ class LabeledGroupBoxTests(unittest.TestCase):
             label_text_color="#111111",
         )
 
-        self.assertTrue(box.is_isolated())
+        self.assertFalse(box.is_isolated())
         self.assertIs(content, box.controls[0].content)
 
         box.label = "Caja actualizada"

--- a/tests/test_main_shell_shell_view.py
+++ b/tests/test_main_shell_shell_view.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import unittest
+
+import flet as ft
+
+from tests.main_shell_test_support import install_data_stub
+
+install_data_stub()
+
+from frosthaven_campaign_journal.models import WeekSummary
+from frosthaven_campaign_journal.ui.common.theme.colors import (
+    COLOR_WEEK_TILE_BG,
+    COLOR_WEEK_TILE_SELECTED_BG,
+)
+from frosthaven_campaign_journal.ui.main_shell.state.shell_state import MainShellState
+from frosthaven_campaign_journal.ui.main_shell.view.shell_view import build_main_shell_view
+from frosthaven_campaign_journal.ui.main_shell.view.temporal_bar import build_top_temporal_bar
+
+
+def _iter_controls(control: ft.Control | None):
+    if control is None:
+        return
+
+    yield control
+
+    content = getattr(control, "content", None)
+    if isinstance(content, ft.Control):
+        yield from _iter_controls(content)
+
+    controls = getattr(control, "controls", None)
+    if controls is not None:
+        for child in controls:
+            yield from _iter_controls(child)
+
+
+def _find_control_by_key(control: ft.Control, key: str) -> ft.Control | None:
+    for item in _iter_controls(control):
+        if getattr(item, "key", None) == key:
+            return item
+    return None
+
+
+def _build_state(*, selected_week: int) -> MainShellState:
+    state = MainShellState()
+    state.notify = lambda: None
+    state.local_state.selected_year = 1
+    state.local_state.selected_week = selected_week
+    state.read_state.years = [1]
+    state.read_state.weeks_by_year = {
+        1: [
+            WeekSummary(year_number=1, week_number=1, is_closed=False, status_label="open"),
+            WeekSummary(year_number=1, week_number=2, is_closed=False, status_label="open"),
+        ]
+    }
+    return state
+
+
+class MainShellShellViewTests(unittest.TestCase):
+    def test_top_temporal_bar_marks_selected_week_tile_with_selected_color(self) -> None:
+        state = _build_state(selected_week=2)
+
+        temporal_bar = build_top_temporal_bar(state.build_view_data(), state)
+
+        selected_tile = _find_control_by_key(temporal_bar, "week-2")
+        unselected_tile = _find_control_by_key(temporal_bar, "week-1")
+
+        self.assertIsNotNone(selected_tile)
+        self.assertIsNotNone(unselected_tile)
+        self.assertEqual(COLOR_WEEK_TILE_SELECTED_BG, selected_tile.bgcolor)
+        self.assertEqual(COLOR_WEEK_TILE_BG, unselected_tile.bgcolor)
+
+    def test_main_shell_view_uses_stack_layout_for_reactive_bars(self) -> None:
+        state = _build_state(selected_week=2)
+
+        shell_view = build_main_shell_view(state, data=state.build_view_data())
+
+        self.assertIsInstance(shell_view, ft.Stack)
+        self.assertFalse(any(isinstance(item, ft.Pagelet) for item in _iter_controls(shell_view)))
+        self.assertIsNotNone(_find_control_by_key(shell_view, "main-shell-top-bar"))
+        self.assertIsNotNone(_find_control_by_key(shell_view, "main-shell-center-panel"))
+        self.assertIsNotNone(_find_control_by_key(shell_view, "main-shell-bottom-bar"))
+        self.assertIsNotNone(_find_control_by_key(shell_view, "main-shell-fab-layer"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_timing.py
+++ b/tests/test_session_timing.py
@@ -94,7 +94,7 @@ class SessionTimingFormattingTests(unittest.TestCase):
         self.assertIsInstance(control, ft.Text)
         self.assertEqual("02:24:31", control.value)
         self.assertEqual(18, control.size)
-        self.assertTrue(control.is_isolated())
+        self.assertFalse(control.is_isolated())
 
 
 class SessionTimingTickerTests(unittest.TestCase):


### PR DESCRIPTION
## Resumen
- reestructura la shell principal sobre un `Stack` reactivo en lugar de depender del chrome de `Pagelet`;
- restaura el feedback visual de la week seleccionada y añade claves estables para la reconciliación;
- elimina el aislamiento de controles que bloqueaba updates y añade pulso vivo para refrescar el cronómetro activo.

## Validación
- `PYTHONPATH=src pipenv run python -m unittest discover -s tests -p test_*.py -v`
- validación web en `http://127.0.0.1:8550`: la week seleccionada queda roja y el cronómetro avanza en vivo.

## Checklist de calidad
- [x] Cambios acotados al flujo UI afectado.
- [x] Suite unitaria del repo en verde.
- [x] Validación visual web realizada.

Closes #121